### PR TITLE
Fix in centroid_polygon if null area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed processing of face keys from data getter and setter in `compas.datastructures.Network`.
 - Using `SimpleHTTPRequestHandler` instead of `BaseHTTPRequestHandler` to provide basic support for serving files via `GET`.
 - Mesh mapping on surface without creating new mesh to keep attributes in `compas_rhino.geometry.surface.py`.
+- Fix exception of null-area polygon of centroid polygon in `compas.geometry.average.py`.
 
 ### Removed
 

--- a/src/compas/geometry/average.py
+++ b/src/compas/geometry/average.py
@@ -319,6 +319,9 @@ def centroid_polygon(polygon):
         cy += a2 * y
         cz += a2 * z
 
+    if A2 == 0:
+        return polygon[0]
+
     return [cx / A2, cy / A2, cz / A2]
 
 


### PR DESCRIPTION
Fix exception in centroid polygon to output one polygon point if polygon has null area.
I did not use area_polygon to check this because it causes a circular import.
Bug fix in a **backwards-compatible** manner.
