### PR TITLE
use dynamic versioning drop down on doc site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ project = "COMPAS"
 copyright = "Block Research Group - ETH Zurich"
 author = "Tom Van Mele"
 
-release = "release = '0.17.2'"
+release = "0.17.2"
 version = ".".join(release.split(".")[0:2])
 
 master_doc = "index"
@@ -262,7 +262,9 @@ html_theme = "compas"
 html_theme_path = sphinx_compas_theme.get_html_theme_path()
 html_theme_options = {
     "navbar_active": "compas",
-    "package_old_versions": package_docs_versions
+    "package_version": release,
+    "package_docs": "https://compas.dev/compas/",
+    "package_old_versions_txt": "https://compas.dev/compas/doc_versions.txt"
 }
 html_context = {}
 html_static_path = []


### PR DESCRIPTION
Implementing the dynamic versioning drop down to compas main doc site. Please merge and publish the corresponding change in sphinx theme first before merging this PR: https://github.com/compas-dev/sphinx_compas_theme/pull/12 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
