### PR TITLE
Removing autodoc for removed module

### DIFF
--- a/docs/api/compas.remote.rst
+++ b/docs/api/compas.remote.rst
@@ -1,2 +1,0 @@
-
-.. automodule:: compas.remote


### PR DESCRIPTION

### What type of change is this?

- [x] Doc fix.

Since compas.remote has been removed in favor of compas.rpc autodoc can't import compas.remote.