### PR TITLE
Speed up STL binary loading time

### DIFF
--- a/src/compas/datastructures/mesh/_mesh.py
+++ b/src/compas/datastructures/mesh/_mesh.py
@@ -647,10 +647,11 @@ class Mesh(FromToPickle,
 
         """
         mesh = cls()
-        for x, y, z in iter(vertices):
-            mesh.add_vertex(x=x, y=y, z=z)
-        for face in iter(faces):
-            mesh.add_face(face)
+        for vkey, vertex in enumerate(vertices):
+            x, y, z = vertex
+            mesh.add_vertex(key=vkey, x=x, y=y, z=z)
+        for fkey, face in enumerate(faces):
+            mesh.add_face(face, fkey=fkey)
         return mesh
 
     @classmethod


### PR DESCRIPTION
This PR speeds up the loading time of STL binary files in two ways: 
 * removing the need to calculate `geometry_key`s for each vertex (and instead relying on the raw bytes of the vertex representation)
 * grouping io operations, specifically doing one file read for the full triangle, instead of many small reads (this might have a bigger positive impact on lame OSs with pathetic io performance such as Windows).

On my system (Python 3.6, Windows), a complex mesh loading went down more than 50%, (according to `timeit`, it's it's about 40% of the time it used to take). The first execution is on current master, the second is on this PR:

```
$ python -m timeit -n 100 -r 5 "import compas;from compas.datastructures import Mesh;Mesh.from_stl('link_4.stl')"
100 loops, best of 5: 445 msec per loop

$ python -m timeit -n 100 -r 5 "import compas;from compas.datastructures import Mesh;Mesh.from_stl('link_4.stl')"
100 loops, best of 5: 179 msec per loop
```

In terms of functionality, nothing has changed. I tested the change on a complex mesh (a robot link from one of our ABBs), loading it with compas and rendering it using `compas_rhino`, and it results in a valid mesh that looks proper:
![image](https://user-images.githubusercontent.com/933277/51267824-ecde8f00-19be-11e9-9d9e-9f2e21ad4f0a.png)


