### PR TITLE
Bugfix: Error drawing mesh/network vertex in ghpyton

### DIFF
--- a/src/compas_ghpython/utilities/drawing.py
+++ b/src/compas_ghpython/utilities/drawing.py
@@ -71,7 +71,7 @@ def draw_points(points):
     """
     rg_points = []
     for p in iter(points):
-        pos = p.data
+        pos = p['pos']
         rg_points.append(Point3d(*pos))
     return rg_points
 


### PR DESCRIPTION
Ran into a bug trying to draw a network in ghpython, this fixes it for vertices from Network and Mesh.

### Error
```
Runtime error (MissingMemberException): 'dict' object has no attribute 'data'

Traceback:
  line 77, in draw_points, "C:\Users\a\AppData\Roaming\McNeel\Rhinoceros\6.0\Plug-ins\IronPython (814d908a-e25c-493d-97e9-ee3861957f49)\settings\lib\compas_ghpython\utilities\drawing.py"
  line 51, in draw_vertices, "C:\Users\a\AppData\Roaming\McNeel\Rhinoceros\6.0\Plug-ins\IronPython (814d908a-e25c-493d-97e9-ee3861957f49)\settings\lib\compas_ghpython\artists\mixins\vertexartist.py"
  line 14, in script
```

### Test code
```
import compas
from compas_ghpython.artists import MeshArtist, NetworkArtist
from compas.datastructures import Mesh, Network

if False:
    
    mesh = Mesh.from_ply(compas.get_bunny())

    artist = MeshArtist(mesh)

    mesh_edges = artist.draw_edges()
    mesh_vertices = artist.draw_vertices()

if True:
    network = Network.from_obj(compas.get('faces.obj'))

    artist = NetworkArtist(network)

    network_edges = artist.draw_edges()
    network_vertices = artist.draw_vertices()
```