### PR TITLE
Changed stderr parameter from STDOUT to PIPE in Proxy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added compas rhino installer for Rhino Mac 6.0 `compas_rhino.__init__`.
+- Added compas rhino installer for Rhino Mac 6.0 `compas.__init__`.
 - Added oriented bounding box for meshes `compas.datastructures.mesh_oriented_bounding_box_numpy`.
 
 ### Changed
-
+- Changed stderr parameter from STDOUT to PIPE in `compas.rpc.Proxy` for Rhino Mac 6.0.
 - Fixed import of `delaunay_from_points` in `Mesh.from_points`.
 - More control over drawing of text labels in Rhino.
 - Extension of `face_vertex_descendant` and `face_vertex_ancestor` in `Mesh`.

--- a/src/compas/rpc/proxy.py
+++ b/src/compas/rpc/proxy.py
@@ -246,7 +246,7 @@ class Proxy(object):
             self._process.Start()
         else:
             args = [self.python, '-m', self.service, str(self._port)]
-            self._process = Popen(args, stdout=PIPE, stderr=STDOUT, env=env)
+            self._process = Popen(args, stdout=PIPE, stderr=PIPE, env=env)
 
         server = ServerProxy(self.address)
 


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] New feature in a **backwards-compatible** manner.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
2. [ ] Run all tests on your computer (i.e. `invoke test`).

### Description

Follow-up on issue #320.

While launching a `Proxy()` server in rhino mac 6.0, a ValueError exception is raised by rhino's subprocess.py stating: "Cannot redirect stderr to stdout yet.".

`XFunc()` however does work.

After inspecting what the differences are between `XFunc()` and `Proxy()` the issue has been _solved_ by setting stderr equal to PIPE (as it currently is in `XFunc()`):
```self._process = Popen(args, stdout=PIPE, stderr=PIPE, *args, **kwargs)```

Nevertheless, I am not sure if this modification would have any potential side effects down the road.

Feedback is welcome 😄 