### PR TITLE
Allow list of meshes in RobotModel.add_link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed bug in `compas.geometry.is_coplanar`.
 * Fixed bug in `compas.datastructures.mesh_merg_faces`.
+* Fixed bug in `compas.robots.RobotModel.add_link`.
 
 ### Removed
 


### PR DESCRIPTION
Closes #665. Turns out the problem wasn't in the serialization, but in `RobotModel.add_link` being able to handle only one mesh at a time.  Now `add_link` can handle a single mesh with the arguments `visual_mesh` and `collision_mesh`, but the preferred arguments are the lists `visual_meshes` and `collision_meshes`.  

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
