### PR TITLE
Installing COMPAS for newly-released Rhino Mac 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
+- Added compas rhino installer for Rhino Mac 6.0 `compas_rhino.__init__`.
 - Added oriented bounding box for meshes `compas.datastructures.mesh_oriented_bounding_box_numpy`.
 
 ### Changed

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -62,12 +62,22 @@ def _get_ironpython_lib_path_win32(version):
                         'lib')
 
 
-def _get_ironpython_lib_path_mac():
+def _get_ironpython_lib_path_mac(version):
+    lib_paths = {
+    '5.0': [''],
+    '6.0':  ['Frameworks', 'RhCore.framework', 'Versions', 'A']
+    }
+
+    lib_path = lib_paths.get(version)
+    if not lib_path:
+        raise Exception('Unsupported Rhino version: {}'.format(version))
+
     return os.path.join(
         '/',
         'Applications',
         'Rhinoceros.app',
         'Contents',
+        *lib_path,
         'Resources',
         'ManagedPlugIns',
         'RhinoDLR_Python.rhp',

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -33,11 +33,25 @@ __version__ = '0.7.2'
 PURGE_ON_DELETE = True
 
 
+def _check_rhino_version(version):
+    supported_versions = ['5.0', '6.0']
+
+    if not version:
+        return '6.0'
+
+    if version not in supported_versions:
+        raise Exception('Unsupported Rhino version: {}'.format(version))
+
+    return version
+
+
 def _get_ironpython_lib_path(version):
+    version = _check_rhino_version(version)
+
     if compas._os.system == 'win32':
         ironpython_lib_path = _get_ironpython_lib_path_win32(version)
     elif compas._os.system == 'darwin':
-        ironpython_lib_path = _get_ironpython_lib_path_mac()
+        ironpython_lib_path = _get_ironpython_lib_path_mac(version)
     else:
         raise Exception('Unsupported platform')
 
@@ -48,9 +62,6 @@ def _get_ironpython_lib_path(version):
 
 
 def _get_ironpython_lib_path_win32(version):
-    if version not in ('5.0', '6.0'):
-        version = '5.0'
-
     appdata = os.getenv('APPDATA')
     return os.path.join(appdata,
                         'McNeel',
@@ -68,16 +79,12 @@ def _get_ironpython_lib_path_mac(version):
     '6.0':  ['Frameworks', 'RhCore.framework', 'Versions', 'A']
     }
 
-    lib_path = lib_paths.get(version)
-    if not lib_path:
-        raise Exception('Unsupported Rhino version: {}'.format(version))
-
     return os.path.join(
         '/',
         'Applications',
         'Rhinoceros.app',
         'Contents',
-        *lib_path,
+        *lib_paths.get(version),
         'Resources',
         'ManagedPlugIns',
         'RhinoDLR_Python.rhp',
@@ -86,6 +93,8 @@ def _get_ironpython_lib_path_mac(version):
 
 
 def _get_python_plugins_path(version):
+    version = _check_rhino_version(version)
+
     if compas._os.system == 'win32':
         python_plugins_path = _get_python_plugins_path_win32(version)
     elif compas._os.system == 'darwin':
@@ -97,9 +106,6 @@ def _get_python_plugins_path(version):
 
 
 def _get_python_plugins_path_win32(version):
-    if version not in ('5.0', '6.0'):
-        version = '6.0'
-
     appdata = os.getenv('APPDATA')
     return os.path.join(appdata,
                         'McNeel',


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### PR Description
Since a new (an long awaited) version for Rhino mac was launched officially last week, I tried to install `compas 0.7.2` in rhino by running `python -m compas_rhino.install` and `python -m compas_rhino.install -v 6.0` without success.

I noticed, nevertheless, that the `ironpython` directory in Rhino 6 for mac has changed, and as such, I implemented a path selector in methods `_get_ironpython_lib_path_mac()` which now distinguishes between versions `5.0`and `6.0`, and chooses the "right" path accordingly.

With this mod, I can happily run `compas`, and other packages (i.e. `compas_tna`) in Rhino Mac 6.

Moreover, and to avoid having to validate the rhino version supplied at the beginning of all path `getters`, I encapsulated this functionality into method `_check_rhino_version()`, which is invoked instead.

### What type of change is this?
- [x] New feature in a **backwards-compatible** manner.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).