### PR TITLE
fix #287: quick hack to resolve the unsupported pythonnet `clr` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Restructure halffaces as lists in `compas.datastructures.VolMesh`.
+- Correctly handle `python-net` module presence during IronPython imports.
 
 ### Removed
 

--- a/src/compas/numerical/_alglib/_core/xalglib.py
+++ b/src/compas/numerical/_alglib/_core/xalglib.py
@@ -25,6 +25,9 @@ import os
 import clr
 import System
 
+if 'AddReferenceToFileAndPath' not in dir(clr):
+    raise ImportError
+
 DT_BOOL = 1
 DT_INT = 2
 DT_REAL = 3


### PR DESCRIPTION
Minimal fix until a proper solution to the `alglib` issues is found.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
