### PR TITLE
Allow RCP connection reuse

### DIFF
--- a/src/compas/rpc/__init__.py
+++ b/src/compas/rpc/__init__.py
@@ -5,6 +5,35 @@ compas.rpc
 
 .. currentmodule:: compas.rpc
 
+**COMPAS** runs in many different environments, but some environments
+limit the availablity of libraries, for example, when running **COMPAS** from
+an IronPython environment like Rhino/Grasshopper, plenty of the CPython libraries
+such as ``numpy``, ``scipy``, etc are not usable.
+
+To workaround this limitation, **COMPAS** provides two mechanisms to access the
+CPython environment seemlessly from any other Python environment. One of them is
+called ``XFunc`` (:class:`compas.utilities.XFunc`) and it works very effectively to
+make single, but expensive calls that execute long-running bits of code. The other
+one is called ``RPC``, which stands for `Remote Procedure Call`` and it allows to
+create a transparent proxy/connection between our environment and the one where
+all the fast libraries and dependencies of **COMPAS** are installed. It also allows
+to re-use the same process for many small calls, making it much more effective for
+the cases in which the required functionality  is not easily isolated in one
+long-running function.
+
+Proxy
+=====
+
+In order to use the RPC communication package, we create an instance of the
+``Proxy`` class to one specific package that we want to have access to.
+After the proxy is created, it behaves as a regular Python on which the functions
+of the proxied package are available as if they were directly present in our environment.
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    Proxy
 
 """
 

--- a/src/compas/rpc/server.py
+++ b/src/compas/rpc/server.py
@@ -20,11 +20,6 @@ __all__ = ['Server']
 class Server(SimpleXMLRPCServer):
     """Version of a `SimpleXMLRPCServer` that can be ceanly terminated from the client side.
 
-    Attributes
-    ----------
-    quit : bool
-        Flag telling the server to stop handling requests.
-
     Examples
     --------
     .. code-block:: python
@@ -54,28 +49,6 @@ class Server(SimpleXMLRPCServer):
 
     """
 
-    # quit = False
-    
-    # def serve_forever(self):
-    #     while not self.quit:
-    #         self.handle_request()
-
-    # def server_bind(self):
-    #     self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    #     SimpleXMLRPCServer.server_bind(self)
-
-    # def kill(self):
-    #     """Helper function used to kill a remote sever.
-
-    #     Notes
-    #     -----
-    #     Should be used together with an instance of `compas.rpc.Server`.
-
-    #     """
-    #     self.quit = True
-    #     return 1
-
-
     def ping(self):
         """Simple function used to check if a remote server can be reached.
 
@@ -87,7 +60,7 @@ class Server(SimpleXMLRPCServer):
         return 1
 
     def remote_shutdown(self):
-        threading.Thread(self._shutdown_thread).start()
+        threading.Thread(target=self._shutdown_thread).start()
         return 1
 
     def _shutdown_thread(self):


### PR DESCRIPTION
Instead of forcing the RCP server to terminate/stop always, this PR changes the behavior of the proxy to allow the server to stay alive and then reconnect to it on a follow up instantiation of the proxy.

Additionally, the automatic disposal of the server was changed from using Python's destructor (`__del__`) -whose invocation time is left up to the runtime, especially on IronPython- for an explicit context manager, so that when used in a `with Proxy(..) as p:` statement, the termination time is clear and deterministic.

Also added some docs to the RPC module.