### PR TITLE
Add the optimized A* algorithm for finding the shortest path in a network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `astar_shortest_path` to `compas.topology.traversal`.
+
 ### Changed
 
 - Fix 'mesh_weld' and 'meshes_join_and_weld' against consecutive duplicates in face vertices.

--- a/src/compas/topology/__init__.py
+++ b/src/compas/topology/__init__.py
@@ -67,6 +67,7 @@ traversal
     breadth_first_traverse
     breadth_first_paths
     shortest_path
+    astar_shortest_path
     dijkstra_distances
     dijkstra_path
 


### PR DESCRIPTION
As part of my application for a software engineer of COMPAS I decided to contribute an implementation of A* - one of the most efficient algorithms for finding a shortest path in a network. It will outperform the existing Dijkstra's algorithm in most situations, especially when the nodes of the network represent geometric locations.
(https://en.wikipedia.org/wiki/A*_search_algorithm) 

To test the algorithm with a larger graph, I've decided to use a dataset containing the entire road network of California, which can be obtained from here:
https://www.cs.utah.edu/~lifeifei/SpatialDataset.htm

I've used the following short test program:

```python
from random import choice
import compas

from compas.utilities import pairwise
from compas.datastructures import Network
from compas.topology import dijkstra_path
from compas.topology.traversal import astar_shortest_path
from compas.plotters import NetworkPlotter

def loadCaliRoadnet():
    network = Network()
    with open('california-roadnet-nodes.txt', 'r') as f:
        for line in f:
            key, x, y = line.split()
            network.add_vertex(key,x=float(x),y=float(y))
    with open('california-roadnet-edges.txt', 'r') as f:
      for line in f:
         id, edge1, edge2, dist = line.split()
         network.add_edge(edge1, edge2)
    return network

network = loadCaliRoadnet()

leaves = list(network.vertices_where({'vertex_degree': 1}))

start = end = 0
while start == end:
    start = choice(leaves)
    end = choice(leaves)

adjacency = {key: network.vertex_neighbors(key) for key in network.vertices()}
weight = {(u, v): network.edge_length(u, v) for u, v in network.edges()}
weight.update({(v, u): weight[(u, v)] for u, v in network.edges()})

print("Computing path from ", start, " to ", end)

import timeit

start_time = timeit.default_timer()
path1 = dijkstra_path(adjacency, weight, start, end)
elapsed = timeit.default_timer() - start_time
print("ELAPSED dijkstra ", elapsed)

start_time = timeit.default_timer()
path2 = astar_shortest_path(network, start, end)
elapsed = timeit.default_timer() - start_time
print("ELAPSED A* ", elapsed)

assert(path1 == path2)
```

For convenience, I've also uploaded the program and the dataset input files as a Github gist that can be cloned and executed like this:

```bash
git clone https://gist.github.com/266ef226c62eb51d45b9e1293f2d535c.git test_shortest_path
cd test_shortest_path
python test_shortest_path.py
```

An example run produces the following: 
 
```
(venv) λ python test_shortest_path.py
Computing path from  3328  to  7654
ELAPSED dijkstra  34.957459915
ELAPSED A*  0.09183666700000259
```

As you can see, The A* algorithm is more than 380 times faster and it produces the same result.


### What type of change is this?

- [x] New feature in a **backwards-compatible** manner.


