### PR TITLE
Add current git commit hash to __version__ if installed from git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `compas.geometry.icp_numpy` for pointcloud alignment using ICP.
+- Show git hash on `compas.__version__` if installed from git.
 
 ### Changed
 

--- a/src/compas/__init__.py
+++ b/src/compas/__init__.py
@@ -50,6 +50,26 @@ APPTEMP = compas._os.absjoin(APPDATA, 'temp')
 
 PRECISION = '3f'
 
+# Check if COMPAS is installed from git
+# If that's the case, try to append the current head's hash to __version__
+try:
+    git_head_file = compas._os.absjoin(HOME, '.git', 'HEAD')
+
+    if os.path.exists(git_head_file):
+        # git head file contains one line that looks like this:
+        # ref: refs/heads/master
+        with open(git_head_file, 'r') as git_head:
+            _, ref_path = git_head.read().strip().split(' ')
+            ref_path = ref_path.split('/')
+
+            git_head_refs_file = compas._os.absjoin(HOME, '.git', *ref_path)
+
+        if os.path.exists(git_head_refs_file):
+            with open(git_head_refs_file, 'r') as git_head_ref:
+                git_commit = git_head_ref.read().strip()
+                __version__ += '-' + git_commit[:8]
+except:
+    pass
 
 __all__ = [
     'raise_if_windows',


### PR DESCRIPTION
Tiny change to add the current git hash to `__version__` if we're installed from git.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
