### PR TITLE
compas_rhino: Object3D > Artist > PrimitiveArtist > PointArtist ...

### DIFF
--- a/src/compas/geometry/__init__.py
+++ b/src/compas/geometry/__init__.py
@@ -501,5 +501,6 @@ from .spatial import *
 from .triangulation import *
 
 from .primitives import *
+from .object3d import *
 
 __all__ = [name for name in dir() if not name.startswith('_')]

--- a/src/compas/geometry/object3d.py
+++ b/src/compas/geometry/object3d.py
@@ -1,0 +1,73 @@
+from compas.geometry import Transformation
+
+
+__all__ = ["Object3D"]
+
+
+class Object3D(object):
+
+    """
+    """
+
+    __module__ = "compas.geometry"
+
+    def __init__(self, geometry=None, attributes=None):
+
+        self.geometry = geometry
+        self.attributes = attributes
+
+        self._parent = None
+        self._children = []
+
+        self.transformation = Transformation()
+
+    @property
+    def parent(self):
+        return self._parent
+
+    @property
+    def children(self):
+        return self._children
+
+    def get_parents(self, parent_chain=None):
+        if parent_chain is None:
+            parent_chain = []
+        if self._parent is not None:
+            parent_chain.append(self._parent)
+            self._parent.get_parents(parent_chain)
+        return parent_chain
+
+    @property
+    def transformation_world(self):
+        T_world = self.transformation.copy()
+        for p in self.get_parents():
+            T_world *= p.transformation
+        return T_world
+
+    def apply_transformation(self, T):
+        self.transformation *= T
+
+    def add_child(self, child):
+
+        if child == self:
+            raise ValueError('cannot add object itself')
+        if child._parent is not None:
+            child._parent.remove(child)
+        child._parent = self
+        self._children.append(child)
+
+    def remove_child(self, child):
+        child._parent = None
+        self._children.remove(child)
+
+
+if __name__ == "__main__":
+
+    obj1 = Object3D()
+    obj2 = Object3D()
+    obj3 = Object3D()
+
+    obj1.add_child(obj2)
+    obj2.add_child(obj3)
+
+    print(obj3.get_parents())

--- a/src/compas_rhino/artists/__init__.py
+++ b/src/compas_rhino/artists/__init__.py
@@ -21,9 +21,17 @@ Artists for visualising (painting) COMPAS data structures in Rhino.
 """
 from __future__ import absolute_import
 
-from .artist import *
-from .meshartist import *
-from .networkartist import *
-from .volmeshartist import *
+from .artist import Artist
+from .meshartist import MeshArtist
+from .networkartist import NetworkArtist
+from .volmeshartist import VolMeshArtist
+from .primitiveartist import PrimitiveArtist
+from .pointartist import PointArtist
+
 
 __all__ = [name for name in dir() if not name.startswith('_')]
+
+
+from compas.geometry import Point
+
+Artist.register(Point, PointArtist)

--- a/src/compas_rhino/artists/pointartist.py
+++ b/src/compas_rhino/artists/pointartist.py
@@ -1,0 +1,77 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+from compas.geometry import Point
+from compas_rhino.artists import Artist
+from compas_rhino.geometry import RhinoPoint
+import compas_rhino
+
+
+__all__ = ["PointArtist"]
+
+
+class PointArtist(Artist):
+    """A point artist defines functionality for visualising a COMPAS point in Rhino.
+    """
+
+    __module__ = "compas_rhino.artists"
+
+    def __init__(self, point=None, attributes=None, layer=None):
+
+        if not isinstance(point, Point):
+            raise ValueError("needs a compas.geometry.Point")
+
+        super(PointArtist, self).__init__(point, attributes=attributes, layer=layer)
+
+        self.GUID = self.create_point()
+
+        self.rhino_point = RhinoPoint(self.GUID)
+
+    @property
+    def point(self):
+        """get the compas point geometry in this artist's local coordinate"""
+        return self.geometry
+
+    def create_point(self):
+        """create the mirror of the point in Rhino, returns its GUID"""
+        if self.attributes:
+            point_dict = self.attributes.copy()
+        else:
+            point_dict = {}
+        point_dict['pos'] = self.point[:3]
+
+        return compas_rhino.draw_points([point_dict], layer=self.layer, redraw=False)[0]
+
+
+# ==============================================================================
+# Main
+# ==============================================================================
+
+if __name__ == "__main__":
+
+    from compas_rhino.utilities import unload_modules
+
+    unload_modules("compas")
+    unload_modules("compas_rhino")
+
+    from compas.geometry import Rotation
+    import math
+
+    # create with Point
+    pa = PointArtist(Point(10, 0, 0))
+
+    # create with Point with attributes
+    pa2 = PointArtist(Point(-10, 0, 0), attributes={'color': (255, 0, 0)})
+    pa.add(pa2)
+
+    # adding directly point with auto-wraped artist
+    pa.add(Point(0, 10, 0), attributes={'color': (0, 255, 0)})
+
+    R = Rotation.from_axis_and_angle([0, 0, 1], math.pi / 40)
+
+    for i in range(0, 20):
+        pa.apply_transformation(R)
+        pa.draw(0.1)
+
+    print('finished!')

--- a/src/compas_rhino/artists/primitiveartist.py
+++ b/src/compas_rhino/artists/primitiveartist.py
@@ -1,0 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+from compas_rhino.artists import Artist
+
+
+__all__ = ["PrimitiveArtist"]
+
+
+class PrimitiveArtist(Artist):
+    pass


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Added Object3D class which allows parent/children hierarchy and can be shared as base of Artists classes across platforms.

Adjust compas_rhino artists inheritance order into:
 Object3D > Artist > PrimitiveArtist > PointArtist/LineArtist/CircleArtist ...     and
Object3D > Artist > DatastructureArtist > MeshArtist/NetworkArtist/VolmeshArtist

The new API would be like:
```
from compas.geometry import Point
from compas.geometry import Rotation
from compas_rhino.artists import PointArtist
from compas_rhino.artists import Artist
import math

# create a artist as container to draw everything inside it
artist = Artist()

# add point directly
artist.add(Point(10, 0, 0))

# add point with attributes
artist.add(Point(0, 10, 0), attributes={'color': (255, 0, 0)})

# add point through PointArtist
pa1 = PointArtist(Point(-10, 0, 0))
artist.add(pa1)

# add point with attributes through PointArtist
pa2 = PointArtist(Point(0, -10, 0), attributes={'color': (0, 255, 0)})
artist.add(pa2)

R = Rotation.from_axis_and_angle([0, 0, 1], math.pi / 40)

for i in range(0, 20):
    artist.apply_transformation(R)
    artist.draw(0.1)

print('finished!')
```

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [ ] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [ ] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
