### PR TITLE
Fix/homogenize xdraw_mesh API across CAD packages

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -6,5 +6,6 @@ Reference
     :maxdepth: 1
 
     reference/compas
-    reference/compas_rhino
     reference/compas_blender
+    reference/compas_ghpython
+    reference/compas_rhino

--- a/docs/reference/compas_ghpython.rst
+++ b/docs/reference/compas_ghpython.rst
@@ -1,0 +1,2 @@
+
+.. automodule:: compas_ghpython

--- a/src/compas/utilities/names.py
+++ b/src/compas/utilities/names.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def random_name(n=17):
-    return ''.join(random.choice(string.lowercase) for _ in range(n))
+    return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
 
 
 # ==============================================================================

--- a/src/compas_blender/utilities/drawing.py
+++ b/src/compas_blender/utilities/drawing.py
@@ -1,5 +1,5 @@
-from math import atan2
 from math import acos
+from math import atan2
 
 from compas_blender.utilities import delete_object
 from compas_blender.utilities import deselect_all_objects
@@ -8,6 +8,7 @@ from compas_blender.utilities import set_objects_show_name
 
 from compas.geometry import centroid_points
 from compas.geometry import distance_point_point
+from compas.utilities import random_name
 
 try:
     import bpy
@@ -349,22 +350,23 @@ def xdraw_lines(lines):
     return _link_objects(objects)
 
 
-def xdraw_mesh(name, vertices=[], edges=[], faces=[], layer=0, color=[1, 1, 1], alpha=1, wire=True):
+def xdraw_mesh(vertices=[], faces=[], edges=[], name=None, color=[1, 1, 1], layer=0, alpha=1, wire=True):
     """ Draws a Blender mesh.
 
     Parameters:
-        name (str): Blender mesh name.
         vertices (list): Vertices co-ordinates.
-        edges (list): Edge vertex indices.
         faces (list): Face vertex indices.
-        layer (int): Layer number.
+        edges (list): Edge vertex indices.
+        name (str): Blender mesh name. If ``None``, it defaults to a randomly generated name.
         color (list): Material color.
+        layer (int): Layer number.
         alpha (float): Alpha [0, 1].
         wire (bool): Show wires for faces.
 
     Returns:
         obj: Created Blender mesh object.
     """
+    name = name or random_name()
     mesh = bpy.data.meshes.new(name)
     mesh.from_pydata(vertices, edges, faces)
     mesh.update(calc_edges=True)

--- a/src/compas_blender/utilities/drawing.py
+++ b/src/compas_blender/utilities/drawing.py
@@ -194,7 +194,7 @@ def draw_plane(Lx=1, Ly=1, dx=0.5, dy=0.5, name='plane', layer=0, color=[1, 1, 1
                     faces.extend([[face[0], face[1], face[2]], [face[2], face[3], face[0]]])
                 elif bracing == 'diagonals-left':
                     faces.extend([[face[1], face[2], face[3]], [face[3], face[0], face[1]]])
-    bmesh = xdraw_mesh(name, vertices=vertices, faces=faces, layer=layer, color=color, wire=wire)
+    bmesh = xdraw_mesh(name=name, vertices=vertices, faces=faces, layer=layer, color=color, wire=wire)
     material = create_material(color=color)
     bmesh.data.materials.append(material)
     bmesh.select = False

--- a/src/compas_ghpython/__init__.py
+++ b/src/compas_ghpython/__init__.py
@@ -1,2 +1,59 @@
+"""
+********************************************************************************
+compas_ghpython
+********************************************************************************
+
+.. currentmodule:: compas_ghpython
+
+This package contains utilities and helpers for working with COMPAS in Grasshopper.
+
+drawing
+=======
+
+.. autosummary::
+    :toctree: generated/
+
+    xdraw_frame
+    xdraw_points
+    xdraw_lines
+    xdraw_polylines
+    xdraw_faces
+    xdraw_cylinders
+    xdraw_pipes
+    xdraw_spheres
+    xdraw_mesh
+    xdraw_network
+    mesh_draw
+
+
+sets
+====
+
+.. autosummary::
+    :toctree: generated/
+
+    list_to_ghtree
+    ghtree_to_list
+
+
+timers
+======
+
+.. autosummary::
+    :toctree: generated/
+
+    update_component
+
+
+utilities
+=========
+
+.. autosummary::
+    :toctree: generated/
+
+    unload_modules
+
+
+"""
 from .utilities import *
 from .helpers import *

--- a/src/compas_ghpython/helpers/mesh.py
+++ b/src/compas_ghpython/helpers/mesh.py
@@ -11,13 +11,16 @@ from compas.datastructures.mesh import Mesh
 from compas_ghpython.utilities import xdraw_mesh
 from compas.utilities.colors import color_to_colordict
 
+__all__ = [
+    'mesh_draw'
+]
 
-def mesh_draw(mesh, 
-              show_faces=False, 
-              show_vertices=False, 
+def mesh_draw(mesh,
+              show_faces=False,
+              show_vertices=False,
               show_edges=False,
-              vertexcolor=None, 
-              edgecolor=None, 
+              vertexcolor=None,
+              edgecolor=None,
               facecolor=None):
     """
     Draw a mesh object in Grasshopper.

--- a/src/compas_ghpython/utilities/drawing.py
+++ b/src/compas_ghpython/utilities/drawing.py
@@ -175,7 +175,7 @@ def xdraw_spheres(spheres):
     return rg_sheres
 
 
-def xdraw_mesh(vertices, faces, vertex_normals=None, texture_coordinates=None,
+def xdraw_mesh(vertices, faces, name=None, vertex_normals=None, texture_coordinates=None,
                vertex_colors=None):
     """Draw mesh in Grasshopper.
     """

--- a/src/compas_ghpython/utilities/drawing.py
+++ b/src/compas_ghpython/utilities/drawing.py
@@ -54,9 +54,9 @@ __all__ = [
 def xdraw_frame(frame):
     """Draw frame.
     """
-    pt = Point3d(*frame.point)
-    xaxis = Vector3d(*frame.xaxis)
-    yaxis = Vector3d(*frame.yaxis)
+    pt = Point3d(*iter(frame.point))
+    xaxis = Vector3d(*iter(frame.xaxis))
+    yaxis = Vector3d(*iter(frame.yaxis))
     return Plane(pt, xaxis, yaxis)
 
 

--- a/src/compas_ghpython/utilities/timer.py
+++ b/src/compas_ghpython/utilities/timer.py
@@ -5,6 +5,10 @@ except ImportError:
     if platform.python_implementation() == 'IronPython':
         raise
 
+__all__ = [
+    'update_component'
+]
+
 
 def update_component(ghenv, delay):
     """Schedule an update of the Grasshopper component.
@@ -12,7 +16,7 @@ def update_component(ghenv, delay):
     After the specified delay, the GH component will be automatically updated.
 
     Args:
-        ghenv (:class:`GhPython.Component.PythonEnvironment`): just available 
+        ghenv (:class:`GhPython.Component.PythonEnvironment`): just available
             from within the GHPython component.
 
         delay (:obj:`int`): Time in milliseconds until the update is performed.
@@ -26,4 +30,5 @@ def update_component(ghenv, delay):
     def callback(ghdoc):
         ghcomp.ExpireSolution(False)
 
-    ghdoc.ScheduleSolution(delay, gh.Kernel.GH_Document.GH_ScheduleDelegate(callback))
+    ghdoc.ScheduleSolution(
+        delay, gh.Kernel.GH_Document.GH_ScheduleDelegate(callback))

--- a/src/compas_rhino/utilities/drawing.py
+++ b/src/compas_rhino/utilities/drawing.py
@@ -106,7 +106,7 @@ def wrap_xdrawfunc(f):
                 clear_layer(layer)
 
         rs.EnableRedraw(False)
-        res = f(*args)
+        res = f(*args, **kwargs)
 
         if redraw:
             rs.EnableRedraw(True)
@@ -523,7 +523,7 @@ def xdraw_spheres(spheres):
 
 
 @wrap_xdrawfunc
-def xdraw_mesh(vertices, faces, color, name):
+def xdraw_mesh(vertices, faces, name=None, color=None):
     guid = rs.AddMesh(vertices, faces)
     if color:
         rs.ObjectColor(guid, color)

--- a/src/compas_rhino/utilities/drawing.py
+++ b/src/compas_rhino/utilities/drawing.py
@@ -119,7 +119,7 @@ def wrap_xdrawfunc(f):
 
 
 @wrap_xdrawfunc
-def xdraw_labels(labels):
+def xdraw_labels(labels, **kwargs):
     """Draw labels as text dots and optionally set individual name and color."""
     guids = []
     for l in iter(labels):
@@ -146,7 +146,7 @@ def xdraw_labels(labels):
 
 
 @wrap_xdrawfunc
-def xdraw_points(points):
+def xdraw_points(points, **kwargs):
     """Draw points and optionally set individual name, layer, and color properties.
     """
     guids = []
@@ -178,7 +178,7 @@ def xdraw_points(points):
 
 
 @wrap_xdrawfunc
-def xdraw_lines(lines):
+def xdraw_lines(lines, **kwargs):
     """Draw lines and optionally set individual name, color, arrow, layer, and
     width properties.
     """
@@ -221,7 +221,7 @@ def xdraw_lines(lines):
 
 
 @wrap_xdrawfunc
-def xdraw_geodesics(geodesics):
+def xdraw_geodesics(geodesics, **kwargs):
     """Draw geodesic lines on specified surfaces, and optionally set individual
     name, color, arrow, and layer properties.
     """
@@ -262,7 +262,7 @@ def xdraw_geodesics(geodesics):
 
 
 @wrap_xdrawfunc
-def xdraw_polylines(polylines):
+def xdraw_polylines(polylines, **kwargs):
     """Draw polylines, and optionally set individual name, color, arrow, and
     layer properties.
     """
@@ -302,7 +302,7 @@ def xdraw_polylines(polylines):
 
 
 @wrap_xdrawfunc
-def xdraw_breps(faces, srf=None, u=10, v=10, trim=True, tangency=True, spacing=0.1, flex=1.0, pull=1.0):
+def xdraw_breps(faces, srf=None, u=10, v=10, trim=True, tangency=True, spacing=0.1, flex=1.0, pull=1.0, **kwargs):
     """Draw polygonal faces as Breps, and optionally set individual name, color,
     and layer properties.
     """
@@ -356,7 +356,7 @@ def xdraw_breps(faces, srf=None, u=10, v=10, trim=True, tangency=True, spacing=0
 
 
 @wrap_xdrawfunc
-def xdraw_cylinders(cylinders, cap=False):
+def xdraw_cylinders(cylinders, cap=False, **kwargs):
     guids = []
     for c in iter(cylinders):
         start  = c['start']
@@ -402,7 +402,7 @@ def xdraw_cylinders(cylinders, cap=False):
 
 
 @wrap_xdrawfunc
-def xdraw_pipes(pipes, cap=2, fit=1.0):
+def xdraw_pipes(pipes, cap=2, fit=1.0, **kwargs):
     guids = []
     abs_tol = TOL
     ang_tol = sc.doc.ModelAngleToleranceRadians
@@ -444,7 +444,7 @@ def xdraw_pipes(pipes, cap=2, fit=1.0):
 
 
 # @wrap_xdrawfunc
-# def xdraw_forces(forces, color):
+# def xdraw_forces(forces, color, **kwargs):
 #     guids = []
 #     for c in iter(cylinders):
 #         start  = c['start']
@@ -490,7 +490,7 @@ def xdraw_pipes(pipes, cap=2, fit=1.0):
 
 
 @wrap_xdrawfunc
-def xdraw_spheres(spheres):
+def xdraw_spheres(spheres, **kwargs):
     guids = []
     for s in iter(spheres):
         pos    = s['pos']
@@ -523,7 +523,7 @@ def xdraw_spheres(spheres):
 
 
 @wrap_xdrawfunc
-def xdraw_mesh(vertices, faces, name=None, color=None):
+def xdraw_mesh(vertices, faces, name=None, color=None, **kwargs):
     guid = rs.AddMesh(vertices, faces)
     if color:
         rs.ObjectColor(guid, color)
@@ -533,7 +533,7 @@ def xdraw_mesh(vertices, faces, name=None, color=None):
 
 
 @wrap_xdrawfunc
-def xdraw_faces(faces):
+def xdraw_faces(faces, **kwargs):
     guids = []
     for face in iter(faces):
         points = face['points']
@@ -551,7 +551,7 @@ def xdraw_faces(faces):
         else:
             mfaces = _face_to_max_quad(points, range(v))
 
-        guid = xdraw_mesh(points, mfaces, color, name, clear=False, redraw=False, layer=None)
+        guid = xdraw_mesh(points, mfaces, color=color, name=name, clear=False, redraw=False, layer=None)
         guids.append(guid)
 
     return guids


### PR DESCRIPTION
I hope I’m not missing something obvious, but I’ve been failing to make the "canonical" example of COMPAS work: i.e. mesh drawing on multiple CADs.

A few (older) docs use `mesh_draw`, but that has been mostly removed (only available on `compas_ghpython`), so I tried using `xdraw_mesh`, but Rhino, Blender and Grasshopper packages all 3 have slightly different APIs: `compas_blender` requires a name, `compas_rhino` has a bug in the `xdraw_wrapper` that doesn’t pass `kwargs` properly, and `compas_ghpython` fails if a name is specified.

So, I tried to fix those very basic inconsistencies because we'll do a workshop this Wednesday and need this to work.

Also I added `compas_ghpython` to the docs because it was missing.