### PR TITLE
Adding support for mimicking joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added circle artist to plotters.
 - Added mesh artist to plotters.
 - Added ellipse artist to plotters.
-- Added support for robot mimic joints.
+- Added support for robot mimicking joints.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added circle artist to plotters.
 - Added mesh artist to plotters.
 - Added ellipse artist to plotters.
+- Added support for robot mimic joints.
 
 ### Changed
 

--- a/src/compas/robots/model/joint.py
+++ b/src/compas/robots/model/joint.py
@@ -103,10 +103,13 @@ class Limit(object):
 class Mimic(object):
     """Description of joint mimic."""
 
-    def __init__(self, joint, multiplier=1.0, offset=0):
-        self.joint = joint
-        self.multiplier = multiplier
-        self.offset = offset
+    def __init__(self, joint, multiplier=1.0, offset=0.):
+        self.joint = joint  # == joint name
+        self.multiplier = float(multiplier)
+        self.offset = float(offset)
+
+    def calculate_position(self, mimicked_joint_position):
+        return self.multiplier * mimicked_joint_position + self.offset
 
 
 class SafetyController(object):

--- a/tests/compas/robots/test_joint.py
+++ b/tests/compas/robots/test_joint.py
@@ -23,7 +23,7 @@ def test_prismatic_calculate_transformation():
     assert t == Translation([550, 0, 0])
 
 
-def test_mimic_calculate_transformation():
+def test_mimic_calculate_position():
     multiplier = 5.0
     offset = 100.
     j1 = Joint('j1', 'prismatic', None, None, axis=Axis('1 0 0'))

--- a/tests/compas/robots/test_joint.py
+++ b/tests/compas/robots/test_joint.py
@@ -6,6 +6,7 @@ from compas.geometry import Translation
 from compas.robots import Axis
 from compas.robots import Joint
 from compas.robots import Limit
+from compas.robots import Mimic
 
 
 def test_revolute_calculate_transformation():
@@ -20,3 +21,13 @@ def test_prismatic_calculate_transformation():
     j1 = Joint('j1', 'prismatic', None, None, axis=Axis('1 0 0'), limit=limit)
     t = j1.calculate_transformation(550)
     assert t == Translation([550, 0, 0])
+
+
+def test_mimic_calculate_transformation():
+    multiplier = 5.0
+    offset = 100.
+    j1 = Joint('j1', 'prismatic', None, None, axis=Axis('1 0 0'))
+    j1.position = 200
+    mimic = Mimic(j1, multiplier=multiplier, offset=offset)
+    result = mimic.calculate_position(j1.position)
+    assert result == multiplier * j1.position + offset


### PR DESCRIPTION
This feature allows to calculate transformations from mimicking joints, i.e. joints that mimic the behavior of other joints.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [X] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
