### PR TITLE
Handling colinear segments in offsets for polylines and polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `tol` parameter to `queries.is_colinear`
 - Added compas rhino installer for Rhino Mac 6.0 `compas_rhino.__init__`.
 - Added oriented bounding box for meshes `compas.datastructures.mesh_oriented_bounding_box_numpy`.
 
 ### Changed
 
+- Extended `offset_polygon` and `offset_polyline` to handle colinear segments
 - Fixed unsorted mesh vertex coordinates `xyz` in `compas_viewers.viewer.MeshView`
 - Changed stderr parameter from STDOUT to PIPE in `compas.rpc.Proxy` for Rhino Mac 6.0.
 - Fixed import of `delaunay_from_points` in `Mesh.from_points`.

--- a/src/compas/geometry/offset/offset.py
+++ b/src/compas/geometry/offset/offset.py
@@ -10,6 +10,7 @@ from compas.geometry import cross_vectors
 from compas.geometry import centroid_points
 from compas.geometry import intersection_line_line
 from compas.geometry import normal_polygon
+from compas.geometry import is_colinear
 
 from compas.utilities import pairwise
 
@@ -62,14 +63,11 @@ def offset_line(line, distance, normal=[0.0, 0.0, 1.0]):
         print(line_offset)
 
     """
+
     a, b = line
     ab = subtract_vectors(b, a)
     direction = normalize_vector(cross_vectors(normal, ab))
-
-    if isinstance(distance, (list, tuple)):
-        distances = distance
-    else:
-        distances = [distance, distance]
+    distances = match_value_sequence(distance, line)
 
     u = scale_vector(direction, distances[0])
     v = scale_vector(direction, distances[1])
@@ -78,7 +76,7 @@ def offset_line(line, distance, normal=[0.0, 0.0, 1.0]):
     return c, d
 
 
-def offset_polygon(polygon, distance):
+def offset_polygon(polygon, distance, tol=1e-6):
     """Offset a polygon (closed) by a distance.
 
     Parameters
@@ -135,35 +133,20 @@ def offset_polygon(polygon, distance):
         print(polygon_offset)
 
     """
-    p = len(polygon)
-
-    if isinstance(distance, (list, tuple)):
-        distances = distance
-    else:
-        distances = [distance] * p
-
-    d = len(distances)
-    if d < p:
-        distances.extend(distances[-1:] * (p - d))
-
     normal = normal_polygon(polygon)
+    distances = match_value_sequence(distance, polygon)
+    polygon = polygon + polygon[:1]
+    segments = offset_segments(polygon, distances, normal)
 
     offset = []
-    for line, distance in zip(pairwise(polygon + polygon[:1]), distances):
-        offset.append(offset_line(line, distance, normal))
+    for s1, s2 in pairwise(segments[-1:] + segments):
+        point = intersect(s1, s2, tol)
+        offset.append(point)
 
-    points = []
-    for l1, l2 in pairwise(offset[-1:] + offset):
-        x1, x2 = intersection_line_line(l1, l2)
-        if x1 and x2:
-            points.append(centroid_points([x1, x2]))
-        else:
-            points.append(x1)
-
-    return points
+    return offset
 
 
-def offset_polyline(polyline, distance, normal=[0.0, 0.0, 1.0]):
+def offset_polyline(polyline, distance, normal=[0.0, 0.0, 1.0], tol=1e-6):
     """Offset a polyline by a distance.
 
     Parameters
@@ -185,32 +168,75 @@ def offset_polyline(polyline, distance, normal=[0.0, 0.0, 1.0]):
 
     """
 
-    p = len(polyline)
+    distances = match_value_sequence(distance, polyline)
+    segments = offset_segments(polyline, distances, normal)
 
-    if isinstance(distance, (list, tuple)):
-        distances = distance
+    offset = [segments[0][0]]
+    for s1, s2 in pairwise(segments):
+        point = intersect(s1, s2, tol)
+        offset.append(point)
+    offset.append(segments[-1][1])
+
+    return offset
+
+
+def match_value_sequence(value, sequence):
+    """
+    """
+    p = len(sequence)
+    if isinstance(value, (list, tuple)):
+        values = value
     else:
-        distances = [distance] * p
+        values = [value] * p
 
-    d = len(distances)
+    d = len(values)
     if d < p:
-        distances.extend(distances[-1:] * (p - d))
+        values.extend(values[-1:] * (p - d))
 
-    offset = []
-    for line, distance in zip(pairwise(polyline), distances):
-        offset.append(offset_line(line, distance, normal))
+    return values
 
-    points = [offset[0][0]]
-    for l1, l2 in pairwise(offset):
-        x1, x2 = intersection_line_line(l1, l2)
-        if x1 and x2:
-            points.append(centroid_points([x1, x2]))
-        else:
-            points.append(x1)
-    points.append(offset[-1][1])
 
-    return points
+def intersect_lines(l1, l2, tol):
+    """
+    """
+    x1, x2 = intersection_line_line(l1, l2, tol)
+    if x1 and x2:
+        return centroid_points([x1, x2])
 
+
+def intersect_lines_colinear(l1, l2, tol):
+    """
+    """
+    def are_segments_colinear(l1, l2, tol):
+        a, b = l1
+        d, c = l2
+        return is_colinear(a, b, c, tol)
+
+    if are_segments_colinear(l1, l2, tol):
+        return centroid_points([l1[1], l2[0]])
+
+
+def intersect(l1, l2, tol):
+    """
+    """
+    supported_funcs = [intersect_lines, intersect_lines_colinear]
+
+    for func in supported_funcs:
+        point = func(l1, l2, tol)
+        if point:
+            return point
+
+    msg = "Intersection not found for line: {}, and line: {}".format(l1, l2)
+    raise ValueError(msg)
+
+
+def offset_segments(point_list, distances, normal):
+    """
+    """
+    segments = []
+    for line, distance in zip(pairwise(point_list), distances):
+        segments.append(offset_line(line, distance, normal))
+    return segments
 
 # ==============================================================================
 # Main
@@ -241,7 +267,7 @@ if __name__ == "__main__":
                 'color': '#00ff00'
             })
 
-    plotter = MeshPlotter(mesh)
+    plotter = MeshPlotter(mesh, figsize=(12, 9))
     plotter.draw_faces()
     plotter.draw_polylines(polygons)
     plotter.draw_lines(lines)

--- a/src/compas/geometry/queries.py
+++ b/src/compas/geometry/queries.py
@@ -114,7 +114,7 @@ def is_ccw_xy(a, b, c, colinear=False):
     return ab_x * ac_y - ab_y  * ac_x > 0
 
 
-def is_colinear(a, b, c):
+def is_colinear(a, b, c, tol=1e-9):
     """Determine if three points are colinear.
 
     Parameters
@@ -125,15 +125,18 @@ def is_colinear(a, b, c):
         Point 2.
     c : tuple, list, Point
         Point 3.
+    tol : float, optional
+        A tolerance for membership verification.
+        Default is ``1e-9``.
 
     Returns
     -------
     bool
-        ``True`` if the points are collinear
+        ``True`` if the points are colinear
         ``False`` otherwise.
 
     """
-    return area_triangle([a, b, c]) < 1e-9
+    return area_triangle([a, b, c]) < tol
 
 
 def is_colinear_xy(a, b, c):
@@ -151,7 +154,7 @@ def is_colinear_xy(a, b, c):
     Returns
     -------
     bool
-        ``True`` if the points are collinear
+        ``True`` if the points are colinear
         ``False`` otherwise.
 
     """

--- a/tests/compas/geometry/test_offset.py
+++ b/tests/compas/geometry/test_offset.py
@@ -1,0 +1,64 @@
+import pytest
+
+from compas.geometry import offset_line
+from compas.geometry import offset_polyline
+from compas.geometry import offset_polygon
+
+# ==============================================================================
+# polygon
+# ==============================================================================
+
+@pytest.mark.parametrize(("polygon", "distance", "tol", "output_polygon"),
+                         [
+                         ([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]], 0.10, 1e-6,
+                          [[0.1, 0.1, 0.0], [0.9, 0.1, 0.0], [0.9, 0.9, 0.0], [0.1, 0.9, 0.0]])
+                         ]
+)
+def test_offset_polygon(polygon, distance, tol, output_polygon):
+    output_polygon = [pytest.approx(v) for v in output_polygon]
+    assert offset_polygon(polygon, distance, tol) == output_polygon
+
+
+@pytest.mark.parametrize(("polygon", "distance", "tol", "output_polygon"),
+                         [
+                         ([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.5, 0.0]], 0.10, 1e-6,
+                          [[0.1, 0.1, 0.0], [0.9, 0.1, 0.0], [0.9, 0.9, 0.0], [0.1, 0.9, 0.0], [0.1, 0.5, 0.0]])
+                         ]
+)
+def test_offset_colinear_polygon(polygon, distance, tol, output_polygon):
+    output_polygon = [pytest.approx(v) for v in output_polygon]
+    assert offset_polygon(polygon, distance, tol) == output_polygon
+
+# ==============================================================================
+# polyline
+# ==============================================================================
+
+@pytest.mark.parametrize(("polyline", "distance", "normal", "tol"),
+                         [([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], 1, [0.0, 0.0, 1.0], 1e-6)]
+                         )
+def test_offset_polyline_equals_offset_line(polyline, distance, normal, tol):
+    output_line = [pytest.approx(v) for v in offset_line(polyline, distance, normal)]
+    assert offset_polyline(polyline, distance, normal, tol) == output_line
+
+
+@pytest.mark.parametrize(("polyline", "distance", "normal", "tol", "output_polyline"),
+                         [([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+                           [(-0.05, -0.1), (-0.1, -0.15)],
+                           [0.0, 0.0, 1.0],
+                           1e-6,
+                           [[0.0, -0.05, 0.0], [1.0, -0.1, 0.0], [2.0, -0.15, 0.0]])]
+                         )
+def test_variable_offset_on_colinear_polyline(polyline, distance, normal, tol, output_polyline):
+    output_polyline = [pytest.approx(v) for v in output_polyline]
+    assert offset_polyline(polyline, distance, normal, tol) == output_polyline
+
+# ==============================================================================
+# line
+# ==============================================================================
+
+@pytest.mark.parametrize(("line", "distance", "normal"),
+                         [([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], 1, [0.0, 0.0, 1.0])]
+                         )
+def test_offset_line_zero_length(line, distance, normal):
+    output_line = [pytest.approx(v) for v in offset_line(line, distance, normal)]
+    assert line == output_line


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] New feature in a **backwards-compatible** manner.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [x] If you add new functions/classes, check that:
   1. [x] Add unit tests (especially important for algorithm implementations).

### Why this PR?

The current version of `offset_polyline` and `offset_polygon` does not take into account cases where two consecutive segments are collinear. This is because the underlying `intersect_line_line`method will return `None` (as expected) when faced with such challenge. 

However, being able to properly handle these collinear situations would come in quite in handy as they are abundant (for example, to consistently offset the tri/quad/ngon faces of a `Mesh()`), and because, in sum, _colinearity_ does not diminish the _polygonality_ of a `polygon`.

A restructure of `offset_line`, `offset_polyline` and `offset_polygon` is therefore proposed. Shared functionality among them has been encapsulated into their own individual methods. 

Moreover, I have added a few testing functions to the `tests` folder 😄 

### How to reproduce?

The following will work:

```
from compas.geometry import offset_polygon
from compas.geometry import offset_polyline
from compas_plotters import Plotter


polygon = [
	[0.0, 0.0, 0.0],
	[1.0, 0.0, 0.0],
	[1.0, 1.0, 0.0],
	[0.0, 1.0, 0.0],	
]

offset = offset_polygon(polygon, 0.25)

polygons = [{'points': polygon}, {'points': offset, 'facecolor': (240, 240, 240)}]
lines = [{'start': a, 'end': b, 'color': '#00ff00'} for a, b in zip(polygon, offset)]
points_a = [{'pos': xyz, 'radius': 0.015} for xyz in polygon]
points_b = [{'pos': xyz, 'radius': 0.025, 'facecolor': (255, 0, 0)} for xyz in offset]

plotter = Plotter(figsize=(12, 9))
plotter.draw_polygons(polygons)
plotter.draw_lines(lines)
plotter.draw_points(points_a + points_b)
plotter.show()

```

![01](https://user-images.githubusercontent.com/13332619/65180269-c6e12100-da5c-11e9-8dc0-c95771e5b16c.png)


Nevertheless, adding an intermediate vertex to the polygon will not when offsetting:

```
polygon = [
	[0.0, 0.0, 0.0],
	[1.0, 0.0, 0.0],
	[1.0, 1.0, 0.0],
	[0.0, 1.0, 0.0],
	[0.0, 0.5, 0.0]	
]
```

### Expected result

With the proposed PR, the following is successfully achieved:

![02](https://user-images.githubusercontent.com/13332619/65180421-1e7f8c80-da5d-11e9-8fae-2a5f0d927b9a.png)
