### PR TITLE
Mesh additions

### DIFF
--- a/src/compas/datastructures/mesh/_mesh.py
+++ b/src/compas/datastructures/mesh/_mesh.py
@@ -824,6 +824,40 @@ class Mesh(FromToPickle,
                 vertices = [key_index[key] + 1 for key in vertices]
                 fh.write(' '.join(['f'] + [str(index) for index in vertices]) + '\n')
 
+    def to_obj_with_attribute(self, filepath, attribute):
+        """
+        Write the mesh to an OBJ file grouping the faces by attribute.
+
+        Parameters
+        ----------
+        filepath: str
+            Full path of the file.
+        attribute: str
+            The name of the faces' attribute to group by.
+        """
+        # if none of the faces has the attribute, export normally
+        if not any(self.get_faces_attribute(self.faces(), attribute)):
+            self.to_obj(filepath)
+            return
+
+        fkeys = list(self.faces())
+        fkeys.sort(key=lambda x: str(self.get_face_attribute(x, attribute)))
+
+        key_index = self.key_index()
+        current_group = 'na'
+        with open(filepath, 'w+') as fh:
+            for key, attr in self.vertices(True):
+                fh.write('v {0[x]:.3f} {0[y]:.3f} {0[z]:.3f}\n'.format(attr))
+            for fkey in fkeys:
+                fa = self.get_face_attribute(fkey, attribute)
+                if fa != current_group:
+                    fh.write("g " + str(fa) + "\n")
+                    current_group = fa
+
+                vertices = self.face_vertices(fkey)
+                vertices = [key_index[key] + 1 for key in vertices]
+                fh.write(' '.join(['f'] + [str(index) for index in vertices]) + '\n')
+
     def to_vertices_and_faces(self):
         """Return the vertices and faces of a mesh.
 

--- a/src/compas_ghpython/utilities/drawing.py
+++ b/src/compas_ghpython/utilities/drawing.py
@@ -220,6 +220,8 @@ def draw_mesh(vertices, faces, color=None, vertex_normals=None, texture_coordina
         for i, normal in enumerate(vertex_normals):
             normals[i] = Vector3f(normal[0], normal[1], normal[2])
         mesh.Normals.SetNormals(normals)
+    else:
+        mesh.Normals.ComputeNormals()
 
     if texture_coordinates:
         count = len(texture_coordinates)
@@ -235,6 +237,8 @@ def draw_mesh(vertices, faces, color=None, vertex_normals=None, texture_coordina
             colors[i] = rs.coercecolor(color)
         mesh.VertexColors.SetColors(colors)
 
+    # optionally https://developer.rhino3d.com/api/RhinoCommon/html/M_Rhino_Geometry_Mesh_Compact.htm:
+    # mesh.Compact()
     return mesh
 
 


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

Adds some functionality to the mesh class (`to_obj_with_attribute`, attributes as obj groups) and to ghpython mesh display (`draw_mesh`: compute normals if none are given). Optionally, this method could call `mesh.Compact()` before returning, see [here](https://developer.rhino3d.com/api/RhinoCommon/html/M_Rhino_Geometry_Mesh_Compact.htm):

> Removes any unreferenced objects from arrays, reindexes as needed and shrinks arrays to minimum required size.