### PR TITLE
RPC Command-line interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `compas.geometry.icp_numpy` for pointcloud alignment using ICP.
+- Added RPC command-line utility: `$ compas_rpc {start|stop} [port]`
 
 ### Changed
 
-- Fixing printing issue with `compas.geometry.Quarternion` in ironPython
+- Fixed printing issue with `compas.geometry.Quarternion` in ironPython
 - Fixed a missing import in `compas.geometry.Polygon`
 - Removed unused imports in `compas.geometry.Polyline`
 - Adjusted `compas.geometry.Quarternion.conjugate()` to in-place change, added `compas.geometry.Quarternion.cojugated()` instead which returns a new quarternion object
 - Fixed `rotation` property of `Transformation`
+- Bind RPC server to `0.0.0.0` instead of `localhost`
 
 ### Removed
 

--- a/docs/tutorials/rpc.rst
+++ b/docs/tutorials/rpc.rst
@@ -17,10 +17,35 @@ is that once the server is started, no additional processes have to launched and
 the server can handle the requests without any overhead. Therefore, the response
 time is much faster than with ``XFunc``.
 
+
+Starting RPC server
+===================
+
+The ``ServerProxy`` will try to start an RPC server automatically
+if no server is already running, but very often it is recommended
+to start it manually from the command-line.
+
+To start a new RPC server use the following command on the terminal
+(default port is ``1753``):
+
+::
+
+    $ compas_rpc start <port>
+
+Conversely, to stop an existing RPC server:
+
+::
+
+    $ compas_rpc stop <port>
+
+
+.. note::
+
+    If COMPAS is installed in a virtual environment, make sure it is activated
+    before trying to use this command-line utility.
+
 .. note::
 
     Currently, the RPC server is launched on the ``localhost``.
     However, it would also be possible to launch it on a remote computer on a
     network, or on a server reachable over the internet.
-
-

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,11 @@ setup(
     install_requires=requirements,
     python_requires='>=2.7',
     extras_require=optional_requirements,
-    entry_points={},
+    entry_points={
+        'console_scripts': [
+            'compas_rpc=compas.rpc.__main__:main'
+        ]
+    },
     ext_modules=[],
     cmdclass={},
     scripts=[]

--- a/src/compas/rpc/__init__.py
+++ b/src/compas/rpc/__init__.py
@@ -35,6 +35,29 @@ of the proxied package are available as if they were directly present in our env
 
     Proxy
 
+RPC Command-line utility
+========================
+
+Besides the API of the RPC module, there is a command-line utility
+provided to start and stop the RPC server easily from the terminal.
+
+To start a new RPC server use the following command (default port is ``1753``):
+
+::
+
+    $ compas_rpc start <port>
+
+Conversely, to stop an existing RPC server:
+
+::
+
+    $ compas_rpc stop <port>
+
+
+.. note::
+
+    If COMPAS is installed in a virtual environment, make sure it is activated
+    before trying to use this command-line utility.
 """
 
 from __future__ import absolute_import

--- a/src/compas/rpc/__main__.py
+++ b/src/compas/rpc/__main__.py
@@ -1,0 +1,70 @@
+import time
+
+from compas.rpc import Proxy
+from compas.rpc.services.default import start_service
+
+try:
+    from xmlrpclib import ServerProxy
+except ImportError:
+    from xmlrpc.client import ServerProxy
+
+
+def start(port, **kwargs):
+    start_service(port)
+
+
+def stop(port, **kwargs):
+    print('Trying to stop remote RPC proxy...')
+    server = ServerProxy('http://127.0.0.1:{}'.format(port))
+
+    success = False
+    count = 5
+    while count:
+        try:
+            server.ping()
+        except Exception:
+            time.sleep(0.1)
+            count -= 1
+            print("    {} attempts left.".format(count))
+        else:
+            success = True
+            break
+
+    if not success:
+        print('RPC server did not respond. Maybe already stopped.')
+    else:
+        server.remote_shutdown()
+        print('RPC server stopped')
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='COMPAS RCP command-line utility')
+
+    commands = parser.add_subparsers(help='Valid RPC commands')
+
+    # Command: start
+    start_command = commands.add_parser('start', help='Start RPC server')
+    start_command.add_argument(
+        '--port', '-p', action='store', default=1753, type=int, help='RPC port number')
+    start_command.set_defaults(func=start)
+
+    # Command: stop
+    stop_command = commands.add_parser(
+        'stop', help='Try to stop a remote RPC server')
+    stop_command.add_argument(
+        '--port', '-p', action='store', default=1753, type=int, help='RPC port number')
+    stop_command.set_defaults(func=stop)
+
+    # Invoke
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(**vars(args))
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/compas/rpc/proxy.py
+++ b/src/compas/rpc/proxy.py
@@ -137,15 +137,22 @@ class Proxy(object):
         self.service = service
         self.package = package
 
+        self._implicitely_started_server = False
         self._server = self.try_reconnect()
         if self._server is None:
             self._server = self.start_server()
+            self._implicitely_started_server = True
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
-        self.stop_server()
+        # If we started the RPC server, we will try to clean up and stop it
+        # otherwise we just disconnect from it
+        if self._implicitely_started_server:
+            self.stop_server()
+        else:
+            self._server.__close()
 
     @property
     def address(self):

--- a/src/compas/rpc/services/default.py
+++ b/src/compas/rpc/services/default.py
@@ -1,10 +1,12 @@
 """This script starts a XMLRPC server and registers the default service.
 
-The server address is *localhost* and it listens to requests on port *1753*
+The server binds to all network interfaces (i.e. ``0.0.0.0``) and
+it listens to requests on port ``1753``.
 
 """
 
 from compas.rpc import Dispatcher
+from compas.rpc import Server
 
 
 class DefaultService(Dispatcher):
@@ -13,25 +15,7 @@ class DefaultService(Dispatcher):
         super(DefaultService, self).__init__()
 
 
-# ==============================================================================
-# main
-# ==============================================================================
-
-if __name__ == '__main__':
-
-    import sys
-    from compas.rpc import Server
-
-    try:
-        port = int(sys.argv[3])
-    except:
-        port = 1753
-
-    # with open('/Users/vanmelet/Code/compas-dev/compas/src/compas/rpc/services/rpc.txt', 'w') as f:
-    #     f.write(str(sys.version_info) + "\n")
-    #     for name in sys.path:
-    #         f.write(name + "\n")
-
+def start_service(port):
     print('Starting default RPC service on port {0}...'.format(port))
 
     # start the server on *localhost*
@@ -52,3 +36,17 @@ if __name__ == '__main__':
 
     print('Listening, press CTRL+C to abort...')
     server.serve_forever()
+
+# ==============================================================================
+# main
+# ==============================================================================
+
+if __name__ == '__main__':
+    import sys
+
+    try:
+        port = int(sys.argv[3])
+    except:
+        port = 1753
+
+    start_service(port)

--- a/src/compas/rpc/services/default.py
+++ b/src/compas/rpc/services/default.py
@@ -20,7 +20,7 @@ def start_service(port):
 
     # start the server on *localhost*
     # and listen to requests on port *1753*
-    server = Server(("localhost", port))
+    server = Server(("0.0.0.0", port))
 
     # register a few utility functions
     server.register_function(server.ping)


### PR DESCRIPTION
The idea of implicitly starting the RPC server from the proxy side is very problematic, so I propose we officialize a more straightforward approach, where the RPC server is explicitly started from the command line via a little cli utility.

The functionality of automatically trying to start it is still there, but I have now documented the new cli-based option, and I would suggest we focus on using that one more often in courses, workshops, etc. It will also make errors and output much more explicit (now it's very often the case that a failure is completely obscure and it ends up in something like `Fault` exception on the proxy side).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
