### PR TITLE
make property form re-sizable

### DIFF
--- a/src/compas_rhino/etoforms/propertylist.py
+++ b/src/compas_rhino/etoforms/propertylist.py
@@ -39,7 +39,6 @@ class PropertyListForm(Dialog):
         self.table = table = forms.GridView()
         table.ShowHeader = True
         table.DataStore = [[name, value] for name, value in zip(self.names, self.values)]
-        table.Height = 300
 
         c1 = forms.GridColumn()
         c1.HeaderText = 'Name'
@@ -53,18 +52,17 @@ class PropertyListForm(Dialog):
         c2.DataCell = forms.TextBoxCell(1)
         table.Columns.Add(c2)
 
-        layout = forms.DynamicLayout()
-        layout.AddRow(table)
-        layout.Add(None)
-        layout.BeginVertical()
-        layout.BeginHorizontal()
-        layout.AddRow(None, self.ok, self.cancel)
-        layout.EndHorizontal()
-        layout.EndVertical()
+        tab_items = forms.StackLayoutItem(table, True)
+        layout = forms.StackLayout()
+        layout.Items.Add(tab_items)
+        layout.HorizontalContentAlignment = forms.HorizontalAlignment.Stretch
+        sub_layout = forms.DynamicLayout()
+        sub_layout.AddRow(None, self.ok, self.cancel)
+        layout.Items.Add(forms.StackLayoutItem(sub_layout))
 
         self.Title = 'RBE: update a list of properties'
         self.Padding = drawing.Padding(12)
-        self.Resizable = False
+        self.Resizable = True
         self.Content = layout
         self.ClientSize = drawing.Size(400, 600)
 


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?
Making rhino eto property form resizable. And have table content fit to window size

Before:
![image](https://user-images.githubusercontent.com/17893605/76853610-eca18400-684d-11ea-9fa5-eb03245c5932.png)



After:
![image](https://user-images.githubusercontent.com/17893605/76853509-b49a4100-684d-11ea-93a1-96ac99292457.png)


- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [ ] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [ ] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
