### PR TITLE
Update RhinoMesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added classmethod ``from_geometry`` to ``RhinoMesh``
+
 ### Changed
 
 ### Removed

--- a/src/compas_rhino/geometry/mesh.py
+++ b/src/compas_rhino/geometry/mesh.py
@@ -45,13 +45,19 @@ class RhinoMesh(RhinoGeometry):
         guid = compas_rhino.select_mesh()
         return cls.from_guid(guid)
 
+    @classmethod
+    def from_geometry(cls, geometry):
+        mesh = cls()
+        mesh.geometry = geometry
+        return mesh
+
     @property
     def vertices(self):
-        return [map(float, vertex) for vertex in compas_rhino.rs.MeshVertices(self.guid)]
+        return [map(float, vertex) for vertex in compas_rhino.rs.MeshVertices(self.geometry)]
 
     @property
     def faces(self):
-        return map(list, compas_rhino.rs.MeshFaceVertices(self.guid))
+        return map(list, compas_rhino.rs.MeshFaceVertices(self.geometry))
 
     def to_compas(self, cls=None):
         if not cls:


### PR DESCRIPTION
Update RhinoMesh such that it can be created from Grasshopper as well
`RhinoMesh.from_geometry(mesh)` and `compas_mesh = RhinoMesh.from_geometry(mesh).to_compas()`

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [X] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.


