### PR TITLE
keep attributes in mesh mapping on surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `compas.remote.service.py` to `compas.remote.services.default.py`.
 - Removed processing of face keys from data getter and setter in `compas.datastructures.Network`.
 - Using `SimpleHTTPRequestHandler` instead of `BaseHTTPRequestHandler` to provide basic support for serving files via `GET`.
+- Mesh mapping on surface without creating new mesh to keep attributes in `compas_rhino.geometry.surface.py`.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/surface.py
+++ b/src/compas_rhino/geometry/surface.py
@@ -413,7 +413,7 @@ class RhinoSurface(RhinoGeometry):
         """
         return [self.point_uv_to_xyz(vertex) for vertex in polyline]
 
-    def mesh_uv_to_xyz(self, mesh, cls=None):
+    def mesh_uv_to_xyz(self, mesh):
         """Return the mesh from the inverse mapping of a UV mesh based on the UV parameterisation of the surface.
         The third coordinate of the mesh vertices is discarded.
 
@@ -424,16 +424,17 @@ class RhinoSurface(RhinoGeometry):
 
         Returns
         -------
-        Mesh, cls
-            The inverse-mapped mesh.
+        mesh : Mesh
+            The mesh once mapped back to the surface.
 
         """
-        if cls is None:
-            cls = type(mesh)
 
-        vertices, faces = mesh.to_vertices_and_faces()
-        vertices = {vkey: self.point_uv_to_xyz(uv[:2]) for vkey, uv in vertices.items()}
-        return cls.from_vertices_and_faces(vertices, faces)
+        for vkey in mesh.vertices():
+            x, y, z = self.point_uv_to_xyz(mesh.vertex_coordinates(vkey)[:2])
+            mesh.vertex[vkey]['x'] = x
+            mesh.vertex[vkey]['y'] = y
+            mesh.vertex[vkey]['z'] = z
+        return mesh
 
       
 # ==============================================================================


### PR DESCRIPTION
when mapping a mesh on a surface, move vertices instead of creating new mesh to keep attributes
bug fix in a **backwards-compatible** manner