### PR TITLE
Add await_callback function

### DIFF
--- a/src/compas/utilities/__init__.py
+++ b/src/compas/utilities/__init__.py
@@ -16,6 +16,16 @@ animation
     gif_from_images
 
 
+async
+=====
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    await_callback
+
+
 colors
 ======
 
@@ -157,6 +167,7 @@ def valuedict(keys, value, default):
 
 
 from .animation import *
+from .async_ import *
 from .coercing import *
 from .colors import *
 from .datetime_ import *

--- a/src/compas/utilities/async_.py
+++ b/src/compas/utilities/async_.py
@@ -1,0 +1,164 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import sys
+import time
+import threading
+
+
+__all__ = [
+    'await_callback',
+]
+
+class ThreadExceptHookHandler(object):
+    """Workaround to deal with a bug in the Python interpreter (!).
+
+    Report: http://bugs.python.org/issue1230540
+    Discussion: https://stackoverflow.com/a/31622038/269335
+    PR (not yet merged): https://github.com/python/cpython/pull/8610
+    Disclaimer (!): https://news.ycombinator.com/item?id=11090814
+    """
+    def __enter__(self):
+        original_init = threading.Thread.__init__
+
+        def init(self, *args, **kwargs):
+
+            original_init(self, *args, **kwargs)
+            original_run = self.run
+
+            def run_with_except_hook(*args2, **kwargs2):
+                try:
+                    original_run(*args2, **kwargs2)
+                except Exception:
+                    sys.excepthook(*sys.exc_info())
+
+            self.run = run_with_except_hook
+
+        self._original_init = original_init
+        threading.Thread.__init__ = init
+
+        return self
+
+    def __exit__(self, *args):
+        threading.Thread.__init__ = self._original_init
+
+
+def await_callback(async_func, callback_name='callback', *args, **kwargs):
+    """Wait for the completion of an asynchronous code that uses callbacks to signal completion.
+
+    This helper function turns an async function into a synchronous one,
+    waiting for its completion before moving forward (without doing a busy wait).
+
+    It is useful to minimize "callback hell" when more advanced options
+    like ``asyncio`` are not available.
+
+    Parameters
+    ----------
+    async_func : callable
+        An asynchronous function that receives at least one callback parameter
+        to signal completion.
+    callback_name : string, optional
+        Name of the callback parameter of ``async_func``.
+        Default is `callback`.
+
+    Notes
+    -----
+
+    Exceptions thrown during the async execution are handled and re-thrown as normal
+    exceptions, even if they were raised on a different thread.
+
+    Examples
+    --------
+
+    The following example shows how to await an async function (``do_sync_stuff` in
+    the example), using this utility:
+
+    .. code-block:: python
+
+        from compas.utilities import await_callback
+
+        def do_async_stuff(callback):
+            from threading import Thread
+
+            def runner(cb):
+                print('doing async stuff')
+                # ..
+                cb('done')
+
+            Thread(target=runner, args=(callback, )).start()
+
+        result = await_callback(do_async_stuff)
+
+    """
+    wait_event = threading.Event()
+    call_results = {}
+    def inner_callback(*args, **kwargs):
+        try:
+            call_results['args'] = args
+            call_results['kwargs'] = kwargs
+            wait_event.set()
+        except Exception as e:
+            call_results['exception'] = e
+            wait_event.set()
+
+    kwargs['callback'] = inner_callback
+
+    def unhandled_exception_handler(type, value, traceback):
+        call_results['exception'] = value
+        wait_event.set()
+
+    try:
+        # Install unhanlded exception handler
+        sys.excepthook = unhandled_exception_handler
+
+        # Invoke async method and wait
+        with ThreadExceptHookHandler():
+            async_func(*args, **kwargs)
+            wait_event.wait()
+    finally:
+        # Restore built-in unhanled exception handler
+        sys.excepthook = sys.__excepthook__
+
+    if 'exception' in call_results:
+        raise call_results['exception']
+
+    return_value = call_results['args']
+    dict_values = call_results['kwargs']
+
+    if not dict_values:
+        # If nothing, then None
+        if len(return_value) == 0:
+            return None
+        # If it's a one-item tuple,
+        # un-wrap from it and return that element
+        elif len(return_value) == 1:
+            return return_value[0]
+        else:
+            return return_value
+
+    if not return_value:
+        return dict_values
+
+    return return_value + (dict_values,)
+
+
+
+# ==============================================================================
+# Main
+# ==============================================================================
+
+if __name__ == "__main__":
+
+    def do_async_stuff(callback):
+        from threading import Thread
+
+        def runner(cb):
+            print('doing async stuff')
+            # ..
+            cb('done')
+
+        Thread(target=runner, args=(callback, )).start()
+
+    result = await_callback(do_async_stuff)
+    print(result)

--- a/tests/utilities/test_async_.py
+++ b/tests/utilities/test_async_.py
@@ -70,6 +70,16 @@ def test_many_positional_args_and_kwargs_callback():
     assert kw['retries'] == 5
 
 
+def test_async_fn_with_more_params():
+    def async_fn(values, other_stuff, callback):
+        def runner(cb):
+            cb(200)
+        Thread(target=runner, args=(callback, )).start()
+
+    result = await_callback(async_fn, values=[1, 2, 3], other_stuff=None)
+    assert result == 200
+
+
 def test_captured_exception_in_thread():
     def async_fn(callback):
         def runner(cb):

--- a/tests/utilities/test_async_.py
+++ b/tests/utilities/test_async_.py
@@ -1,0 +1,81 @@
+from threading import Thread
+
+from compas.utilities import await_callback
+
+import pytest
+
+
+def test_void_return_callback():
+    def async_fn(callback):
+        def runner(cb):
+            cb()
+        Thread(target=runner, args=(callback, )).start()
+
+    result = await_callback(async_fn)
+    assert result is None
+
+
+def test_single_positional_arg_callback():
+    def async_fn(callback):
+        def runner(cb):
+            cb('only_return_value')
+        Thread(target=runner, args=(callback, )).start()
+
+    result = await_callback(async_fn)
+    assert result == 'only_return_value'
+
+
+def test_many_positional_args_callback():
+    def async_fn(callback):
+        def runner(cb):
+            cb(1, 2)
+        Thread(target=runner, args=(callback, )).start()
+
+    result = await_callback(async_fn)
+    assert result == (1, 2, )
+
+
+def test_kwargs_callback():
+    def async_fn(callback):
+        def runner(cb):
+            cb(name='Austin', last_name='Powers')
+        Thread(target=runner, args=(callback, )).start()
+
+    result = await_callback(async_fn)
+    assert result['name'] == 'Austin'
+    assert result['last_name'] == 'Powers'
+
+
+def test_one_positional_arg_and_kwargs_callback():
+    def async_fn(callback):
+        def runner(cb):
+            cb(1, retries=5)
+        Thread(target=runner, args=(callback, )).start()
+
+    result, kwargs = await_callback(async_fn)
+    assert result == 1
+    assert kwargs['retries'] == 5
+
+
+def test_many_positional_args_and_kwargs_callback():
+    def async_fn(callback):
+        def runner(cb):
+            cb(4, 2, 3, retries=5)
+        Thread(target=runner, args=(callback, )).start()
+
+    a, b, c, kw = await_callback(async_fn)
+    assert a == 4
+    assert b == 2
+    assert c == 3
+    assert kw['retries'] == 5
+
+
+def test_captured_exception_in_thread():
+    def async_fn(callback):
+        def runner(cb):
+            raise ValueError('exception')
+
+        Thread(target=runner, args=(callback, )).start()
+
+    with pytest.raises(ValueError):
+        await_callback(async_fn)


### PR DESCRIPTION
When using the robotic fabrication package (and many other libraries) that uses callbacks to handle asynchronous code to signal completion, it is very easy to end up in callback hell, and a significant added complexity in written code that needs to deal with this, and while in many places it does make sense to keep code totally asynchronous, there are situations in which the application code just needs to wait for it before proceeding, and not having access to more advanced tooling such as `asyncio` (since it's not available for IronPython) means the code ends up being pretty convoluted.

This PR introduces a little utility function that helps with that case. Basically a poor man's `asyncio` awaiter. 😛 It deals with exceptions thrown in a thread as well and re-arranging callback parameters into meaningful return values.  

> It makes async code great again™️ 

I added several tests and an example, but for completeness, here's once again. Assuming an asynchronous method like: `def request(url, callback):`, one can write the following bit:

```python
from compas.utilities import await_callback

response = await_callback(request, url='https://api.something.ch/')
```
