### PR TITLE
Doc workflow fix

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -11,23 +11,31 @@ jobs:
   build:
     name: cleanup
     runs-on: ubuntu-latest
+    env:
+      PULL_FOLDER: pull_${{ github.event.pull_request.number }}
     steps:
       # checkout at gh-pages branch
       - uses: actions/checkout@v2
         with:
           ref: gh-pages
 
+      # check if folder for this pull request exists
+      - name: Check folder existence
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: ${{ env.PULL_FOLDER }}
+
       # delete the corresponding pull request doc folder
       - name: Delete folder
-        env:
-          PULL_FOLDER: pull_${{ github.event.pull_request.number }}
+        if: steps.check_files.outputs.files_exists == 'true'
         run: |
           echo the folder $PULL_FOLDER will be deleted
           if [ -d "$PULL_FOLDER" ]; then rm -Rf $PULL_FOLDER; fi
 
       # force push the deletion to gp-pages
       - name: Deploy docs
-        if: success()
+        if: success() && steps.check_files.outputs.files_exists == 'true'
         uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: build and deploy docs
     runs-on: ubuntu-latest
+    env:
+      GH_PAT: ${{secrets.GH_PAT}}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
@@ -44,7 +46,7 @@ jobs:
           echo "Docs will be deployed to https://compas.dev/compas/$BRANCH_OR_TAG"
           mkdir -p deploy/$BRANCH_OR_TAG && mv -T dist/docs deploy/$BRANCH_OR_TAG/
       - name: Deploy docs
-        if: success()
+        if: success() && env.GH_PAT != ''
         uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages


### PR DESCRIPTION
Fixing workflow doc deploy
1. Skip deploy when there not GH_PAT (eg. a PR from a forked repo)
2. Skip deleting and pushing on PR close if there hasn't been a doc folder for this PR