### PR TITLE
Fix mesh drawing and generation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added compas rhino installer for Rhino Mac 6.0 `compas_rhino.__init__`.
 - Added oriented bounding box for meshes `compas.datastructures.mesh_oriented_bounding_box_numpy`.
 - Added full testing functions for `compas.datastructures.mesh`
+- Added `draw_mesh` to `compas_ghpython.artists.MeshArtist`
 
 ### Changed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `axis` and `origin` defaults to `compas.robots.Joint`
 - Unified vertices and face import order for .obj files with python2 and 3
 - Fixed `compas_ghpython.artists.MeshArtist` to support ngons.
+- Deprecate the method `draw` of `compas_ghpython.artists.MeshArtist` in favor of `draw_mesh`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the name and meaning of the parameter `oriented` in the function `Mesh.edges_on_boundary`.
 - Add `axis` and `origin` defaults to `compas.robots.Joint`
 - Unified vertices and face import order for .obj files with python2 and 3
+- Fixed `compas_ghpython.artists.MeshArtist` to support ngons.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified vertices and face import order for .obj files with python2 and 3
 - Fixed `compas_ghpython.artists.MeshArtist` to support ngons.
 - Deprecate the method `draw` of `compas_ghpython.artists.MeshArtist` in favor of `draw_mesh`.
+- Fix icosahedron generation
 
 ### Removed
 

--- a/docs/examples/rhino/mesh-subd-modeling.py
+++ b/docs/examples/rhino/mesh-subd-modeling.py
@@ -60,4 +60,4 @@ artist.mesh = subd
 artist.layer = 'SubdModeling::Mesh'
 
 artist.clear_layer()
-artist.draw()
+artist.draw_mesh()

--- a/docs/gettingstarted/cad/grasshopper.rst
+++ b/docs/gettingstarted/cad/grasshopper.rst
@@ -26,7 +26,7 @@ component on your Grasshopper canvas, paste the following script and hit `OK`.
 
     artist = MeshArtist(mesh)
 
-    a = artist.draw()
+    a = artist.draw_mesh()
 
 
 .. figure:: /_images/gh_verify.jpg

--- a/src/compas/geometry/primitives/polyhedron.py
+++ b/src/compas/geometry/primitives/polyhedron.py
@@ -276,24 +276,36 @@ class Icosahedron(Polyhedron):
         super(Icosahedron, self).__init__()
         self.compute()
 
-    # (    0,   +-1, +-phi)
-    # (  +-1, +-phi,     0)
-    # (+-phi,     0,   +-1)
     def compute(self):
         """"""
         phi = (1 + sqrt(5)) / 2.
-        vertices = []
-        faces = []
-        l = 2.
-        r = l * sqrt(phi * sqrt(5)) / 2.
-        c = 1. / r
-        for i in -1., +1.:
-            i *= c
-            for j in -1., +1.:
-                j *= c
-                vertices.append([     0.,       i, j * phi])
-                vertices.append([      i, j * phi,      0.])
-                vertices.append([j * phi,      0.,       i])
+        vertices = [
+            (-1, phi, 0),
+            (1, phi, 0),
+            (-1, -phi, 0),
+            (1, -phi, 0),
+
+            (0, -1, phi),
+            (0, 1, phi),
+            (0, -1, -phi),
+            (0, 1, -phi),
+
+            (phi, 0, -1),
+            (phi, 0, 1),
+            (-phi, 0, -1),
+            (-phi, 0, 1),
+        ]
+        faces = [
+            # 5 faces around point 0
+            [0, 11, 5], [0, 5, 1], [0, 1, 7], [0, 7, 10], [0, 10, 11],
+            # Adjacent faces
+            [1, 5, 9], [5, 11, 4], [11, 10, 2], [10, 7, 6], [7, 1, 8],
+            # 5 faces around 3
+            [3, 9, 4], [3, 4, 2], [3, 2, 6], [3, 6, 8], [3, 8, 9],
+            # Adjacent faces
+            [4, 9, 5], [2, 4, 11], [6, 2, 10], [8, 6, 7], [9, 8, 1],
+        ]
+
         self.vertices = vertices
         self.faces = faces
 

--- a/src/compas/geometry/primitives/polyhedron.py
+++ b/src/compas/geometry/primitives/polyhedron.py
@@ -40,7 +40,7 @@ class Polyhedron(object):
             return Dodecahedron()
         if fcount == 20:
             return Icosahedron()
-        raise Exception
+        raise ValueError('Unsupported solid type. Supported face count values: 4, 6, 8, 12, 20')
 
     @classmethod
     def from_platonicsolid(cls, fcount):

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -61,6 +61,12 @@ class MeshArtist(FaceArtist, EdgeArtist, VertexArtist):
         self.datastructure = mesh
 
     def draw(self, color=None):
+        """Deprecated. Use ``draw_mesh()``"""
+        # NOTE: This warning should be triggered with warnings.warn(), not be a print statement, but GH completely ignores that
+        print('MeshArtist.draw() is deprecated: please use draw_mesh() instead')
+        return self.draw_mesh(color)
+
+    def draw_mesh(self, color=None):
         key_index = self.mesh.key_index()
         vertices = self.mesh.get_vertices_attributes('xyz')
         faces = [[key_index[key] for key in self.mesh.face_vertices(fkey)] for fkey in self.mesh.faces()]

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -1,13 +1,14 @@
-from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
 
 import compas_ghpython
-
-from compas_ghpython.artists.mixins import VertexArtist
 from compas_ghpython.artists.mixins import EdgeArtist
 from compas_ghpython.artists.mixins import FaceArtist
+from compas_ghpython.artists.mixins import VertexArtist
 
+from compas.geometry import centroid_polygon
+from compas.utilities import pairwise
 
 __all__ = ['MeshArtist']
 
@@ -70,6 +71,14 @@ class MeshArtist(FaceArtist, EdgeArtist, VertexArtist):
                 new_faces.append(face + [face[-1]])
             elif l == 4:
                 new_faces.append(face)
+            elif l > 4:
+                centroid = len(vertices)
+                vertices.append(centroid_polygon(
+                    [vertices[index] for index in face]))
+                for a, b in pairwise(face + face[0:1]):
+                    new_faces.append([centroid, a, b, b])
+            else:
+                continue
         return compas_ghpython.draw_mesh(vertices, new_faces, color)
 
 

--- a/src/compas_ghpython/helpers/mesh.py
+++ b/src/compas_ghpython/helpers/mesh.py
@@ -40,7 +40,7 @@ def mesh_draw(mesh, color=None):
     """
 
     artist = MeshArtist(mesh)
-    return artist.draw(color)
+    return artist.draw_mesh(color)
 
 
 def mesh_draw_vertices(mesh,


### PR DESCRIPTION
Fixed a bunch of loosely related mesh generation and drawing issues:
* Icosahedron computation was incomplete (contained no faces)
* The `MeshArtist` of `compas_ghpython` was missing support for ngons
* Added a `draw_mesh` method to the `MeshArtist` of `compas_ghpython` for consistency with the other artists and deprecated the `draw` one.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
