### PR TITLE
compas.files.base_reader raise if bad address is given

### DIFF
--- a/src/compas/files/base_reader.py
+++ b/src/compas/files/base_reader.py
@@ -64,8 +64,10 @@ class BaseReader(object):
             else:
                 pathobj = self._address
 
-        if pathobj.exists():
-            return pathobj
+        # Makes path absolute and raises FileNotFound if file is not found
+        pathobj.resolve(strict=True)
+
+        return pathobj
 
     @property
     def is_binary(self):

--- a/src/compas/files/base_reader.py
+++ b/src/compas/files/base_reader.py
@@ -55,6 +55,11 @@ class BaseReader(object):
         ------
         Path object
             Path object for file location
+
+        Raises
+        ------
+        FileNotFound (Python >=3.3) or OSError (Python <3.3)
+            If a file can't be found at given address
         """
         if self.is_address_url():
             pathobj = self._download(self._address)
@@ -64,7 +69,6 @@ class BaseReader(object):
             else:
                 pathobj = self._address
 
-        # Makes path absolute and raises FileNotFound if file is not found
         pathobj.resolve(strict=True)
 
         return pathobj

--- a/tests/compas/files/test_base_reader.py
+++ b/tests/compas/files/test_base_reader.py
@@ -95,8 +95,12 @@ def open_nonexistant_file():
 
 
 def test_open_nonexistant_file():
-    with pytest.raises(FileNotFoundError):
-        open_nonexistant_file()
+    try:
+        with pytest.raises(FileNotFoundError):
+            open_nonexistant_file()
+    except NameError:
+        with pytest.raises(OSError):
+            open_nonexistant_file()
 
 
 def test_location_from_string_adress(ascii_ply):

--- a/tests/compas/files/test_base_reader.py
+++ b/tests/compas/files/test_base_reader.py
@@ -89,6 +89,16 @@ def test_iterate_over_binary_file(binary_stl):
     assert two_chunks[1][:5] == b'\x9a%\x00\x00\x8b'
 
 
+def open_nonexistant_file():
+    not_a_file = BaseReader('not_a_file')
+    print(not_a_file.location)
+
+
+def test_open_nonexistant_file():
+    with pytest.raises(FileNotFoundError):
+        open_nonexistant_file()
+
+
 def test_location_from_string_adress(ascii_ply):
     file = BaseReader(ascii_ply)
     assert isinstance(file.location, Path)


### PR DESCRIPTION
While working on OBJReader I noticed a mistake in BaseReader. If address to file is a string or Path object containing a non resolvable path methods fail silently, when they should in fact raise FileNotFoundError (or OSError in Python 2).

Property location in BaseReader now checks the path with Path method resolve(strict=True) instead of exists.

I've also added a test case for this.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.

### Checklist

1 .~~[ ] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.~~ (base_reader is still under unreleased - added in changelog)
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [x] If you add new functions/classes, check that:
      1. [x] Add unit tests (especially important for algorithm implementations).
