### PR TITLE
Define joint's origin and axis defaults to match docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added oriented bounding box for meshes `compas.datastructures.mesh_oriented_bounding_box_numpy`.
 
 ### Changed
+
 - Fixed unsorted mesh vertex coordinates `xyz` in `compas_viewers.viewer.MeshView`
 - Changed stderr parameter from STDOUT to PIPE in `compas.rpc.Proxy` for Rhino Mac 6.0.
 - Fixed import of `delaunay_from_points` in `Mesh.from_points`.
 - More control over drawing of text labels in Rhino.
 - Extension of `face_vertex_descendant` and `face_vertex_ancestor` in `Mesh`.
 - Changed the name and meaning of the parameter `oriented` in the function `Mesh.edges_on_boundary`.
+- Add `axis` and `origin` defaults to `compas.robots.Joint`
 
 ### Removed
 

--- a/src/compas/robots/model/joint.py
+++ b/src/compas/robots/model/joint.py
@@ -189,8 +189,8 @@ class Joint(object):
         self.type = Joint.SUPPORTED_TYPES.index(type)
         self.parent = parent if isinstance(parent, ParentLink) else ParentLink(parent)
         self.child = child if isinstance(child, ChildLink) else ChildLink(child)
-        self.origin = origin
-        self.axis = axis
+        self.origin = origin or Origin.from_euler_angles([0., 0., 0.])
+        self.axis = axis or Axis()
         self.calibration = calibration
         self.dynamics = dynamics
         self.limit = limit
@@ -239,6 +239,9 @@ class Joint(object):
         Args:
             position (float): the angle in radians
         """
+        if not self.limit:
+            raise ValueError('Revolute joints are required to define a limit')
+
         position = max(min(position, self.limit.upper), self.limit.lower)
         return self.calculate_continous_transformation(position)
 
@@ -262,6 +265,9 @@ class Joint(object):
         Args:
             position (float): the movement in meters.
         """
+        if not self.limit:
+            raise ValueError('Prismatic joints are required to define a limit')
+
         position = max(min(position, self.limit.upper), self.limit.lower)
         return Translation(self.axis.vector * position)
 

--- a/tests/compas/robots/test_joint.py
+++ b/tests/compas/robots/test_joint.py
@@ -1,0 +1,22 @@
+from math import pi
+
+from compas.geometry import Frame
+from compas.geometry import Transformation
+from compas.geometry import Translation
+from compas.robots import Axis
+from compas.robots import Joint
+from compas.robots import Limit
+from compas.robots import Link
+
+
+def test_revolute_calculate_transformation():
+    limit = Limit(lower=-2 * pi, upper=2 * pi)
+    j1 = Joint('j1', 'revolute', None, None, limit=limit)
+    transformation = j1.calculate_transformation(2*pi)
+    assert transformation == Transformation()
+
+def test_prismatic_calculate_transformation():
+    limit = Limit(lower=0, upper=1000)
+    j1 = Joint('j1', 'prismatic', None, None, axis=Axis('1 0 0'), limit=limit)
+    t = j1.calculate_transformation(550)
+    assert t == Translation([550, 0, 0])


### PR DESCRIPTION
[URDF docs](http://wiki.ros.org/urdf/XML/joint) indicate that Axis and Origin should not be mandatory, but should have defined defaults instead.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
