### PR TITLE
Fix rotation property of Transformation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a missing import in `compas.geometry.Polygon`
 - Removed unused imports in `compas.geometry.Polyline`
 - Adjusted `compas.geometry.Quarternion.conjugate()` to in-place change, added `compas.geometry.Quarternion.cojugated()` instead which returns a new quarternion object
+- Fixed `rotation` property of `Transformation`
 
 ### Removed
 

--- a/src/compas/geometry/transformations/transformation.py
+++ b/src/compas/geometry/transformations/transformation.py
@@ -53,7 +53,7 @@ class Transformation(object):
     >>> T = Transformation()
     >>> f1 = Frame([1, 1, 1], [0.68, 0.68, 0.27], [-0.67, 0.73, -0.15])
     >>> T = Transformation.from_frame(f1)
-    >>> Sc, Sh, R, Tl, P = T.decompose()
+    >>> Sc, Sh, R, Tl, P = T.decomposed()
     >>> Tinv = T.inverse()
 
     """
@@ -252,7 +252,7 @@ class Transformation(object):
     def rotation(self):
         """Returns the ``Rotation`` component from the ``Transformation``.
         """
-        Sc, Sh, R, T, P = self.decompose()
+        Sc, Sh, R, T, P = self.decomposed()
         return R
 
     @property

--- a/tests/compas/geometry/test_transformations/test_transformation.py
+++ b/tests/compas/geometry/test_transformations/test_transformation.py
@@ -41,7 +41,7 @@ def test_inverse():
     assert Transformation() == T * T.inverse()
 
 
-def test_decompose():
+def test_decomposed():
     trans1 = [1, 2, 3]
     angle1 = [-2.142, 1.141, -0.142]
     scale1 = [0.123, 2, 0.5]
@@ -60,6 +60,12 @@ def test_rotation():
     R = Rotation.from_euler_angles(angle1)
     r = [[0.41249169135312663, -0.8335562904208867, -0.3674704277413451, 0.0], [-0.05897071585157175, -0.4269749553355485, 0.9023385407861949, 0.0], [-0.9090506362335324, -0.35053715668381935, -0.22527903264048646, 0.0], [0.0, 0.0, 0.0, 1.0]]
     assert np.allclose(R, r)
+
+def test_rotation_property():
+    T = Transformation()
+    r = T.rotation
+    assert type(r) == Rotation
+    assert r.matrix == [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
 
 
 def test_translation():


### PR DESCRIPTION
Fixed call to renamed method, and added unit test for it.

**I think this fix should be cherry picked and released into 0.10.1**

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
