### PR TITLE
Sorting vertices' coordinates in MeshViewer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added compas rhino installer for Rhino Mac 6.0 `compas.__init__`.
+- Added compas rhino installer for Rhino Mac 6.0 `compas_rhino.__init__`.
 - Added oriented bounding box for meshes `compas.datastructures.mesh_oriented_bounding_box_numpy`.
 
 ### Changed
+- Fixed unsorted mesh vertex coordinates `xyz` in `compas_viewers.viewer.MeshView`
 - Changed stderr parameter from STDOUT to PIPE in `compas.rpc.Proxy` for Rhino Mac 6.0.
 - Fixed import of `delaunay_from_points` in `Mesh.from_points`.
 - More control over drawing of text labels in Rhino.

--- a/src/compas_viewers/viewer.py
+++ b/src/compas_viewers/viewer.py
@@ -78,7 +78,9 @@ class MeshView(object):
 
     @property
     def edges(self):
-        return self.mesh.edges()
+        key_index = self.mesh.key_index()
+        for u, v in self.mesh.edges():
+            yield key_index[u], key_index[v]
 
     @property
     def mesh(self):
@@ -89,7 +91,7 @@ class MeshView(object):
         self._mesh = mesh
 
         key_index = mesh.key_index()
-        xyz = mesh.get_vertices_attributes('xyz')
+        xyz = [mesh.vertex_coordinates(key) for key in mesh.vertices()]
 
         faces = []
         for fkey in mesh.faces():

--- a/src/compas_viewers/viewer.py
+++ b/src/compas_viewers/viewer.py
@@ -88,7 +88,7 @@ class MeshView(object):
     def mesh(self, mesh):
         self._mesh = mesh
 
-        xyz = mesh.get_vertices_attributes('xyz')
+        xyz = mesh.get_vertices_attributes('xyz', keys=sorted(list(mesh.vertices())))
         faces = []
         for fkey in mesh.faces():
             fvertices = mesh.face_vertices(fkey)
@@ -178,6 +178,7 @@ class Front(Controller):
         super(Front, self).__init__(app)
         self._mesh = None
         self._meshview = None
+
 
     @property
     def view(self):

--- a/src/compas_viewers/viewer.py
+++ b/src/compas_viewers/viewer.py
@@ -179,7 +179,6 @@ class Front(Controller):
         self._mesh = None
         self._meshview = None
 
-
     @property
     def view(self):
         return self.app.view


### PR DESCRIPTION
### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.

### Why this PR?

There is a discordance between the ordering of the vertices coordinates (attribute `_self.xyz`) and the faces keys (attribute `self._faces`) whenever the `mesh` property of `MeshViewer()` is set. 

The most probable reason is that `mesh.get_vertices_attributes('xyz')` in line 91 yields values from the unordered dictionary `self.vertex' from`compas.datastructures.Mesh`.

Hence, it is proposed that the ordering of the vertices' keys is explicitly stated when querying for their `xyz` attributes: `mesh.get_vertices_attributes('xyz', keys=sorted(list(mesh.vertices())`

This bug was not evident when testing against default meshes (such as that derived from `compas.get('faces.obj')`).

### How to reproduce?

The following will work:
```
from compas.datastructures import Mesh
from compas_viewers import Viewer

viewer.mesh = Mesh.from_obj(compas.get('faces.obj)')
viewer.show() 
```
<img width="1425" alt="Screenshot 2019-09-14 at 13 08 23" src="https://user-images.githubusercontent.com/13332619/64907323-045a4d00-d6f1-11e9-8542-cd371b97307e.png">

The following will not work:

```
from compas.datastructures import Mesh
from compas_viewers import Viewer

viewer.mesh = Mesh.from_obj('my_favorite_mesh.obj')
viewer.show() 
```

<img width="1429" alt="Screenshot 2019-09-14 at 13 07 25" src="https://user-images.githubusercontent.com/13332619/64907314-ed1b5f80-d6f0-11e9-9bd2-6f6a88dad424.png">

### Expected result

<img width="1435" alt="Screenshot 2019-09-14 at 13 06 59" src="https://user-images.githubusercontent.com/13332619/64907317-f3a9d700-d6f0-11e9-9aaa-1a437acd7841.png">







