### PR TITLE
Fallback to python executable if pythonw is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the name and meaning of the parameter `oriented` in the function `Mesh.edges_on_boundary`.
 - Add `axis` and `origin` defaults to `compas.robots.Joint`
 - Unified vertices and face import order for .obj files with python2 and 3
+- Changed python interpreter selection (e.g. RPC calls) to fallback to `python` if `pythonw` is not present on the system
 
 ### Removed
 

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -76,30 +76,28 @@ def select_python(python_executable):
         Select which python executable you want to use,
         either `python` or `pythonw`.
     """
-    python_executable = python_executable or 'pythonw'
-
     if PYTHON_DIRECTORY and os.path.exists(PYTHON_DIRECTORY):
-        python = os.path.join(PYTHON_DIRECTORY, python_executable)
-        if os.path.exists(python):
-            return python
+        python_executables = [python_executable] if python_executable else ['pythonw', 'python']
 
-        python = os.path.join(PYTHON_DIRECTORY, '{0}.exe'.format(python_executable))
-        if os.path.exists(python):
-            return python
+        for python_exe in python_executables:
+            python = os.path.join(PYTHON_DIRECTORY, python_exe)
+            if os.path.exists(python):
+                return python
 
-        python = os.path.join(PYTHON_DIRECTORY, 'bin', python_executable)
-        if os.path.exists(python):
-            return python
+            python = os.path.join(PYTHON_DIRECTORY, '{0}.exe'.format(python_exe))
+            if os.path.exists(python):
+                return python
 
-        python = os.path.join(PYTHON_DIRECTORY, 'bin', '{0}.exe'.format(python_executable))
-        if os.path.exists(python):
-            return python
+            python = os.path.join(PYTHON_DIRECTORY, 'bin', python_exe)
+            if os.path.exists(python):
+                return python
 
-        if python:
-            return python
+            python = os.path.join(PYTHON_DIRECTORY, 'bin', '{0}.exe'.format(python_exe))
+            if os.path.exists(python):
+                return python
 
     # Assume a system-wide install exists
-    return python_executable
+    return python_executable or 'pythonw'
 
 
 def prepare_environment():


### PR DESCRIPTION
On a normal case, we use `pythonw` to start the RPC Proxy services and other tasks that also require a CPython interpreter to be executed, but on some Mac installations that executable is not present (it needs to be installed with the `python.app` package), so now we fallback to `python` standard executable if the windowless one is not there. 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
