### PR TITLE
fix blender re-installing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed blender re-installing bug.
+
 ### Removed
 
 

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -163,7 +163,9 @@ def _native_symlinks(symlinks, raise_on_error):
 
     for source, link_name in symlinks:
         try:
-            os.symlink(source, link_name)
+            tmpLink = link_name+'_temp'
+            os.symlink(source, tmpLink)
+            os.rename(tmpLink, link_name)
             result.append(True)
         except OSError:
             if raise_on_error:


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

When re-installing compas blender,  os.symlink will throw a `File Exists Error`. To fix this, a templink is created and renamed to overwrite the original one.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
