### PR TITLE
List class attributes, document joint types.

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -19,3 +19,14 @@
     {%- endfor %}
     {% endif %}
     {% endblock %}
+
+    {% block attributes %}
+    {% if attributes %}
+    .. rubric:: Attributes
+
+    .. autosummary::
+    {% for item in attributes %}
+        ~{{ name }}.{{ item }}
+    {%- endfor %}
+    {% endif %}
+    {% endblock %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -19,14 +19,3 @@
     {%- endfor %}
     {% endif %}
     {% endblock %}
-
-    {% block attributes %}
-    {% if attributes %}
-    .. rubric:: Attributes
-
-    .. autosummary::
-    {% for item in attributes %}
-        ~{{ name }}.{{ item }}
-    {%- endfor %}
-    {% endif %}
-    {% endblock %}

--- a/src/compas/robots/model/joint.py
+++ b/src/compas/robots/model/joint.py
@@ -192,8 +192,7 @@ class Axis(object):
 
 
 class Joint(object):
-    """Representation of the kinematics and dynamics of a joint and its safety
-    limits.
+    """Representation of the kinematics and dynamics of a joint and its safety limits.
 
     Attributes
     ----------
@@ -226,28 +225,38 @@ class Joint(object):
         Used to specify that the defined joint mimics another existing joint.
     attr : :obj:`dict`
         Non-standard attributes.
-    child_link : :class:`compas.robot.Link`
+    child_link : :class:`Link`
         Joint's child link
     position : :obj:`float`
         The current position of the joint. This depends on the
         joint type, i.e. for revolute joints, it will be the rotation angle
         in radians, for prismatic joints the translation in meters.
+
+    Class Attributes
+    ----------------
+    REVOLUTE : :obj:`int`
+        Revolute joint type.
+    CONTINUOUS : :obj:`int`
+        Continous joint type.
+    PRISMATIC : :obj:`int`
+        Prismatic joint type.
+    FIXED : :obj:`int`
+        Fixed joint type.
+    FLOATING : :obj:`int`
+        Floating joint type.
+    PLANAR : :obj:`int`
+        Planar joint type.
+    SUPPORTED_TYPES : :obj:`list` of :obj:`str`
+        String representations of the supported joint types.
     """
 
-    #: Revolute joint type
     REVOLUTE = 0
-    #: Continous joint type
     CONTINUOUS = 1
-    #: Prismatic joint type
     PRISMATIC = 2
-    #: Fixed joint type
     FIXED = 3
-    #: Floating joint type
     FLOATING = 4
-    #: Planar joint type
     PLANAR = 5
 
-    #: List of supported joint types
     SUPPORTED_TYPES = ('revolute', 'continuous', 'prismatic', 'fixed',
                        'floating', 'planar')
 

--- a/src/compas/robots/model/joint.py
+++ b/src/compas/robots/model/joint.py
@@ -212,7 +212,7 @@ class Joint(object):
         rotation for revolute joints, the axis of translation for prismatic
         joints, and the surface normal for planar joints. The axis is
         specified in the joint frame of reference.
-    calibration : :class`Calibration`
+    calibration : :class:`Calibration`
         Reference positions of the joint, used to calibrate the absolute position of the joint.
     dynamics : :class:`Dynamics`
         Physical properties of the joint. These values are used to
@@ -226,7 +226,7 @@ class Joint(object):
         Used to specify that the defined joint mimics another existing joint.
     attr : :obj:`dict`
         Non-standard attributes.
-    child_link
+    child_link : :class:`compas.robot.Link`
         Joint's child link
     position : :obj:`float`
         The current position of the joint. This depends on the
@@ -234,13 +234,20 @@ class Joint(object):
         in radians, for prismatic joints the translation in meters.
     """
 
+    #: Revolute joint type
     REVOLUTE = 0
+    #: Continous joint type
     CONTINUOUS = 1
+    #: Prismatic joint type
     PRISMATIC = 2
+    #: Fixed joint type
     FIXED = 3
+    #: Floating joint type
     FLOATING = 4
+    #: Planar joint type
     PLANAR = 5
 
+    #: List of supported joint types
     SUPPORTED_TYPES = ('revolute', 'continuous', 'prismatic', 'fixed',
                        'floating', 'planar')
 


### PR DESCRIPTION
### What type of change is this?

Display class attributes from [`autoattribute`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoattribute) in Sphinx class documentation.

This came up in discussion related to `compas.robots.Joint.type` here: https://github.com/compas-dev/compas_fab/pull/119#discussion_r389408529

I still can't link to these though (with `:data:`/`:any:`/`:attr:`).

I'm hosting the docs built from this branch. Have a look at the API reference of `compas.robots.Joint` [here](https://p.tetov.se/pr_class_attr/api/generated/compas.robots.Joint.html#compas.robots.Joint).

### Checklist

1. [x] Run all tests on your computer (i.e. `invoke test`).