### PR TITLE
Add uninstall script and refactor generic methods

### DIFF
--- a/src/compas/utilities/_os.py
+++ b/src/compas/utilities/_os.py
@@ -1,0 +1,36 @@
+"""
+These are internal functions of the framework.
+Not intended to be used outside compas* packages.
+"""
+import os
+
+
+def create_symlink(source, link_name):
+    """Create a symbolic link pointing to source named link_name.
+
+    Parameters:
+        source: Source of the link
+        link_name: Link name.
+
+    Note:
+        This function is a polyfill of the native ``os.symlink``
+        for Python 2.x on Windows platforms.
+    """
+    os_symlink = getattr(os, 'symlink', None)
+
+    if not callable(os_symlink) and os.name == 'nt':
+        import subprocess
+
+        def symlink_ms(source, link_name):
+            subprocess.check_output(
+                ['mklink', '/D', link_name, source], stderr=subprocess.STDOUT, shell=True)
+
+        os_symlink = symlink_ms
+
+    os_symlink(source, link_name)
+
+def remove_symlink(link):
+    if os.path.isdir(link):
+        os.rmdir(link)
+    else:
+        os.unlink(link)

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -25,29 +25,19 @@ from __future__ import absolute_import
 
 import os
 
+import compas
+
 from .utilities import *
 from . import utilities
 
 __version__ = '0.3.0'
 
 
-def create_symlink(source, link_name):
-    os_symlink = getattr(os, "symlink", None)
-
-    # For Python 2.x on Windows, we need to polyfill os.symlink
-    if not callable(os_symlink) and os.name == "nt":
-        import subprocess
-
-        def symlink_ms(source, link_name):
-            subprocess.check_output(
-                ['mklink', '/D', link_name, source], stderr=subprocess.STDOUT, shell=True)
-
-        os_symlink = symlink_ms
-
-    os_symlink(source, link_name)
+def _get_compas_path():
+    return os.path.abspath(os.path.join(os.path.dirname(compas.__file__), '..'))
 
 
-def get_ironpython_lib_path(version):
+def _get_ironpython_lib_path(version):
     if version not in ('5.0', '6.0'):
         version = '5.0'
 

--- a/src/compas_rhino/uninstall.py
+++ b/src/compas_rhino/uninstall.py
@@ -6,21 +6,14 @@ import os
 
 import compas_rhino
 
-from compas.utilities._os import create_symlink
-
-__author__    = ['Tom Van Mele', ]
-__copyright__ = 'Copyright 2016 - Block Research Group, ETH Zurich'
-__license__   = 'MIT License'
-__email__     = 'vanmelet@ethz.ch'
-
+from compas_rhino.install import INSTALLABLE_PACKAGES
+from compas.utilities._os import remove_symlink
 
 __all__ = []
 
-INSTALLABLE_PACKAGES = ('compas', 'compas_ghpython', 'compas_rhino')
 
-
-def install(version='5.0'):
-    """Install COMPAS for Rhino.
+def uninstall(version='5.0'):
+    """Uninstall COMPAS from Rhino.
 
     Parameters
     ----------
@@ -32,37 +25,33 @@ def install(version='5.0'):
     .. code-block:: python
 
         >>> import compas_rhino
-        >>> compas_rhino.install('5.0')
+        >>> compas_rhino.uninstall('5.0')
 
     .. code-block:: python
 
-        $ python -m compas_rhino.install 5.0
+        $ python -m compas_rhino.uninstall 5.0
 
     """
 
-    print('Installing COMPAS packages to Rhino IronPython lib:')
+    print('Uninstalling COMPAS packages from Rhino IronPython lib:')
 
-    base_path = compas_rhino._get_compas_path()
     ipylib_path = compas_rhino._get_ironpython_lib_path(version)
 
     results = []
     exit_code = 0
 
     for package in INSTALLABLE_PACKAGES:
-        package_path = os.path.join(base_path, package)
         symlink_path = os.path.join(ipylib_path, package)
 
-        if os.path.exists(symlink_path):
-            results.append(
-                (package, 'ERROR: Package "{}" already found in Rhino lib, try uninstalling first'.format(package)))
+        if not os.path.exists(symlink_path):
             continue
 
         try:
-            create_symlink(package_path, symlink_path)
+            remove_symlink(symlink_path)
             results.append((package, 'OK'))
         except OSError:
             results.append(
-                (package, 'Cannot create symlink, try to run as administrator.'))
+                (package, 'Cannot remove symlink, try to run as administrator.'))
 
     for package, status in results:
         print('   {} {}'.format(package.ljust(20), status))
@@ -81,7 +70,7 @@ if __name__ == "__main__":
 
     import sys
 
-    print('\nusage: python -m compas_rhino.install [version]\n')
+    print('\nusage: python -m compas_rhino.uninstall [version]\n')
     print('  version       Rhino version (5.0 or 6.0)\n')
 
     try:
@@ -94,4 +83,4 @@ if __name__ == "__main__":
         except Exception:
             version = '5.0'
 
-    install(version=version)
+    uninstall(version=version)


### PR DESCRIPTION
Moved generic symlink polyfills to `compas.utilities` (explicitly as an internal package, since this should not be documented functionality of the library) to address #149, and added an matching `uninstall` script to go with the `install` one.