### PR TITLE
Deploy docs only for tagged commits (releases)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ deploy:
   target-branch: master
   local_dir: dist/docs
   on:
-    branch: master
+    tags: true
     condition: $TRAVIS_PYTHON_VERSION = 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Docs are only deployed to github pages for tagged commits.
 - Fixing printing issue with `compas.geometry.Quarternion` in ironPython.
 - Fixed a missing import in `compas.geometry.Polygon`.
 - Removed unused imports in `compas.geometry.Polyline`.


### PR DESCRIPTION
### What type of change is this?

- [x] New feature in a **backwards-compatible** manner.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).

### Description
 
I've tried to implement sphinxcontrib-versioning to have docs generated for all releases of Compas, as described in #341. I've gotten it to work now after some patching of the sphinx extension (it's in maintenance limbo at the moment, again see #341 ).

However, Sphinx itself fails for a few of the tagged releases and fixing all those errors release by release doesn't seem feasible.

I suggest instead that we change the Travis job to only deploy after building tagged commits as described in [Travis docs](https://docs.travis-ci.com/user/deployment/releases/#deploying-only-on-tagged-builds).

This means that the docs will reflect the latest version of Compas which is most likely the one the user has installed. Travis will still run `invoke docs` and fail if there are errors in the Sphinx build. Contributors can run `invoke docs` to preview changes to the docs.

I've ran a few tests:
* [Tagged commit](https://travis-ci.org/tetov/compas/jobs/612837967#L3820) (tagged using `git tag -a 123)
* [Normal commit](https://travis-ci.org/tetov/compas/jobs/612840492#L3976)

This will only work if the commit is tagged before it's pushed, not if commits are tagged retroactively.

(Tags are never included in pull requests, at least according to [person on Stack Overflow](https://stackoverflow.com/a/45553305)