### PR TITLE
fix #73: try..except all layer-related imports that fail in GHPython context

### DIFF
--- a/src/compas_rhino/utilities/drawing.py
+++ b/src/compas_rhino/utilities/drawing.py
@@ -34,7 +34,6 @@ try:
     from Rhino.DocObjects.ObjectPlotWeightSource import PlotWeightFromObject
 
     find_object = sc.doc.Objects.Find
-    find_layer_by_fullpath = sc.doc.Layers.FindByFullPath
     add_point = sc.doc.Objects.AddPoint
     add_line = sc.doc.Objects.AddLine
     add_dot = sc.doc.Objects.AddTextDot
@@ -49,6 +48,11 @@ except ImportError:
     import platform
     if platform.python_implementation() == 'IronPython':
         raise
+
+try:
+    find_layer_by_fullpath = sc.doc.Layers.FindByFullPath
+except SystemError:
+    find_layer_by_fullpath = None
 
 
 __author__     = ['Tom Van Mele', ]
@@ -161,7 +165,7 @@ def xdraw_points(points):
             attr.ColorSource = ColorFromObject
         else:
             attr.ColorSource = ColorFromLayer
-        if layer:
+        if layer and find_layer_by_fullpath:
             index = find_layer_by_fullpath(layer, True)
             if index >= 0:
                 attr.LayerIndex = index
@@ -201,7 +205,7 @@ def xdraw_lines(lines):
             attr.ObjectDecoration = EndArrowhead
         if arrow == 'start':
             attr.ObjectDecoration = StartArrowhead
-        if layer:
+        if layer and find_layer_by_fullpath:
             index = find_layer_by_fullpath(layer, True)
             if index >= 0:
                 attr.LayerIndex = index
@@ -245,7 +249,7 @@ def xdraw_geodesics(geodesics):
             attr.ObjectDecoration = EndArrowhead
         if arrow == 'start':
             attr.ObjectDecoration = StartArrowhead
-        if layer:
+        if layer and find_layer_by_fullpath:
             index = find_layer_by_fullpath(layer, True)
             if index >= 0:
                 attr.LayerIndex = index
@@ -285,7 +289,7 @@ def xdraw_polylines(polylines):
             attr.ObjectDecoration = EndArrowhead
         if arrow == 'start':
             attr.ObjectDecoration = StartArrowhead
-        if layer:
+        if layer and find_layer_by_fullpath:
             index = find_layer_by_fullpath(layer, True)
             if index >= 0:
                 attr.LayerIndex = index
@@ -338,7 +342,7 @@ def xdraw_breps(faces, srf=None, u=10, v=10, trim=True, tangency=True, spacing=0
             attr.ColorSource = ColorFromObject
         else:
             attr.ColorSource = ColorFromLayer
-        if layer:
+        if layer and find_layer_by_fullpath:
             index = find_layer_by_fullpath(layer, True)
             if index >= 0:
                 attr.LayerIndex = index
@@ -384,7 +388,7 @@ def xdraw_cylinders(cylinders, cap=False):
             attr.ColorSource = ColorFromObject
         else:
             attr.ColorSource = ColorFromLayer
-        if layer:
+        if layer and find_layer_by_fullpath:
             index = find_layer_by_fullpath(layer, True)
             if index >= 0:
                 attr.LayerIndex = index
@@ -426,7 +430,7 @@ def xdraw_pipes(pipes, cap=2, fit=1.0):
                 attr.ColorSource = ColorFromObject
             else:
                 attr.ColorSource = ColorFromLayer
-            if layer:
+            if layer and find_layer_by_fullpath:
                 index = find_layer_by_fullpath(layer, True)
                 if index >= 0:
                     attr.LayerIndex = index
@@ -472,7 +476,7 @@ def xdraw_pipes(pipes, cap=2, fit=1.0):
 #             attr.ColorSource = ColorFromObject
 #         else:
 #             attr.ColorSource = ColorFromLayer
-#         if layer:
+#         if layer and find_layer_by_fullpath:
 #             index = find_layer_by_fullpath(layer, True)
 #             if index >= 0:
 #                 attr.LayerIndex = index
@@ -505,7 +509,7 @@ def xdraw_spheres(spheres):
             attr.ColorSource = ColorFromObject
         else:
             attr.ColorSource = ColorFromLayer
-        if layer:
+        if layer and find_layer_by_fullpath:
             index = find_layer_by_fullpath(layer, True)
             if index >= 0:
                 attr.LayerIndex = index

--- a/src/compas_rhino/utilities/layers.py
+++ b/src/compas_rhino/utilities/layers.py
@@ -63,17 +63,16 @@ def find_objects_on_layer(name, include_hidden=True, include_children=True):
 
 def delete_objects_on_layer(name, include_hidden=True, include_children=False, purge=True):
     guids = find_objects_on_layer(name, include_hidden, include_children)
-    if not purge:
-        rs.DeleteObjects(guids)
-    else:
+    if purge and purge_object:
         rs.EnableRedraw(False)
         for guid in guids:
             obj = find_object(guid)
             if not obj:
                 continue
-            if purge_object:
-                purge_object(obj.RuntimeSerialNumber)
+            purge_object(obj.RuntimeSerialNumber)
         rs.EnableRedraw(True)
+    else:
+        rs.DeleteObjects(guids)
 
 
 # ==============================================================================
@@ -135,15 +134,14 @@ def clear_layer(name, include_hidden=True, include_children=True, purge=True):
         return
     guids = find_objects_on_layer(name, include_hidden, include_children)
     rs.EnableRedraw(False)
-    if not purge:
-        rs.DeleteObjects(guids)
-    else:
+    if purge and purge_object:
         for guid in guids:
             obj = find_object(guid)
             if not obj:
                 continue
-            if purge_object:
-                purge_object(obj.RuntimeSerialNumber)
+            purge_object(obj.RuntimeSerialNumber)
+    else:
+        rs.DeleteObjects(guids)
     rs.EnableRedraw(True)
 
 

--- a/src/compas_rhino/utilities/layers.py
+++ b/src/compas_rhino/utilities/layers.py
@@ -7,13 +7,16 @@ try:
     import scriptcontext as sc
 
     find_object = sc.doc.Objects.Find
-    purge_object = sc.doc.Objects.Purge
 
 except ImportError:
     import platform
     if platform.python_implementation() == 'IronPython':
         raise
 
+try:
+    purge_object = sc.doc.Objects.Purge
+except AttributeError:
+    purge_object = None
 
 __author__     = ['Tom Van Mele', ]
 __copyright__  = 'Copyright 2014, BLOCK Research Group - ETH Zurich'
@@ -68,7 +71,8 @@ def delete_objects_on_layer(name, include_hidden=True, include_children=False, p
             obj = find_object(guid)
             if not obj:
                 continue
-            purge_object(obj.RuntimeSerialNumber)
+            if purge_object:
+                purge_object(obj.RuntimeSerialNumber)
         rs.EnableRedraw(True)
 
 
@@ -138,7 +142,8 @@ def clear_layer(name, include_hidden=True, include_children=True, purge=True):
             obj = find_object(guid)
             if not obj:
                 continue
-            purge_object(obj.RuntimeSerialNumber)
+            if purge_object:
+                purge_object(obj.RuntimeSerialNumber)
     rs.EnableRedraw(True)
 
 
@@ -156,7 +161,8 @@ def clear_layers(layers, include_children=True, include_hidden=True):
         obj = find_object(guid)
         if not obj:
             continue
-        purge_object(obj.RuntimeSerialNumber)
+        if purge_object:
+            purge_object(obj.RuntimeSerialNumber)
     rs.EnableRedraw(True)
 
 

--- a/src/compas_rhino/utilities/objects.py
+++ b/src/compas_rhino/utilities/objects.py
@@ -7,13 +7,16 @@ try:
     import scriptcontext as sc
 
     find_object = sc.doc.Objects.Find
-    purge_object = sc.doc.Objects.Purge
 
 except ImportError:
     import platform
     if platform.python_implementation() == 'IronPython':
         raise
 
+try:
+    purge_object = sc.doc.Objects.Purge
+except AttributeError:
+    purge_object = None
 
 __author__     = ['Tom Van Mele', ]
 __copyright__  = 'Copyright 2014, BLOCK Research Group - ETH Zurich'
@@ -91,14 +94,14 @@ def get_objects(name=None, color=None, layer=None):
 
 
 def delete_object(guid, purge=True):
-    if purge:
+    if purge and purge_object:
         purge_objects([guid])
     else:
         delete_objects([guid], purge)
 
 
 def delete_objects(guids, purge=True):
-    if purge:
+    if purge and purge_object:
         purge_objects(guids)
     else:
         for guid in guids:
@@ -113,6 +116,8 @@ def delete_objects_by_name(name, purge=True):
 
 
 def purge_objects(guids):
+    if not purge_object:
+        raise RuntimeError('Cannot purge outside Rhino script context')
     for guid in guids:
         if rs.IsObjectHidden(guid):
             rs.ShowObject(guid)


### PR DESCRIPTION
Since we discussed different options about the GH support, and this is definitely not a long-term solution, I propose it as a PR.

This small fix at least makes the `compas_rhino` module importable, so things like `RhinoMesh` can be used from Grasshopper, and also several of the utility functions at least.

Perhaps the support we discussed for `xdraw_*` (or `draw_*` according to the upcoming rename), could be implemented directly on `compas_rhino`, detecting the context, instead of creating a separate `compas_grasshopper` one.