### PR TITLE
Make installer a bit more resilient

### DIFF
--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -66,8 +66,10 @@ def select_python(python_executable):
 def absjoin(*parts):
     return os.path.abspath(os.path.join(*parts))
 
+
 # Cache whatever symlink function works (native or polyfill)
 _os_symlink = None
+
 
 def create_symlink_polyfill():
     def symlink_ms(source, link_name):
@@ -75,6 +77,7 @@ def create_symlink_polyfill():
             ['mklink', '/D', link_name, source], stderr=subprocess.STDOUT, shell=True)
 
     return symlink_ms
+
 
 def create_symlink(source, link_name):
     """Create a symbolic link pointing to source named link_name.
@@ -107,6 +110,7 @@ def create_symlink(source, link_name):
 
         _os_symlink = create_symlink_polyfill()
         _os_symlink(source, link_name)
+
 
 def remove_symlink(link):
     if os.path.isdir(link):

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -5,6 +5,7 @@ Not intended to be used outside compas* packages.
 """
 import os
 import sys
+import subprocess
 
 PY3 = sys.version_info[0] == 3
 system = sys.platform
@@ -65,6 +66,15 @@ def select_python(python_executable):
 def absjoin(*parts):
     return os.path.abspath(os.path.join(*parts))
 
+# Cache whatever symlink function works (native or polyfill)
+_os_symlink = None
+
+def create_symlink_polyfill():
+    def symlink_ms(source, link_name):
+        subprocess.check_output(
+            ['mklink', '/D', link_name, source], stderr=subprocess.STDOUT, shell=True)
+
+    return symlink_ms
 
 def create_symlink(source, link_name):
     """Create a symbolic link pointing to source named link_name.
@@ -77,19 +87,26 @@ def create_symlink(source, link_name):
         This function is a polyfill of the native ``os.symlink``
         for Python 2.x on Windows platforms.
     """
-    os_symlink = getattr(os, 'symlink', None)
+    global _os_symlink
+    enable_retry_with_polyfill = False
 
-    if not callable(os_symlink) and os.name == 'nt':
-        import subprocess
+    if not _os_symlink:
+        _os_symlink = getattr(os, 'symlink', None)
 
-        def symlink_ms(source, link_name):
-            subprocess.check_output(
-                ['mklink', '/D', link_name, source], stderr=subprocess.STDOUT, shell=True)
+        if os.name == 'nt':
+            if not callable(_os_symlink):
+                _os_symlink = create_symlink_polyfill()
+            else:
+                enable_retry_with_polyfill = True
 
-        os_symlink = symlink_ms
+    try:
+        _os_symlink(source, link_name)
+    except OSError:
+        if not enable_retry_with_polyfill:
+            raise
 
-    os_symlink(source, link_name)
-
+        _os_symlink = create_symlink_polyfill()
+        _os_symlink(source, link_name)
 
 def remove_symlink(link):
     if os.path.isdir(link):

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -30,11 +30,11 @@ def _get_package_path(package):
 def _get_bootstrapper_data(compas_bootstrapper):
     data = {}
 
-    try:
-        content = io.open(compas_bootstrapper, encoding='utf8').read()
-        exec(content, data)
-    except FileNotFoundError:
-        pass
+    if not os.path.exists(compas_bootstrapper):
+        return data
+
+    content = io.open(compas_bootstrapper, encoding='utf8').read()
+    exec(content, data)
 
     return data
 
@@ -83,7 +83,8 @@ def install(version=None, packages=None):
         package_path = _get_package_path(importlib.import_module(package))
         symlink_path = os.path.join(ipylib_path, package)
 
-        if os.path.exists(symlink_path):
+        # Broken links return False on .exists(), so we need to check .islink() as well
+        if os.path.islink(symlink_path) or os.path.exists(symlink_path):
             try:
                 remove_symlink(symlink_path)
             except OSError:

--- a/src/compas_rhino/uninstall.py
+++ b/src/compas_rhino/uninstall.py
@@ -72,7 +72,7 @@ def uninstall(version=None, packages=None):
     for package in packages:
         symlink_path = os.path.join(ipylib_path, package)
 
-        if not os.path.exists(symlink_path):
+        if not (os.path.exists(symlink_path) or os.path.islink(symlink_path)):
             continue
 
         try:


### PR DESCRIPTION
- Fixed detection issue that caused broken symlinks to not be removable (e.g. when the target was deleted but link stays in place)
- Always retry with `create_symlink` polyfill: Interestingly enough, the polyfill does NOT require admin rights, so, we first try with the native function if available, but if that fails (e.g. due to lack of admin rights), we retry with the polyfill.
- Fixed an exception on Py2k: `FileNotFoundError` is not defined on python 2, so the installer was broken.