### PR TITLE
fixes LayerVisible different argument naming between Rhino5 and Rhino6

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@
 - Elitsa Dimitrova <<e.dimitrova77@gmail.com>> [@elidim](https://github.com/elidim)
 - Li Chen <<li.chen@arch.ethz.ch>> [@licini](https://github.com/licini)
 - Anton Johansson <<anton@tetov.se>> [@tetov](https://github.com/tetov)
+- Victor Leung <<yck011522@gmail.com>> [@yck011522](https://github.com/yck011522)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixing printing issue with `compas.geometry.Quarternion` in ironPython.
 - Fixed a missing import in `compas.geometry.Polygon`.
 - Removed unused imports in `compas.geometry.Polyline`.
-- Adjusted `compas.geometry.Quarternion.conjugate()` to in-place change, added `compas.geometry.Quarternion.conjugated()` instead which returns a new quarternion object
+- Adjusted `compas.geometry.Quarternion.conjugate()` to in-place change, added `compas.geometry.Quarternion.conjugated()` instead which returns a new quarternion object.
 - Fixed `rotation` property of `Transformation`.
 - Simplified plugin installation (use plugin name only, without GUID).
-- Bind RPC server to `0.0.0.0` instead of `localhost`
+- Bind RPC server to `0.0.0.0` instead of `localhost`.
+- Fixed different argument naming between Rhino5 and Rhino6 of `rs.LayerVisible()` in `compas_rhino.utilities.objects`.
 
 ### Removed
 

--- a/src/compas_rhino/utilities/objects.py
+++ b/src/compas_rhino/utilities/objects.py
@@ -217,10 +217,12 @@ def select_points(message='Select points.'):
 def get_points(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
+        # Argument names for LayerVisible command are not the same for Rhino5 and Rhino6
+        # that is why we use positional instead of named arguments
+        visible = rs.LayerVisible(layer, True, True)
         guids = rs.ObjectsByType(rs.filter.point)
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
+        rs.LayerVisible(layer, visible, True)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.point)
@@ -319,10 +321,12 @@ def select_polygons(message='Select polygons (closed curves with degree = 1)'):
 def get_curves(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
+        # Argument names for LayerVisible command are not the same for Rhino5 and Rhino6
+        # that is why we use positional instead of named arguments
+        visible = rs.LayerVisible(layer, True, True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
+        rs.LayerVisible(layer, visible, True)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)
@@ -332,11 +336,13 @@ def get_curves(layer=None):
 def get_lines(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
+        # Argument names for LayerVisible command are not the same for Rhino5 and Rhino6
+        # that is why we use positional instead of named arguments
+        visible = rs.LayerVisible(layer, True, True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = [guid for guid in guids if is_curve_line(guid)]
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
+        rs.LayerVisible(layer, visible, True)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)
@@ -347,11 +353,13 @@ def get_lines(layer=None):
 def get_polylines(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
+        # Argument names for LayerVisible command are not the same for Rhino5 and Rhino6
+        # that is why we use positional instead of named arguments
+        visible = rs.LayerVisible(layer, True, True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = [guid for guid in guids if is_curve_polyline(guid)]
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
+        rs.LayerVisible(layer, visible, True)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)
@@ -362,11 +370,13 @@ def get_polylines(layer=None):
 def get_polygons(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
+        # Argument names for LayerVisible command are not the same for Rhino5 and Rhino6
+        # that is why we use positional instead of named arguments
+        visible = rs.LayerVisible(layer, True, True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = [guid for guid in guids if is_curve_polygon(guid)]
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
+        rs.LayerVisible(layer, visible, True)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)
@@ -473,10 +483,12 @@ def select_meshes(message='Select meshes.'):
 def get_meshes(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, force_visible=True)
+        # Argument names for LayerVisible command are not the same for Rhino5 and Rhino6
+        # that is why we use positional instead of named arguments
+        visible = rs.LayerVisible(layer, True, True)
         guids = rs.ObjectsByType(rs.filter.mesh)
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, force_visible=visible)
+        rs.LayerVisible(layer, visible, True)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.mesh)

--- a/src/compas_rhino/utilities/objects.py
+++ b/src/compas_rhino/utilities/objects.py
@@ -217,10 +217,10 @@ def select_points(message='Select points.'):
 def get_points(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, force_visible=True)
+        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
         guids = rs.ObjectsByType(rs.filter.point)
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, force_visible=visible)
+        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.point)
@@ -319,10 +319,10 @@ def select_polygons(message='Select polygons (closed curves with degree = 1)'):
 def get_curves(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, force_visible=True)
+        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, force_visible=visible)
+        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)
@@ -332,11 +332,11 @@ def get_curves(layer=None):
 def get_lines(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, force_visible=True)
+        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = [guid for guid in guids if is_curve_line(guid)]
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, force_visible=visible)
+        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)
@@ -347,11 +347,11 @@ def get_lines(layer=None):
 def get_polylines(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, force_visible=True)
+        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = [guid for guid in guids if is_curve_polyline(guid)]
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, force_visible=visible)
+        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)
@@ -362,11 +362,11 @@ def get_polylines(layer=None):
 def get_polygons(layer=None):
     if layer:
         rs.EnableRedraw(False)
-        visible = rs.LayerVisible(layer, visible=True, force_visible=True)
+        visible = rs.LayerVisible(layer, visible=True, forcevisible_or_donotpersist=True)
         guids = rs.ObjectsByType(rs.filter.curve)
         guids = [guid for guid in guids if is_curve_polygon(guid)]
         guids = list(set(guids) & set(rs.ObjectsByLayer(layer)))
-        rs.LayerVisible(layer, visible=visible, force_visible=visible)
+        rs.LayerVisible(layer, visible=visible, forcevisible_or_donotpersist=visible)
         rs.EnableRedraw(True)
     else:
         guids = rs.ObjectsByType(rs.filter.curve)


### PR DESCRIPTION
Argument names have changed between Rhino5 and Rhino6 for `LayerVisible` command. This fix switches from named arguments to positional ones. Also changes the behaviour of setting back the visibility state of the parent layer, to always return to visible. 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
2. [x] Run all tests on your computer (i.e. `invoke test`).
3. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
