### PR TITLE
Add continuous integration via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: python
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.6
+
+before_install:
+- if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    bash miniconda.sh -b -p $HOME/miniconda;
+    export PATH="$HOME/miniconda/bin:$PATH";
+    hash -r;
+    conda config --set always_yes yes --set changeps1 no;
+    conda update -q conda;
+    conda info -a;
+    conda create -y -q -n compas_3x -c conda-forge python=3.6;
+    source ~/miniconda/bin/activate compas_3x;
+    pip install -r requirements-dev.txt;
+  else
+    sudo apt-get update -qq;
+    pip install -r requirements-dev.txt;
+  fi
+
+install:
+- python setup.py install;
+
+script:
+- invoke test
+- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+    invoke docs;
+  fi
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  keep-history: true
+  github_token: $GITHUB_TOKEN
+  repo: compas-dev/main
+  name: COMPAS doc bot
+  target-branch: master
+  local_dir: dist/docs
+  on:
+    branch: develop
+    condition: $TRAVIS_PYTHON_VERSION = 2.7

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,5 +11,6 @@ include README.md
 include requirements.txt
 
 exclude requirements-dev.txt requirements-freeze.txt pytest.ini .bumpversion.cfg .editorconfig tasks.py
+exclude _README.md
 
 global-exclude *.py[cod] __pycache__ *.dylib *.nb[ic]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ html_theme = 'default'
 html_theme_options = {}
 html_context = {}
 html_static_path = []
+html_extra_path = ['.nojekyll']
 html_last_updated_fmt = ''
 html_copy_source = False
 html_show_sourcelink = False


### PR DESCRIPTION
Configuration to add continuous integration to compas using [Travis-CI](https://travis-ci.org/). The proposed config does the following:
 * It runs the installer of the repository on both Python 2.7 and 3.6
 * It runs unit tests on both configurations (2.7 and 3.6) (for now, there's almost no unit tests, but hopefully that will change)
 * It builds the documentation (only on 2.7)
 * It deploys the statically generated documentation to Github Pages (only on `develop` branch, but that can be changed). Currently configured to deploy to the [compas-dev/main](https://github.com/compas-dev/main) repo.

Additionally, this means that all pull requests are checked by Travis on all configurations, so if the unit test suite grows, this becomes a great safety net to avoid regressions.

To get this to work, one of the admins (@brgcode ?) needs to:
 * Sign in to Travis
 * Add this repository
 * Generate a personal token with the `public_repo` scope from the github web ui and add it as a Travis variable ([check here for more details](https://docs.travis-ci.com/user/deployment/pages/#setting-the-github-token))

I tested this on a fork of compas and was able to build and push to [some random github page](http://gnz.io/compas-docs/) the generated documentation:

For reference, the settings I used on Travis are the following:
![image](https://user-images.githubusercontent.com/933277/43473140-a534083c-94ef-11e8-9d5a-c9037ecf2d12.png)

I would like to enable the `invoke check` as well once we have this merged, but right now it throws a million warnings about PEP8 violations, unused code and a bunch of other stuff that we should eventually fix but it's not that critical. ;)
