### PR TITLE
Addig __slot__ = [] to _primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Blender installation docs for latest release.
 - Fixed ``robot.forward_kinematics()`` when requested for base link.
 - Fixed bug in ``to_compas`` conversion of Rhino meshes.
+- Fixed bug where ``compas.geometry.Primitive`` derived classes cannot be serialized by jsonpickle.
 
 ### Removed
 

--- a/src/compas/geometry/_primitives/_primitive.py
+++ b/src/compas/geometry/_primitives/_primitive.py
@@ -9,6 +9,8 @@ class Primitive(object):
     """Base class for geometric primitives."""
 
     __module__ = "compas.geometry"
+    
+    __slots__ = []
 
     def __init__(self):
         pass

--- a/src/compas/geometry/_primitives/_primitive.py
+++ b/src/compas/geometry/_primitives/_primitive.py
@@ -9,7 +9,7 @@ class Primitive(object):
     """Base class for geometric primitives."""
 
     __module__ = "compas.geometry"
-    
+
     __slots__ = []
 
     def __init__(self):


### PR DESCRIPTION
Fixed #525.
The __slot__ = [] declaration in geometry.Primitive suppress the creation of __dict__ in all the child class such as Points, Frame etc... 

This is motivated by the need for these classes to be serializes correctly by jsonpickle.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)