### PR TITLE
Add re-planarity to windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
   - "3.6"
 
 before_install:
-- pip install --upgrade pip
-- pip --version
 - pip install Cython --install-option="--no-cython-compile"
 
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-cython; sys_platform != 'win32'
+cython
 matplotlib >= 2.0; python_version == '3.6'
 matplotlib >= 2.0, < 3.0; python_version == '2.7'
 networkx
 numba
 numpy
 pillow
-planarity; sys_platform != 'win32'
+planarity
 scipy
 sympy

--- a/src/compas/datastructures/network/_planarity.py
+++ b/src/compas/datastructures/network/_planarity.py
@@ -182,7 +182,7 @@ def network_is_planar(network):
     Warning
     -------
     This function uses the python binding of the *edge addition planarity suite*.
-    It is available on GitHub: https://github.com/hagberg/planarity.
+    It is available on Anaconda: https://anaconda.org/conda-forge/python-planarity.
 
     Examples
     --------
@@ -219,7 +219,7 @@ def network_is_planar(network):
     try:
         import planarity
     except ImportError:
-        print("Planarity is not installed. Get Planarity at https://github.com/hagberg/planarity.")
+        print("Planarity is not installed. Install with: conda install python-planarity")
         raise
     return planarity.is_planar(list(network.edges()))
 

--- a/tests/datastructures/test_network.py
+++ b/tests/datastructures/test_network.py
@@ -1,7 +1,29 @@
+import pytest
+
 import compas
 
 from compas.datastructures import Network
 from compas.datastructures import network_is_planar
+
+
+@pytest.fixture
+def k5_network():
+    network = Network()
+    network.add_edge('a', 'b')
+    network.add_edge('a', 'c')
+    network.add_edge('a', 'd')
+    network.add_edge('a', 'e')
+
+    network.add_edge('b', 'c')
+    network.add_edge('b', 'd')
+    network.add_edge('b', 'e')
+
+    network.add_edge('c', 'd')
+    network.add_edge('c', 'e')
+
+    network.add_edge('d', 'e')
+
+    return network
 
 
 def test_add_vertex():
@@ -11,7 +33,11 @@ def test_add_vertex():
     assert network.add_vertex(key=2) == 2
     assert network.add_vertex(key=0, x=1) == 0
 
-def test_planarity():
-    network = Network.from_obj(compas.get('lines.obj'))
-    network.add_edge(6, 15)
-    assert network_is_planar(network) is not True
+
+def test_non_planar(k5_network):
+    assert network_is_planar(k5_network) is not True
+
+
+def test_planar(k5_network):
+    k5_network.delete_edge('a', 'b')  # Delete (a, b) edge to make K5 planar
+    assert network_is_planar(k5_network) is True

--- a/tests/datastructures/test_network.py
+++ b/tests/datastructures/test_network.py
@@ -1,4 +1,7 @@
+import compas
+
 from compas.datastructures import Network
+from compas.datastructures import network_is_planar
 
 
 def test_add_vertex():
@@ -7,3 +10,8 @@ def test_add_vertex():
     assert network.add_vertex(x=0, y=0, z=0) == 1
     assert network.add_vertex(key=2) == 2
     assert network.add_vertex(key=0, x=1) == 0
+
+def test_planarity():
+    network = Network.from_obj(compas.get('lines.obj'))
+    network.add_edge(6, 15)
+    assert network_is_planar(network) is not True


### PR DESCRIPTION
Planarity support for Windows is good to go!

 - Fixed [planarity](https://anaconda.org/conda-forge/planarity) (the C lib) to support Windows
 - Created [python-planarity](https://anaconda.org/conda-forge/python-planarity) conda recipe for the bindings
  - Updated [compas-feedstock](https://github.com/conda-forge/compas-feedstock/pull/16) to re-add planarity

And now this PR updates the `requirements.txt` to re-introduce `planarity` dependency and adds a couple of unit tests for it.

Also removed all the `pip` upgrading, since it seems to be a cause of problems (see this conversation: https://github.com/conda-forge/compas-feedstock/pull/16#discussion_r249262049).