### PR TITLE
deal with str keys after json serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Fixed bug in `compas.datastructures.Halfface.data(setter)`  in reading json serialized data
 
 ### Removed
 

--- a/src/compas/datastructures/volmesh/core/halfface.py
+++ b/src/compas/datastructures/volmesh/core/halfface.py
@@ -268,10 +268,7 @@ class HalfFace(Datastructure):
             for u in cell[c]:
                 for v in cell[c][u]:
                     f = cell[c][u][v]
-                    if f in halfface:
-                        faces.append(halfface[f])
-                    else:
-                        faces.append(halfface[str(f)])
+                    faces.append(self._halfface[f])
             self.add_cell(faces, ckey=int(c), attr_dict=attr)
 
         for e in edge_data:

--- a/src/compas/datastructures/volmesh/core/halfface.py
+++ b/src/compas/datastructures/volmesh/core/halfface.py
@@ -268,7 +268,10 @@ class HalfFace(Datastructure):
             for u in cell[c]:
                 for v in cell[c][u]:
                     f = cell[c][u][v]
-                    faces.append(halfface[f])
+                    if f in halfface:
+                        faces.append(halfface[f])
+                    else:
+                        faces.append(halfface[str(f)])
             self.add_cell(faces, ckey=int(c), attr_dict=attr)
 
         for e in edge_data:

--- a/src/compas/datastructures/volmesh/core/halfface.py
+++ b/src/compas/datastructures/volmesh/core/halfface.py
@@ -264,12 +264,15 @@ class HalfFace(Datastructure):
 
         for c in cell:
             attr = cell_data.get(c) or {}
-            faces = []
+            fkeys = set()
             for u in cell[c]:
                 for v in cell[c][u]:
                     f = cell[c][u][v]
-                    faces.append(self._halfface[f])
-            self.add_cell(faces, ckey=int(c), attr_dict=attr)
+                    fkeys.add(f)
+            fkeys = list(fkeys)
+            faces = [self._halfface[fkey] for fkey in fkeys]
+
+            self.add_cell(faces, ckey=int(c), attr_dict=attr, fkeys=fkeys)
 
         for e in edge_data:
             self._edge_data[literal_eval(e)] = edge_data[e] or {}
@@ -476,7 +479,7 @@ class HalfFace(Datastructure):
                 self._plane[w][v][u] = None
         return fkey
 
-    def add_cell(self, faces, ckey=None, attr_dict=None, **kwattr):
+    def add_cell(self, faces, ckey=None, attr_dict=None, fkeys=None, **kwattr):
         """Add a cell to the volmesh object.
 
         Parameters
@@ -525,9 +528,13 @@ class HalfFace(Datastructure):
         self._cell[ckey] = {}
         for name, value in attr.items():
             self.cell_attribute(ckey, name, value)
-        for vertices in faces:
-            fkey = self.add_halfface(vertices)
-            vertices = self.halfface_vertices(fkey)
+
+        for fkey_index, vertices in enumerate(faces):
+            if fkeys:
+                fkey = fkeys[fkey_index]
+            else:
+                fkey = self.add_halfface(vertices)
+                vertices = self.halfface_vertices(fkey)
             for i in range(-2, len(vertices) - 2):
                 u = vertices[i]
                 v = vertices[i + 1]

--- a/tests/compas/datastructures/test_halfface.py
+++ b/tests/compas/datastructures/test_halfface.py
@@ -1,0 +1,17 @@
+import compas
+from compas.datastructures import VolMesh
+from compas.utilities import DataEncoder
+import json
+
+
+
+def test_data_setter():
+
+    v1 = VolMesh.from_obj(compas.get("boxes.obj"))
+    data1 = v1.to_data()
+    json_str = json.dumps(data1, cls=DataEncoder)
+
+    v2 = VolMesh.from_data(json.loads(json_str))
+    data2 = v2.to_data()
+
+    assert data1 == data2


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
After json-serialization, All keys of dicts will be converted from `int` to `str` ,  this is to deal with this situation in data setter of `Halfface` class

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
