### PR TITLE
add clean up workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,37 @@
+name: cleanup
+
+# triggered whenever a PR submitted to master is merged or closed
+on:
+  pull_request:
+    types: [closed]   
+    branches:
+      - master
+
+jobs:
+  build:
+    name: cleanup
+    runs-on: ubuntu-latest
+    steps:
+      # checkout at gh-pages branch
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      # delete the corresponding pull request doc folder
+      - name: Delete folder
+        env:
+          PULL_FOLDER: pull_${{ github.event.pull_request.number }}
+        run: |
+          echo the folder $PULL_FOLDER will be deleted
+          rm -r $PULL_FOLDER
+
+      # force push the deletion to gp-pages
+      - name: Deploy docs
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: ./
+          keep_history: false  
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Adding documentation clean up workflow triggered when a PR is merged or closed:

1. The workflow will checkout the gh-pages. 
2. Delete the folder corresponding to the PR that is merged/closed.
3. Then push the change back to gh-pages.

I've tested this on another repo. Should work as expected.