### PR TITLE
Fixes #297: Support install to Rhino with non-admin accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restructure halffaces as lists in `compas.datastructures.VolMesh`.
 - Correctly handle `python-net` module presence during IronPython imports.
 - Switched to `compas.IPY` check instead of `try-except` for preventing non IronPython friendly imports.
+- Changed installation of compas packages to Rhino to support non-admin user accounts on Windows.
 
 ### Removed
 

--- a/bin/install_compas_sublime
+++ b/bin/install_compas_sublime
@@ -25,9 +25,7 @@ def main():
 
     symlink_path = os.path.join(HOME, 'Library', 'Application Support', 'Sublime Text 3', 'Packages', name)
 
-    if os.path.exists(symlink_path):
-        compas._os.remove_symlink(symlink_path)
-
+    compas._os.remove_symlink(symlink_path)
     compas._os.create_symlink(plugin_path, symlink_path)
 
     print("\nSuccess: ST3 plugin installed!\n")

--- a/docs/environments/rhino.rst
+++ b/docs/environments/rhino.rst
@@ -23,8 +23,7 @@ The default is ``6.0``.
 
 .. note::
 
-    On Windows, use the "Anaconda Prompt" instead of the "Command Prompt", and make
-    sure to run it as administrator.
+    On Windows, use the "Anaconda Prompt" instead of the "Command Prompt".
 
     On Mac, use the Terminal.
 

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -3,10 +3,10 @@
 These are internal functions of the framework.
 Not intended to be used outside compas* packages.
 """
-import ctypes
 import os
 import subprocess
 import sys
+import tempfile
 
 try:
     NotADirectoryError
@@ -16,6 +16,38 @@ except NameError:
 
 PY3 = sys.version_info[0] == 3
 system = sys.platform
+
+if os.name == 'nt':
+    import ctypes
+    import ctypes.wintypes
+
+    class ShellExecuteInfo(ctypes.Structure):
+        _fields_ = [
+            ('cbSize',       ctypes.wintypes.DWORD),
+            ('fMask',        ctypes.c_ulong),
+            ('hwnd',         ctypes.wintypes.HWND),
+            ('lpVerb',       ctypes.c_char_p),
+            ('lpFile',       ctypes.c_char_p),
+            ('lpParameters', ctypes.c_char_p),
+            ('lpDirectory',  ctypes.c_char_p),
+            ('nShow',        ctypes.c_int),
+            ('hInstApp',     ctypes.wintypes.HINSTANCE),
+            ('lpIDList',     ctypes.c_void_p),
+            ('lpClass',      ctypes.c_char_p),
+            ('hKeyClass',    ctypes.wintypes.HKEY),
+            ('dwHotKey',     ctypes.wintypes.DWORD),
+            ('hIcon',        ctypes.wintypes.HANDLE),
+            ('hProcess',     ctypes.wintypes.HANDLE)]
+
+        def __init__(self, **kw):
+            super(ShellExecuteInfo, self).__init__()
+            self.cbSize = ctypes.sizeof(self)
+            for field_name, field_value in kw.items():
+                setattr(self, field_name, field_value)
+
+    SEE_MASK_NOCLOSEPROCESS = 0x00000040
+    SEE_MASK_NO_CONSOLE = 0x00008000
+    INFINITE = -1
 
 # IronPython support (OMG)
 if 'ironpython' in sys.version.lower() and os.name == 'nt':
@@ -99,12 +131,71 @@ def absjoin(*parts):
 _os_symlink = None
 
 
-def _create_symlink_win_polyfill():
-    def symlink_ms(source, link_name):
-        ret = _run_as_admin(['cmd.exe', '/c', 'mklink', '/D', link_name, source])
-        print(ret)
+def _polyfill_symlinks(symlinks, raise_on_error):
+    """Create multiple symlinks using the polyfill implementation."""
+    _handle, temp_path = tempfile.mkstemp(suffix='.cmd', text=True)
 
-    return symlink_ms
+    with open(temp_path, 'w') as mklink_cmd:
+        mklink_cmd.write('@echo off' + os.linesep)
+        mklink_cmd.write('SET /A symlink_result=0' + os.linesep)
+        mklink_cmd.write('ECHO ret=%symlink_result%' + os.linesep)
+        for i, (source, link_name) in enumerate(symlinks):
+            mklink_cmd.write("mklink /D {}{}".format(subprocess.list2cmdline([link_name, source]), os.linesep))
+            mklink_cmd.write('IF %ERRORLEVEL% EQU 0 SET /A symlink_result += {} {}'.format(2 ** i, os.linesep))
+
+        mklink_cmd.write('EXIT /B %symlink_result%' + os.linesep)
+
+    ret_value = _run_as_admin([temp_path])
+
+    # The error level integer (ret_value) reflects the success/failure of
+    # each of the symlink operations, so we do a bit of bitwise-arithmetic
+    # on it to figure out which symlinks worked and which ones failed.
+
+    result = []
+    for i in range(len(symlinks)):
+        success = ret_value & 2 ** i != 0
+        result.append(success)
+
+    return result
+
+
+def _native_symlinks(symlinks, raise_on_error):
+    """Create multiple symlinks using the native implementation."""
+    result = []
+
+    for source, link_name in symlinks:
+        try:
+            os.symlink(source, link_name)
+            result.append(True)
+        except OSError:
+            if raise_on_error:
+                raise
+
+            result.append(False)
+
+    return result
+
+
+def _set_symlink_function(fn):
+    global _os_symlink
+    _os_symlink = fn
+
+
+def _get_symlink_function():
+    global _os_symlink
+    allow_polyfill_retry = False
+
+    if not _os_symlink:
+        if getattr(os, 'symlink', None):
+            _os_symlink = _native_symlinks
+
+        if os.name == 'nt':
+            if not callable(_os_symlink):
+                _os_symlink = _polyfill_symlinks
+            else:
+                allow_polyfill_retry = True
+
+    return _os_symlink, allow_polyfill_retry
 
 
 def create_symlink(source, link_name):
@@ -122,36 +213,80 @@ def create_symlink(source, link_name):
     This function is a polyfill of the native ``os.symlink``
     for Python 2.x on Windows platforms.
     """
-    global _os_symlink
-    enable_retry_with_polyfill = False
+    create_symlinks([(source, link_name)], raise_on_error=True)
 
-    if not _os_symlink:
-        _os_symlink = getattr(os, 'symlink', None)
 
-        if os.name == 'nt':
-            if not callable(_os_symlink):
-                _os_symlink = _create_symlink_win_polyfill()
-            else:
-                enable_retry_with_polyfill = True
+def create_symlinks(symlinks, raise_on_error=False):
+    """Create multiple symbolic links in one call.
+
+    Parameters
+    ----------
+    symlinks: list of string tuples
+        List of ``source`` and ``link_name`` of the symlinks as tuples.
+    """
+    symlink, allow_polyfill_retry = _get_symlink_function()
 
     try:
-        _os_symlink(source, link_name)
+        return symlink(symlinks, raise_on_error=True)
     except OSError:
-        if not enable_retry_with_polyfill:
+        if raise_on_error:
             raise
 
-        _os_symlink = _create_symlink_win_polyfill()
-        _os_symlink(source, link_name)
+        _set_symlink_function(_polyfill_symlinks)
+        return _polyfill_symlinks(symlinks, raise_on_error=False)
 
 
-def remove_symlink(link):
-    if os.path.isdir(link):
+def remove_symlink(symlink):
+    """Remove a symlink from the file system.
+
+    Parameters
+    ----------
+    symlink : :obj:`str`
+        Symlink to remove.
+    """
+    # Broken links return False on .exists(), so we need to check .islink() as well
+    if not (os.path.islink(symlink) or os.path.exists(symlink)):
+        return
+
+    if os.path.isdir(symlink):
         try:
-            os.rmdir(link)
+            os.rmdir(symlink)
         except NotADirectoryError:
-            os.unlink(link)
+            os.unlink(symlink)
     else:
-        os.unlink(link)
+        os.unlink(symlink)
+
+
+def remove_symlinks(symlinks, raise_on_error=False):
+    """Remove one or more symlinks.
+
+    Parameters
+    ----------
+    links
+        Sequence of symlinks to remove.
+    raise_on_error : bool
+        ``False`` to continue removing even on error,
+        otherwise ``True``.
+
+    Returns
+    -------
+    list
+        If ``raise_on_error`` is ``False``, returns a list
+        of bools indicating which links were successfully removed.
+    """
+    result = []
+
+    for symlink in symlinks:
+        try:
+            remove_symlink(symlink)
+            result.append(True)
+        except OSError:
+            if raise_on_error:
+                raise
+
+            result.append(False)
+
+    return result
 
 
 def is_admin():
@@ -170,15 +305,13 @@ def is_admin():
     except:  # noqa: E722
         return False
 
-# PShellExecuteInfo = POINTER(ShellExecuteInfo)
-
 
 def _run_as_admin(command):
     """Run the specified command as an admin.
 
     Paramters
     ---------
-    command : list
+    command : :obj:`list` of :obj:`str`
         List of strings of the command to run.
 
     Returns
@@ -189,34 +322,6 @@ def _run_as_admin(command):
 
     if os.name != 'nt':
         raise RuntimeError('Only supported on Windows')
-
-    class ShellExecuteInfo(ctypes.Structure):
-        _fields_ = [
-            ('cbSize',       ctypes.wintypes.DWORD),
-            ('fMask',        ctypes.c_ulong),
-            ('hwnd',         ctypes.wintypes.HWND),
-            ('lpVerb',       ctypes.c_char_p),
-            ('lpFile',       ctypes.c_char_p),
-            ('lpParameters', ctypes.c_char_p),
-            ('lpDirectory',  ctypes.c_char_p),
-            ('nShow',        ctypes.c_int),
-            ('hInstApp',     ctypes.wintypes.HINSTANCE),
-            ('lpIDList',     ctypes.c_void_p),
-            ('lpClass',      ctypes.c_char_p),
-            ('hKeyClass',    ctypes.wintypes.HKEY),
-            ('dwHotKey',     ctypes.wintypes.DWORD),
-            ('hIcon',        ctypes.wintypes.HANDLE),
-            ('hProcess',     ctypes.wintypes.HANDLE)]
-
-        def __init__(self, **kw):
-            super(ShellExecuteInfo, self).__init__()
-            self.cbSize = ctypes.sizeof(self)
-            for field_name, field_value in kw.items():
-                setattr(self, field_name, field_value)
-
-    SEE_MASK_NOCLOSEPROCESS = 0x00000040
-    SEE_MASK_NO_CONSOLE = 0x00008000
-    INFINITE = -1
 
     command_file, command_args = command[0], command[1:]
 
@@ -356,8 +461,6 @@ def _get_win_folder_with_pywin32(csidl_name):
 
 
 def _get_win_folder_with_ctypes(csidl_name):
-    import ctypes
-
     csidl_const = {
         "CSIDL_APPDATA": 26,
         "CSIDL_COMMON_APPDATA": 35,
@@ -398,7 +501,9 @@ __all__ = [
     'absjoin',
     'system',
     'create_symlink',
+    'create_symlinks',
     'remove_symlink',
+    'remove_symlinks',
     'user_data_dir',
     'select_python',
     'prepare_environment',

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -101,8 +101,7 @@ _os_symlink = None
 
 def _create_symlink_win_polyfill():
     def symlink_ms(source, link_name):
-        ret = _run_as_admin(['cmd.exe', '/c', 'mklink', '/D', link_name, source])
-        print(ret)
+        _run_as_admin(['cmd.exe', '/c', 'mklink', '/D', link_name, source])
 
     return symlink_ms
 

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -75,6 +75,8 @@ def install(version=None, packages=None):
         packages = INSTALLABLE_PACKAGES
 
     ipylib_path = compas_rhino._get_ironpython_lib_path(version)
+    print('IronPython location: {}'.format(ipylib_path))
+    print()
 
     results = []
     symlinks = []

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -10,8 +10,8 @@ import sys
 import compas_rhino
 
 from compas._os import system
-from compas._os import remove_symlink
-from compas._os import create_symlink
+from compas._os import remove_symlinks
+from compas._os import create_symlinks
 
 
 __all__ = ['install']
@@ -77,28 +77,28 @@ def install(version=None, packages=None):
     ipylib_path = compas_rhino._get_ironpython_lib_path(version)
 
     results = []
+    symlinks = []
     exit_code = 0
 
     for package in packages:
         package_path = _get_package_path(importlib.import_module(package))
         symlink_path = os.path.join(ipylib_path, package)
+        symlinks.append((package_path, symlink_path))
 
-        # Broken links return False on .exists(), so we need to check .islink() as well
-        if os.path.islink(symlink_path) or os.path.exists(symlink_path):
-            try:
-                remove_symlink(symlink_path)
-            except OSError:
-                results.append((package, 'ERROR: Cannot remove symlink, try to run as administrator.'))
+    removal_results = remove_symlinks([link[1] for link in symlinks])
 
-        try:
-            create_symlink(package_path, symlink_path)
-            results.append((package, 'OK'))
-        except OSError:
-            results.append((package, 'ERROR: Cannot create symlink, try to run as administrator.'))
+    for package, success in zip(packages, removal_results):
+        if not success:
+            results.append((package, 'ERROR: Cannot remove symlink, try to run as administrator.'))
 
-    for _, status in results:
-        if status is not 'OK':
-            exit_code = -1
+    create_results = create_symlinks(symlinks)
+
+    for package, success in zip(packages, create_results):
+        result = 'OK' if success else 'ERROR: Cannot create symlink, try to run as administrator.'
+        results.append((package, result))
+
+    if not all(create_results):
+        exit_code = -1
 
     if exit_code == -1:
         results.append(('compas_bootstrapper', 'WARNING: One or more packages failed, will not install bootstrapper, try uninstalling first'))
@@ -118,13 +118,13 @@ def install(version=None, packages=None):
                 f.write('PYTHON_DIRECTORY = r"{}"\n'.format(python_directory))
                 f.write('INSTALLED_PACKAGES = {}'.format(repr(installed_packages)))
                 results.append(('compas_bootstrapper', 'OK'))
-        except:
+        except:  # noqa: E722
             results.append(('compas_bootstrapper', 'ERROR: Could not create compas_bootstrapper to auto-determine Python environment'))
 
     for package, status in results:
         print('   {} {}'.format(package.ljust(20), status))
 
-        if status is not 'OK':
+        if status != 'OK':
             exit_code = -1
 
     print('\nCompleted.')

--- a/src/compas_rhino/install_plugin.py
+++ b/src/compas_rhino/install_plugin.py
@@ -75,8 +75,7 @@ def install_plugin(plugin, version=None):
 
     print('Installing PlugIn {} to Rhino PythonPlugIns.'.format(plugin_name))
 
-    if os.path.exists(destination):
-        remove_symlink(destination)
+    remove_symlink(destination)
     create_symlink(source, destination)
 
     print('PlugIn {} Installed.'.format(plugin_name))

--- a/src/compas_rhino/uninstall_plugin.py
+++ b/src/compas_rhino/uninstall_plugin.py
@@ -43,8 +43,7 @@ def uninstall_plugin(plugin, version=None):
 
     print('Uninstalling PlugIn {} from Rhino PythonPlugIns.'.format(plugin))
 
-    if os.path.exists(destination):
-        remove_symlink(destination)
+    remove_symlink(destination)
 
     print('PlugIn {} Uninstalled.'.format(plugin))
 


### PR DESCRIPTION
Reworked the install scripts to Rhino to trigger privilege escalation requests from a non-admin user account during the installation itself (without having to start it from an administrator's prompt, which causes the install to always end up in the admin's Rhino user folder).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
