### PR TITLE
Fix missing import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ``Mesh.to_obj``.
 
 ### Changed
+
 - Updated Blender installation docs for latest release.
+- Fixed ``robot.forward_kinematics()`` when requested for base link.
 
 ### Removed
 

--- a/src/compas/robots/model/robot.py
+++ b/src/compas/robots/model/robot.py
@@ -6,23 +6,22 @@ import itertools
 
 from compas.files import URDF
 from compas.files import URDFParser
+from compas.geometry import Frame
 from compas.geometry import Transformation
-from compas.topology import shortest_path
-
 from compas.robots.model.geometry import Color
-from compas.robots.model.geometry import Material
-from compas.robots.model.geometry import Texture
 from compas.robots.model.geometry import Geometry
+from compas.robots.model.geometry import Material
 from compas.robots.model.geometry import MeshDescriptor
 from compas.robots.model.geometry import Origin
+from compas.robots.model.geometry import Texture
 from compas.robots.model.joint import Axis
 from compas.robots.model.joint import Joint
 from compas.robots.model.joint import Limit
+from compas.robots.model.link import Collision
 from compas.robots.model.link import Link
 from compas.robots.model.link import Visual
-from compas.robots.model.link import Collision
 from compas.robots.resources import DefaultMeshLoader
-
+from compas.topology import shortest_path
 
 __all__ = ['RobotModel']
 


### PR DESCRIPTION
Fixed missing `Frame` import (used on `forward_kinematic` (only if requested for base link).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas.datastructures.Mesh`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
