### PR TITLE
Yield pipes instead of extending lists over and over

### DIFF
--- a/src/compas_ghpython/utilities/drawing.py
+++ b/src/compas_ghpython/utilities/drawing.py
@@ -148,7 +148,6 @@ def xdraw_cylinders(cylinders, cap=False):
 
 
 def xdraw_pipes(pipes, cap=2, fit=1.0):
-    rg_pipes = []
     abs_tol = TOL
     ang_tol = sc.doc.ModelAngleToleranceRadians
     for p in pipes:
@@ -159,12 +158,12 @@ def xdraw_pipes(pipes, cap=2, fit=1.0):
         if type(radius) in (int, float):
             radius = [radius] * 2
         radius = [float(r) for r in radius]
+
         rail = Curve.CreateControlPointCurve([Point3d(*xyz) for xyz in points])
         breps = Brep.CreatePipe(rail, params, radius, 1, cap, fit, abs_tol,
                                 ang_tol)
-        rg_pipes += breps
-    return rg_pipes
-
+        for brep in breps:
+            yield brep
 
 def xdraw_spheres(spheres):
     rg_sheres = []


### PR DESCRIPTION
Very small performance fix on `xdraw_pipes`.