### PR TITLE
Fix xfunc and rpc environment activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix `XFunc` and `RPC` environment activation.
 - Fix exception on Rhino Mac.
 - Fix missing import on `compas_rhino.geometry`.
 

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -6,6 +6,11 @@ Not intended to be used outside compas* packages.
 import os
 import sys
 
+try:
+    NotADirectoryError
+except NameError:
+    class NotADirectoryError(Exception):
+        pass
 
 PY3 = sys.version_info[0] == 3
 system = sys.platform
@@ -71,7 +76,7 @@ def prepare_environment():
     variables.
     """
     env = os.environ.copy()
-    
+
     if PYTHON_DIRECTORY:
         lib_bin = os.path.join(PYTHON_DIRECTORY, 'Library', 'bin')
         if os.path.exists(lib_bin):

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -14,6 +14,16 @@ system = sys.platform
 if 'ironpython' in sys.version.lower() and os.name == 'nt':
     system = 'win32'
 
+try:
+    from compas_bootstrapper import PYTHON_DIRECTORY
+except:
+    # We re-map CONDA_PREFIX for backwards compatibility reasons
+    # In a few releases down the line, we can get rid of this bit
+    try:
+        from compas_bootstrapper import CONDA_PREFIX as PYTHON_DIRECTORY
+    except:
+        PYTHON_DIRECTORY = None
+
 
 def select_python(python_executable):
     """Selects the most likely python interpreter to run.
@@ -28,16 +38,6 @@ def select_python(python_executable):
         either `python` or `pythonw`.
     """
     python_executable = python_executable or 'pythonw'
-
-    try:
-        from compas_bootstrapper import PYTHON_DIRECTORY
-    except:
-        # We re-map CONDA_PREFIX for backwards compatibility reasons
-        # In a few releases down the line, we can get rid of this bit
-        try:
-            from compas_bootstrapper import CONDA_PREFIX as PYTHON_DIRECTORY
-        except:
-            PYTHON_DIRECTORY = None
 
     if PYTHON_DIRECTORY and os.path.exists(PYTHON_DIRECTORY):
         python = os.path.join(PYTHON_DIRECTORY, python_executable)
@@ -62,6 +62,22 @@ def select_python(python_executable):
     # Assume a system-wide install exists
     return python_executable
 
+
+def prepare_environment():
+    """Prepares an environment context to run Python on.
+
+    If Python is being used from a conda environment, this is roughly equivalent
+    to activating the conda environment by setting up the correct environment
+    variables.
+    """
+    env = os.environ.copy()
+    
+    if PYTHON_DIRECTORY:
+        lib_bin = os.path.join(PYTHON_DIRECTORY, 'Library', 'bin')
+        if os.path.exists(lib_bin):
+            env['PATH'] += ';' + lib_bin
+
+    return env
 
 def absjoin(*parts):
     return os.path.abspath(os.path.join(*parts))

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -80,7 +80,11 @@ def prepare_environment():
     if PYTHON_DIRECTORY:
         lib_bin = os.path.join(PYTHON_DIRECTORY, 'Library', 'bin')
         if os.path.exists(lib_bin):
-            env['PATH'] += ';' + lib_bin
+            env['PATH'] += os.pathsep + lib_bin
+
+        lib_bin = os.path.join(PYTHON_DIRECTORY, 'lib')
+        if os.path.exists(lib_bin):
+            env['PATH'] += os.pathsep + lib_bin
 
     return env
 

--- a/src/compas/rpc/proxy.py
+++ b/src/compas/rpc/proxy.py
@@ -236,7 +236,8 @@ class Proxy(object):
             self._process.Start()
         else:
             args = [python, '-m', self.service, str(self._port)]
-            self._process = Popen(args, stdout=PIPE, stderr=STDOUT)
+            env = compas._os.prepare_environment()
+            self._process = Popen(args, stdout=PIPE, stderr=STDOUT, env=env)
 
         server = ServerProxy(self.address)
 

--- a/src/compas/rpc/proxy.py
+++ b/src/compas/rpc/proxy.py
@@ -223,11 +223,13 @@ class Proxy(object):
 
         """
         python = self.python
+        env = compas._os.prepare_environment()
 
         try:
             Popen
         except NameError:
             self._process = Process()
+            self._process.StartInfo.EvironmentVariables = env
             self._process.StartInfo.UseShellExecute = False
             self._process.StartInfo.RedirectStandardOutput = True
             self._process.StartInfo.RedirectStandardError = True
@@ -236,7 +238,6 @@ class Proxy(object):
             self._process.Start()
         else:
             args = [python, '-m', self.service, str(self._port)]
-            env = compas._os.prepare_environment()
             self._process = Popen(args, stdout=PIPE, stderr=STDOUT, env=env)
 
         server = ServerProxy(self.address)

--- a/src/compas/utilities/xfunc.py
+++ b/src/compas/utilities/xfunc.py
@@ -376,7 +376,8 @@ class XFunc(object):
                         self.opath,
                         self.serializer]
 
-        process = Popen(process_args, stderr=PIPE, stdout=PIPE)
+        env = compas._os.prepare_environment()
+        process = Popen(process_args, stderr=PIPE, stdout=PIPE, env=env)
 
         while process.poll() is None:
             line = process.stdout.readline().strip()


### PR DESCRIPTION
Conda environments need to add some things to the `PATH` when activated, at least on Windows. This fixes it for `XFunc` and `RPC` calls ([report on Forum](https://forum.compas-framework.org/t/rhino-6-0-error-no-module-name-numpy/156/9)).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file.
1. [x] Run all tests on your computer (i.e. `invoke test`).
