### PR TITLE
add factory methods to rhino artist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added factory methods for `compas_rhino.artists._Artist`
+
 ### Changed
 
 - set `compas_rhino.artists.FrameArtist` Layer clear to false by default

--- a/src/compas_rhino/artists/__init__.py
+++ b/src/compas_rhino/artists/__init__.py
@@ -57,5 +57,12 @@ from .meshartist import *
 from .networkartist import *
 from .volmeshartist import *
 
+from compas.geometry import Frame
+from compas.geometry import Line
+from compas.geometry import Point
+
+_Artist.register(Point, PointArtist)
+_Artist.register(Frame, FrameArtist)
+_Artist.register(Line, LineArtist)
 
 __all__ = [name for name in dir() if not name.startswith('_')]

--- a/src/compas_rhino/artists/_artist.py
+++ b/src/compas_rhino/artists/_artist.py
@@ -7,6 +7,9 @@ import compas_rhino
 __all__ = ["_Artist"]
 
 
+_ITEM_ARTIST = {}
+
+
 class _Artist(object):
     """Base class for all ``Artist`` objects.
 
@@ -29,6 +32,21 @@ class _Artist(object):
     def __init__(self, settings):
         self.settings = {'layer': None}
         self.settings.update(settings)
+
+    @staticmethod
+    def register(item_type, artist_type):
+        _ITEM_ARTIST[item_type] = artist_type
+
+    @staticmethod
+    def build(item, **kwargs):
+        artist_type = _ITEM_ARTIST[type(item)]
+        artist = artist_type(item, **kwargs)
+        return artist
+
+    @staticmethod
+    def build_as(item, artist_type, **kwargs):
+        artist = artist_type(item, **kwargs)
+        return artist
 
     @staticmethod
     def draw_collection(collection):


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Added factory methods for `compas_rhino.artists._Artist` to enable creating corresponding artists through detecting datastructure/primitive types. This will be later used for `compas.cad.Object3d` to attach correct artists implicitly

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
