### PR TITLE
make matrix math specific to 4x4 matrices

### DIFF
--- a/src/compas/geometry/basic.py
+++ b/src/compas/geometry/basic.py
@@ -1101,12 +1101,39 @@ def multiply_matrices4(A, B):
 
     Examples
     --------
-    >>> TODO
+    >>> A = Translation([5.0, 5.0, 5.0])
+    >>> B = Translation([5.0, 5.0, 5.0])
+    >>> multiply_matrices(A, B)
+    [[1.0, 0.0, 0.0, 10.0], [0.0, 1.0, 0.0, 10.0], [0.0, 0.0, 1.0, 10.0], [0.0, 0.0, 0.0, 1.0]]
     """
     A = list(A)
     B = list(B)
-    B = list(zip(* list(B)))
-    return [[dot_vectors(row, col) for col in B] for row in A]
+    return [
+            [
+                A[0][0]*B[0][0] + A[0][1]*B[1][0] + A[0][2]*B[2][0] + A[0][3]*B[3][0],
+                A[0][0]*B[0][1] + A[0][1]*B[1][1] + A[0][2]*B[2][1] + A[0][3]*B[3][1],
+                A[0][0]*B[0][2] + A[0][1]*B[1][2] + A[0][2]*B[2][2] + A[0][3]*B[3][2],
+                A[0][0]*B[0][3] + A[0][1]*B[1][3] + A[0][2]*B[2][3] + A[0][3]*B[3][3]
+            ],
+            [
+                A[1][0]*B[0][0] + A[1][1]*B[1][0] + A[1][2]*B[2][0] + A[1][3]*B[3][0],
+                A[1][0]*B[0][1] + A[1][1]*B[1][1] + A[1][2]*B[2][1] + A[1][3]*B[3][1],
+                A[1][0]*B[0][2] + A[1][1]*B[1][2] + A[1][2]*B[2][2] + A[1][3]*B[3][2],
+                A[1][0]*B[0][3] + A[1][1]*B[1][3] + A[1][2]*B[2][3] + A[1][3]*B[3][3]
+            ],
+            [
+                A[2][0]*B[0][0] + A[2][1]*B[1][0] + A[2][2]*B[2][0] + A[2][3]*B[3][0],
+                A[2][0]*B[0][1] + A[2][1]*B[1][1] + A[2][2]*B[2][1] + A[2][3]*B[3][1],
+                A[2][0]*B[0][2] + A[2][1]*B[1][2] + A[2][2]*B[2][2] + A[2][3]*B[3][2],
+                A[2][0]*B[0][3] + A[2][1]*B[1][3] + A[2][2]*B[2][3] + A[2][3]*B[3][3]
+            ],
+            [
+                A[3][0]*B[0][0] + A[3][1]*B[1][0] + A[3][2]*B[2][0] + A[3][3]*B[3][0],
+                A[3][0]*B[0][1] + A[3][1]*B[1][1] + A[3][2]*B[2][1] + A[3][3]*B[3][1],
+                A[3][0]*B[0][2] + A[3][1]*B[1][2] + A[3][2]*B[2][2] + A[3][3]*B[3][2],
+                A[3][0]*B[0][3] + A[3][1]*B[1][3] + A[3][2]*B[2][3] + A[3][3]*B[3][3]
+            ]
+        ]
 
 
 def multiply_matrix_vector(A, b):
@@ -1559,3 +1586,26 @@ if __name__ == "__main__":
 
     import doctest
     doctest.testmod()
+
+    # from compas.geometry import Translation
+    # import time
+    # import numpy as np
+
+    # t1 = Translation([5.0, 5.0, 5.0])
+    # t2 = Translation([5.0, 5.0, 5.0])
+
+    # # t1 = list(t1)
+    # # t2 = list(t2)
+    # # t1 = np.array(t1)
+    # # t2 = np.array(t2)
+
+    # start = time.time()
+    # for i in range(0, 1000000):
+    #     multiply_matrices4(t1, t2)
+    #     # x = np.dot(t1, t2)
+    # end = time.time() - start
+    # print(end)
+
+    # print(np.dot(t1, t2))
+    # print(multiply_matrices4(t1, t2))
+    # print(multiply_matrices(t1, t2))

--- a/src/compas/geometry/basic.py
+++ b/src/compas/geometry/basic.py
@@ -1072,6 +1072,43 @@ def multiply_matrices(A, B):
     return [[dot_vectors(row, col) for col in B] for row in A]
 
 
+def multiply_matrices4(A, B):
+    r"""Mutliply a 4x4 matrix with a 4x4 matrix.
+
+    Parameters
+    ----------
+    A : sequence of sequence of float
+        The first matrix.
+    B : sequence of sequence of float
+        The second matrix.
+
+    Returns
+    -------
+    C : list of list of float
+        The result matrix.
+
+
+    Notes
+    -----
+    This is a pure Python version of the following linear algebra procedure:
+
+    .. math::
+
+        \mathbf{A} \cdot \mathbf{B} = \mathbf{C}
+
+    with :math:`\mathbf{A}` a *m* by *n* matrix, :math:`\mathbf{B}` a *n* by *o*
+    matrix, and :math:`\mathbf{C}` a *m* by *o* matrix.
+
+    Examples
+    --------
+    >>> TODO
+    """
+    A = list(A)
+    B = list(B)
+    B = list(zip(* list(B)))
+    return [[dot_vectors(row, col) for col in B] for row in A]
+
+
 def multiply_matrix_vector(A, b):
     r"""Multiply a matrix with a vector.
 
@@ -1114,6 +1151,45 @@ def multiply_matrix_vector(A, b):
     n = len(b)
     if not all([len(row) == n for row in A]):
         raise Exception('Matrix shape is not compatible with vector length.')
+    return [dot_vectors(row, b) for row in A]
+
+
+def multiply_matrix4_vector(A, b):
+    r"""Multiply a 4x4 matrix with a vector.
+
+    Parameters
+    ----------
+    A : list of list
+        The matrix.
+    b : list
+        The vector.
+
+    Returns
+    -------
+    c : list
+        The resulting vector.
+
+    Raises
+    ------
+    Exception
+        If not all rows of the matrix have the same length as the vector.
+
+    Notes
+    -----
+    This is a Python version of the following linear algebra procedure:
+
+    .. math::
+
+        \mathbf{A} \cdot \mathbf{x} = \mathbf{b}
+
+    with :math:`\mathbf{A}` a *m* by *n* matrix, :math:`\mathbf{x}` a vector of
+    length *n*, and :math:`\mathbf{b}` a vector of length *m*.
+
+    Examples
+    --------
+    >>> TODO
+
+    """
     return [dot_vectors(row, b) for row in A]
 
 

--- a/src/compas/geometry/transformations/matrices.py
+++ b/src/compas/geometry/transformations/matrices.py
@@ -11,10 +11,10 @@ from compas.geometry.basic import normalize_vector
 from compas.geometry.basic import subtract_vectors
 from compas.geometry.basic import cross_vectors
 from compas.geometry.basic import dot_vectors
-from compas.geometry.basic import multiply_matrix_vector
+from compas.geometry.basic import multiply_matrix4_vector
 from compas.geometry.basic import length_vector
 from compas.geometry.basic import allclose
-from compas.geometry.basic import multiply_matrices
+from compas.geometry.basic import multiply_matrices4
 from compas.geometry.basic import transpose_matrix
 from compas.geometry.basic import norm_vector
 
@@ -138,7 +138,7 @@ def matrix_inverse(M):
     >>> from compas.geometry import Frame
     >>> f = Frame([1, 1, 1], [0.68, 0.68, 0.27], [-0.67, 0.73, -0.15])
     >>> T = matrix_from_frame(f)
-    >>> I = multiply_matrices(T, matrix_inverse(T))
+    >>> I = multiply_matrices4(T, matrix_inverse(T))
     >>> I2 = identity_matrix(4)
     >>> allclose(I[0], I2[0])
     True
@@ -211,7 +211,7 @@ def decompose_matrix(M):
     >>> T = matrix_from_translation(trans1)
     >>> R = matrix_from_euler_angles(angle1)
     >>> S = matrix_from_scale_factors(scale1)
-    >>> M = multiply_matrices(multiply_matrices(T, R), S)
+    >>> M = multiply_matrices4(multiply_matrices4(T, R), S)
     >>> # M = compose_matrix(scale1, None, angle1, trans1, None)
     >>> scale2, shear2, angle2, trans2, persp2 = decompose_matrix(M)
     >>> allclose(scale1, scale2)
@@ -309,7 +309,7 @@ def decompose_matrix(M):
         P = deepcopy(Mt)
         P[0][3], P[1][3], P[2][3], P[3][3] = 0.0, 0.0, 0.0, 1.0
         Ptinv = matrix_inverse(transpose_matrix(P))
-        perspective = multiply_matrix_vector(Ptinv, [Mt[0][3], Mt[1][3],
+        perspective = multiply_matrix4_vector(Ptinv, [Mt[0][3], Mt[1][3],
                                                      Mt[2][3], Mt[3][3]])
     else:
         perspective = [0.0, 0.0, 0.0, 1.0]
@@ -353,19 +353,19 @@ def compose_matrix(scale=None, shear=None, angles=None,
     M = [[1. if i == j else 0. for i in range(4)] for j in range(4)]
     if perspective is not None:
         P = matrix_from_perspective_entries(perspective)
-        M = multiply_matrices(M, P)
+        M = multiply_matrices4(M, P)
     if translation is not None:
         T = matrix_from_translation(translation)
-        M = multiply_matrices(M, T)
+        M = multiply_matrices4(M, T)
     if angles is not None:
         R = matrix_from_euler_angles(angles, static=True, axes="xyz")
-        M = multiply_matrices(M, R)
+        M = multiply_matrices4(M, R)
     if shear is not None:
         Sh = matrix_from_shear_entries(shear)
-        M = multiply_matrices(M, Sh)
+        M = multiply_matrices4(M, Sh)
     if scale is not None:
         Sc = matrix_from_scale_factors(scale)
-        M = multiply_matrices(M, Sc)
+        M = multiply_matrices4(M, Sc)
     for i in range(4):
         for j in range(4):
             M[i][j] /= M[3][3]
@@ -421,7 +421,7 @@ def matrix_from_frame_to_frame(frame_from, frame_to):
     """
     T1 = matrix_from_frame(frame_from)
     T2 = matrix_from_frame(frame_to)
-    return multiply_matrices(T2, matrix_inverse(T1))
+    return multiply_matrices4(T2, matrix_inverse(T1))
 
 
 def matrix_change_basis(frame_from, frame_to):
@@ -445,7 +445,7 @@ def matrix_change_basis(frame_from, frame_to):
     """
     T1 = matrix_from_frame(frame_from)
     T2 = matrix_from_frame(frame_to)
-    return multiply_matrices(matrix_inverse(T2), T1)
+    return multiply_matrices4(matrix_inverse(T2), T1)
 
 
 def matrix_from_euler_angles(euler_angles, static=True, axes='xyz'):
@@ -665,7 +665,7 @@ def matrix_from_axis_and_angle(axis, angle, point=None, rtype='list'):
             M[i][j] = R[i][j]
 
     # rotation about axis, angle AND point includes also translation
-    t = subtract_vectors(point, multiply_matrix_vector(R, point))
+    t = subtract_vectors(point, multiply_matrix4_vector(R, point))
     M[0][3] = t[0]
     M[1][3] = t[1]
     M[2][3] = t[2]

--- a/src/compas/geometry/transformations/transformation.py
+++ b/src/compas/geometry/transformations/transformation.py
@@ -12,7 +12,7 @@ Ippoliti for providing code and documentation.
 """
 import math
 
-from compas.geometry.basic import multiply_matrices
+from compas.geometry.basic import multiply_matrices4
 from compas.geometry.basic import transpose_matrix
 
 from compas.geometry.transformations import matrix_inverse
@@ -216,7 +216,7 @@ class Transformation(object):
         T1 = cls.from_frame(frame_from)
         T2 = cls.from_frame(frame_to)
 
-        return cls(multiply_matrices(T2.matrix, matrix_inverse(T1.matrix)))
+        return cls(multiply_matrices4(T2.matrix, matrix_inverse(T1.matrix)))
 
     @classmethod
     def change_basis(cls, frame_from, frame_to):
@@ -246,7 +246,7 @@ class Transformation(object):
         T1 = cls.from_frame(frame_from)
         T2 = cls.from_frame(frame_to)
 
-        return cls(multiply_matrices(matrix_inverse(T2.matrix), T1.matrix))
+        return cls(multiply_matrices4(matrix_inverse(T2.matrix), T1.matrix))
 
     @property
     def rotation(self):
@@ -399,7 +399,7 @@ class Transformation(object):
         -----
         Rz * Ry * Rx means that Rx is first transformation, Ry second, and Rz third.
         """
-        self.matrix = multiply_matrices(self.matrix, other.matrix)
+        self.matrix = multiply_matrices4(self.matrix, other.matrix)
 
     def concatenated(self, other):
         """Concatenate two transformations into one ``Transformation``.
@@ -423,8 +423,8 @@ class Transformation(object):
         # return T
         cls = type(self)
         if isinstance(other, cls):
-            return cls(multiply_matrices(self.matrix, other.matrix))
-        return Transformation(multiply_matrices(self.matrix, other.matrix))
+            return cls(multiply_matrices4(self.matrix, other.matrix))
+        return Transformation(multiply_matrices4(self.matrix, other.matrix))
 
 
 # ==============================================================================


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Added 4x4 matrix specific functions (skipping dimension checks) to make transformation faster

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [ ] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [x] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
