### PR TITLE
Add additional possibilities to filter mesh's vertices/edges/faces

### DIFF
--- a/src/compas/datastructures/_mixins/filters.py
+++ b/src/compas/datastructures/_mixins/filters.py
@@ -95,8 +95,8 @@ class VertexFilter(object):
 
         Parameters
         ----------
-        predicate : function
-            The condition you want to evaluate. The function takes 2 parameters: ``key``, ``attr`` and should return ``True`` or ``False``.
+        predicate : callable
+            The condition you want to evaluate. The callable takes 2 parameters: ``key``, ``attr`` and should return ``True`` or ``False``.
         data : bool, optional
             Yield the vertices and their data attributes.
             Default is ``False``.
@@ -124,10 +124,10 @@ class VertexFilter(object):
             mesh.add_face([v0,v1,v3])
             mesh.add_face([v1,v2,v3])
 
-            for v_key in mesh.vertices_where_predicate(lambda key, attr: attr['x']==100.0):
+            for v_key in mesh.vertices_where_predicate(lambda key, attr: attr['x'] == 100.0):
                 print v_key
 
-            for v_key, v_data in mesh.vertices_where_predicate(lambda key, attr: 50.0<=attr['y']<=150.0, True):
+            for v_key, v_data in mesh.vertices_where_predicate(lambda key, attr: 50.0 <= attr['y'] <= 150.0, True):
                 print v_key, v_data
 
             for v_key in mesh.vertices_where_predicate(lambda key, attr: 'extra_attr2' in attr):
@@ -231,8 +231,8 @@ class EdgeFilter(object):
 
         Parameters
         ----------
-        predicate : function
-            The condition you want to evaluate. The function takes 3 parameters: ``u``, ``v``, ``attr`` and should return ``True`` or ``False``.
+        predicate : callable
+            The condition you want to evaluate. The callable takes 3 parameters: ``u``, ``v``, ``attr`` and should return ``True`` or ``False``.
         data : bool, optional
             Yield the vertices and their data attributes.
             Default is ``False``.
@@ -265,7 +265,7 @@ class EdgeFilter(object):
             mesh.set_edge_attributes(random_edge, ['extra_attr1', 'extra_attr2'], [2, [3,5,9]])
 
 
-            for u, v, e_data in mesh.edges_where_predicate(lambda u, v, attr: attr['extra_attr1']==2, True):
+            for u, v, e_data in mesh.edges_where_predicate(lambda u, v, attr: attr['extra_attr1'] == 2, True):
                 print u, v, e_data
 
             for u, v in mesh.edges_where_predicate(lambda u, v, attr: 'extra_attr1' in attr):
@@ -367,8 +367,8 @@ class FaceFilter(object):
 
         Parameters
         ----------
-        predicate : function
-            The condition you want to evaluate. The function takes 2 parameters: ``key``, ``attr`` and should return ``True`` or ``False``.
+        predicate : callable
+            The condition you want to evaluate. The callable takes 2 parameters: ``key``, ``attr`` and should return ``True`` or ``False``.
         data : bool, optional
             Yield the faces and their data attributes.
             Default is ``False``.
@@ -397,10 +397,10 @@ class FaceFilter(object):
             mesh.add_face([v1,v2,v3], extra_attr1=1, extra_attr2=[3,7,12])
 
 
-            for f_key in mesh.faces_where_predicate(lambda f_key, attr: attr['extra_attr1']==5):
+            for f_key in mesh.faces_where_predicate(lambda f_key, attr: attr['extra_attr1'] == 5):
                 print f_key
 
-            for f_key, f_data in mesh.faces_where_predicate(lambda f_key, attr: 3<=attr['extra_attr1']<=6, True):
+            for f_key, f_data in mesh.faces_where_predicate(lambda f_key, attr: 3 <= attr['extra_attr1'] <= 6, True):
                 print f_key, f_data
 
             for f_key in mesh.faces_where_predicate(lambda f_key, attr: 'extra_attr2' in attr):

--- a/src/compas/datastructures/_mixins/filters.py
+++ b/src/compas/datastructures/_mixins/filters.py
@@ -96,7 +96,7 @@ class VertexFilter(object):
         Parameters
         ----------
         predicate : function
-            The condition you want to evaluate.
+            The condition you want to evaluate. The function takes 2 parameters: ``key``, ``attr`` and should return ``True`` or ``False``.
         data : bool, optional
             Yield the vertices and their data attributes.
             Default is ``False``.
@@ -116,18 +116,18 @@ class VertexFilter(object):
 
             mesh = Mesh()
 
-            v0 = mesh.add_vertex( x = 0.0, y = 0.0, z = 0.0, extra_attr1 = 0, extra_attr2 = [])
-            v1 = mesh.add_vertex( x = 100.0, y = 0.0, z = 0.0, extra_attr1 = 2, extra_attr2 = [3,5,9])
-            v2 = mesh.add_vertex( x = 100.0, y = 100.0, z = 0.0, extra_attr1 = 1, extra_attr2 = ['value1', 'value2'])
-            v3 = mesh.add_vertex( x = 0.0, y = 100.0, z = 0.0, extra_attr1 = 2, extra_attr2 = [3,7,12])
+            v0 = mesh.add_vertex(x=0.0, y=0.0, z=0.0, extra_attr1=0, extra_attr2=[])
+            v1 = mesh.add_vertex(x=100.0, y=0.0, z=0.0, extra_attr1=2, extra_attr2=[3,5,9])
+            v2 = mesh.add_vertex(x=100.0, y=100.0, z=0.0, extra_attr1=1, extra_attr2=['value1', 'value2'])
+            v3 = mesh.add_vertex(x=0.0, y=100.0, z=0.0, extra_attr1=2, extra_attr2=[3,7,12])
 
             mesh.add_face([v0,v1,v3])
             mesh.add_face([v1,v2,v3])
 
-            for v_key in mesh.vertices_where_predicate(lambda key, attr: attr['x'] == 100.0):
+            for v_key in mesh.vertices_where_predicate(lambda key, attr: attr['x']==100.0):
                 print v_key
 
-            for v_key, v_data in mesh.vertices_where_predicate(lambda key, attr: 50.0 <= attr['y'] <= 150.0, True):
+            for v_key, v_data in mesh.vertices_where_predicate(lambda key, attr: 50.0<=attr['y']<=150.0, True):
                 print v_key, v_data
 
             for v_key in mesh.vertices_where_predicate(lambda key, attr: 'extra_attr2' in attr):
@@ -232,7 +232,7 @@ class EdgeFilter(object):
         Parameters
         ----------
         predicate : function
-            The condition you want to evaluate.
+            The condition you want to evaluate. The function takes 3 parameters: ``u``, ``v``, ``attr`` and should return ``True`` or ``False``.
         data : bool, optional
             Yield the vertices and their data attributes.
             Default is ``False``.
@@ -251,10 +251,10 @@ class EdgeFilter(object):
 
             mesh = Mesh()
 
-            v0 = mesh.add_vertex(x = 0.0, y = 0.0, z = 0.0)
-            v1 = mesh.add_vertex(x = 100.0, y = 0.0, z = 0.0)
-            v2 = mesh.add_vertex(x = 100.0, y = 100.0, z = 0.0)
-            v3 = mesh.add_vertex(x = 0.0, y = 100.0, z = 0.0)
+            v0 = mesh.add_vertex(x=0.0, y=0.0, z=0.0)
+            v1 = mesh.add_vertex(x=100.0, y=0.0, z=0.0)
+            v2 = mesh.add_vertex(x=100.0, y=100.0, z=0.0)
+            v3 = mesh.add_vertex(x=0.0, y=100.0, z=0.0)
 
             mesh.add_face([v0,v1,v3])
             mesh.add_face([v1,v2,v3])
@@ -265,7 +265,7 @@ class EdgeFilter(object):
             mesh.set_edge_attributes(random_edge, ['extra_attr1', 'extra_attr2'], [2, [3,5,9]])
 
 
-            for u, v, e_data in mesh.edges_where_predicate(lambda u, v, attr: attr['extra_attr1'] == 2, True):
+            for u, v, e_data in mesh.edges_where_predicate(lambda u, v, attr: attr['extra_attr1']==2, True):
                 print u, v, e_data
 
             for u, v in mesh.edges_where_predicate(lambda u, v, attr: 'extra_attr1' in attr):
@@ -368,7 +368,7 @@ class FaceFilter(object):
         Parameters
         ----------
         predicate : function
-            The condition you want to evaluate.
+            The condition you want to evaluate. The function takes 2 parameters: ``key``, ``attr`` and should return ``True`` or ``False``.
         data : bool, optional
             Yield the faces and their data attributes.
             Default is ``False``.
@@ -388,25 +388,25 @@ class FaceFilter(object):
 
             mesh = Mesh()
 
-            v0 = mesh.add_vertex(x = 0.0, y = 0.0, z = 0.0)
-            v1 = mesh.add_vertex(x = 100.0, y = 0.0, z = 0.0)
-            v2 = mesh.add_vertex(x = 100.0, y = 100.0, z = 0.0)
-            v3 = mesh.add_vertex(x = 0.0, y = 100.0, z = 0.0)
+            v0 = mesh.add_vertex(x=0.0, y=0.0, z=0.0)
+            v1 = mesh.add_vertex(x=100.0, y=0.0, z=0.0)
+            v2 = mesh.add_vertex(x=100.0, y=100.0, z=0.0)
+            v3 = mesh.add_vertex(x=0.0, y=100.0, z=0.0)
 
-            mesh.add_face([v0,v1,v3], extra_attr1 = 5, extra_attr2 = [3,5,9])
-            mesh.add_face([v1,v2,v3], extra_attr1 = 1, extra_attr2 = [3,7,12])
+            mesh.add_face([v0,v1,v3], extra_attr1=5, extra_attr2=[3,5,9])
+            mesh.add_face([v1,v2,v3], extra_attr1=1, extra_attr2=[3,7,12])
 
 
-            for f_key in mesh.faces_where_predicate(lambda key, attr: attr['extra_attr1'] == 5):
+            for f_key in mesh.faces_where_predicate(lambda f_key, attr: attr['extra_attr1']==5):
                 print f_key
 
-            for f_key, f_data in mesh.faces_where_predicate(lambda key, attr: 3 <= attr['extra_attr1'] <= 6, True):
+            for f_key, f_data in mesh.faces_where_predicate(lambda f_key, attr: 3<=attr['extra_attr1']<=6, True):
                 print f_key, f_data
 
-            for f_key in mesh.faces_where_predicate(lambda key, attr: 'extra_attr2' in attr):
+            for f_key in mesh.faces_where_predicate(lambda f_key, attr: 'extra_attr2' in attr):
                 print f_key
 
-            for f_key in mesh.faces_where_predicate(lambda key, attr: 3 in attr['extra_attr2']):
+            for f_key in mesh.faces_where_predicate(lambda f_key, attr: 3 in attr['extra_attr2']):
                 print f_key
         """
         for fkey, attr in self.faces(True):

--- a/src/compas/datastructures/_mixins/filters.py
+++ b/src/compas/datastructures/_mixins/filters.py
@@ -44,6 +44,12 @@ class VertexFilter(object):
                 if callable(method):
                     val = method(key)
 
+                    if isinstance(val, list):
+                       if value not in val:
+                          is_match = False
+                          break
+                       break
+
                     if isinstance(value, (tuple, list)):
                         minval, maxval = value
 
@@ -60,6 +66,12 @@ class VertexFilter(object):
                         is_match = False
                         break
 
+                    if isinstance(attr[name], list):
+                       if value not in attr[name]:
+                          is_match = False
+                          break
+                       break
+
                     if isinstance(value, (tuple, list)):
                         minval, maxval = value
 
@@ -73,6 +85,62 @@ class VertexFilter(object):
 
             if is_match:
 
+                if data:
+                    yield key, attr
+                else:
+                    yield key
+
+    def vertices_where_predicate(self, predicate, data=False):
+        """Get vertices for which a certain condition or set of conditions is true using a lambda function.
+
+        Parameters
+        ----------
+        predicate : function
+            The condition you want to evaluate
+        data : bool, optional
+            Yield the vertices and their data attributes.
+            Default is ``False``.
+
+        Yields
+        ------
+        key: hashable
+            The next vertex that matches the condition.
+        2-tuple
+            The next vertex and its attributes, if ``data=True``.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            from compas.datastructures import Mesh
+
+            mesh = Mesh()
+
+            v0 = mesh.add_vertex( x = 0.0, y = 0.0, z = 0.0, extra_attr1 = 0, extra_attr2 = [])
+            v1 = mesh.add_vertex( x = 100.0, y = 0.0, z = 0.0, extra_attr1 = 2, extra_attr2 = [3,5,9])
+            v2 = mesh.add_vertex( x = 100.0, y = 100.0, z = 0.0, extra_attr1 = 1, extra_attr2 = ['value1', 'value2'])
+            v3 = mesh.add_vertex( x = 0.0, y = 100.0, z = 0.0, extra_attr1 = 2, extra_attr2 = [3,7,12])
+
+            mesh.add_face([v0,v1,v3])
+            mesh.add_face([v1,v2,v3])
+
+            for v_key in mesh.vertices_where_predicate(lambda _, attr: attr['x'] == 100.0):
+                print v_key
+
+            for v_key, v_data in mesh.vertices_where_predicate(lambda _, attr: 50.0 <= attr['y'] <= 150.0, True):
+                print v_key, v_data
+
+            for v_key in mesh.vertices_where_predicate(lambda _, attr: 'extra_attr2' in attr):
+                print v_key
+
+            for v_key in mesh.vertices_where_predicate(lambda _, attr: 3 in attr['extra_attr2']):
+                print v_key
+
+            for v_key in mesh.vertices_where_predicate(lambda _, attr: 'value2' in attr['extra_attr2']):
+                print v_key
+        """
+        for key, attr in self.vertices(True):
+            if predicate(key, attr):
                 if data:
                     yield key, attr
                 else:

--- a/src/compas/datastructures/_mixins/filters.py
+++ b/src/compas/datastructures/_mixins/filters.py
@@ -96,7 +96,7 @@ class VertexFilter(object):
         Parameters
         ----------
         predicate : function
-            The condition you want to evaluate
+            The condition you want to evaluate.
         data : bool, optional
             Yield the vertices and their data attributes.
             Default is ``False``.
@@ -124,19 +124,19 @@ class VertexFilter(object):
             mesh.add_face([v0,v1,v3])
             mesh.add_face([v1,v2,v3])
 
-            for v_key in mesh.vertices_where_predicate(lambda _, attr: attr['x'] == 100.0):
+            for v_key in mesh.vertices_where_predicate(lambda key, attr: attr['x'] == 100.0):
                 print v_key
 
-            for v_key, v_data in mesh.vertices_where_predicate(lambda _, attr: 50.0 <= attr['y'] <= 150.0, True):
+            for v_key, v_data in mesh.vertices_where_predicate(lambda key, attr: 50.0 <= attr['y'] <= 150.0, True):
                 print v_key, v_data
 
-            for v_key in mesh.vertices_where_predicate(lambda _, attr: 'extra_attr2' in attr):
+            for v_key in mesh.vertices_where_predicate(lambda key, attr: 'extra_attr2' in attr):
                 print v_key
 
-            for v_key in mesh.vertices_where_predicate(lambda _, attr: 3 in attr['extra_attr2']):
+            for v_key in mesh.vertices_where_predicate(lambda key, attr: 3 in attr['extra_attr2']):
                 print v_key
 
-            for v_key in mesh.vertices_where_predicate(lambda _, attr: 'value2' in attr['extra_attr2']):
+            for v_key in mesh.vertices_where_predicate(lambda key, attr: 'value2' in attr['extra_attr2']):
                 print v_key
         """
         for key, attr in self.vertices(True):
@@ -160,12 +160,16 @@ class EdgeFilter(object):
             A set of conditions in the form of key-value pairs.
             The keys should be attribute names. The values can be attribute
             values or ranges of attribute values in the form of min/max pairs.
+        data : bool, optional
+            Yield the edges and their data attributes.
+            Default is ``False``.
 
-        Returns
-        -------
-        list
-            A list of edge keys that satisfy the condition(s).
-
+        Yields
+        ------
+        2-tuple
+            The next edge as a (u, v) tuple, if ``data=False``.
+        3-tuple
+            The next edge as a (u, v, data) tuple, if ``data=True``.
         """
         for u, v, attr in self.edges(True):
             is_match = True
@@ -175,6 +179,12 @@ class EdgeFilter(object):
 
                 if callable(method):
                     val = method(u, v)
+
+                    if isinstance(val, list):
+                       if value not in val:
+                          is_match = False
+                          break
+                       break
 
                     if isinstance(value, (tuple, list)):
                         minval, maxval = value
@@ -192,6 +202,12 @@ class EdgeFilter(object):
                         is_match = False
                         break
 
+                    if isinstance(attr[name], list):
+                       if value not in attr[name]:
+                          is_match = False
+                          break
+                       break
+
                     if isinstance(value, (tuple, list)):
                         minval, maxval = value
 
@@ -205,6 +221,61 @@ class EdgeFilter(object):
 
             if is_match:
 
+                if data:
+                    yield u, v, attr
+                else:
+                    yield u, v
+
+    def edges_where_predicate(self, predicate, data=False):
+        """Get edges for which a certain condition or set of conditions is true using a lambda function.
+
+        Parameters
+        ----------
+        predicate : function
+            The condition you want to evaluate.
+        data : bool, optional
+            Yield the vertices and their data attributes.
+            Default is ``False``.
+
+        Yields
+        ------
+        2-tuple
+            The next edge as a (u, v) tuple, if ``data=False``.
+        3-tuple
+            The next edge as a (u, v, data) tuple, if ``data=True``.
+
+        Examples
+        --------
+        .. code-block:: python
+            from compas.datastructures import Mesh
+
+            mesh = Mesh()
+
+            v0 = mesh.add_vertex(x = 0.0, y = 0.0, z = 0.0)
+            v1 = mesh.add_vertex(x = 100.0, y = 0.0, z = 0.0)
+            v2 = mesh.add_vertex(x = 100.0, y = 100.0, z = 0.0)
+            v3 = mesh.add_vertex(x = 0.0, y = 100.0, z = 0.0)
+
+            mesh.add_face([v0,v1,v3])
+            mesh.add_face([v1,v2,v3])
+
+            mesh.update_default_edge_attributes({'extra_attr1':None, "extra_attr2":[]})
+
+            random_edge = mesh.get_any_edge()
+            mesh.set_edge_attributes(random_edge, ['extra_attr1', 'extra_attr2'], [2, [3,5,9]])
+
+
+            for u, v, e_data in mesh.edges_where_predicate(lambda u, v, attr: attr['extra_attr1'] == 2, True):
+                print u, v, e_data
+
+            for u, v in mesh.edges_where_predicate(lambda u, v, attr: 'extra_attr1' in attr):
+                print u, v
+
+            for u, v in mesh.edges_where_predicate(lambda u, v, attr: 3 in attr['extra_attr2']):
+                print u, v
+        """
+        for u, v, attr in self.edges(True):
+            if predicate(u, v, attr):
                 if data:
                     yield u, v, attr
                 else:


### PR DESCRIPTION
Added features:
* `vertices_where()`,`edges_where()`,`faces_where()` now will return results even if the `attr` is a list.

* I've also added functions that can accept functions/lambdas as a condition instead of `dict`.
`vertices_where_predicate()`, `edges_where_predicate()`, `faces_where_predicate()`