### PR TITLE
Max connections attempts attribute added to compas.rpc.Proxy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed return value of drawing functions of `compas_rhino.artists.NetworkArtist` to list of GUID.
 * Moved "inspectors" to `compas_rhino.objects`.
 * Moved "modifiers" to `compas_rhino.objects`.
+* Connection attempts can now be set for `compas.Proxy.start_server` using the
+  attribute `Proxy.max_conn_attempts`.
 
 ### Removed
 


### PR DESCRIPTION
Grasshopper locks up while Proxy object tries to contact RPC server with no way to stop it except by terminating Rhino. Setting retries to a lower value than 100 makes sure Grasshopper isn't locked up for minutes in case RPC server can't be reached.

### What type of change is this?

- New feature in a **backwards-compatible** manner.

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- ~~I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added necessary documentation (if appropriate)
