### PR TITLE
remove all draw_collection methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed IronPython checks to `compas.IPY` instead of `compas.is_ironpython`.
 
 ### Removed
+* Removed all implementations of `draw_collection`.
 
 
 ## [0.18.1] 2020-12-01

--- a/src/compas_blender/artists/_artist.py
+++ b/src/compas_blender/artists/_artist.py
@@ -5,7 +5,7 @@ import abc
 import compas
 import compas_blender
 
-from typing import Any, Type, List
+from typing import Any, Type
 
 
 __all__ = ['BaseArtist']
@@ -63,11 +63,6 @@ class BaseArtist(abc.ABC):
     def draw(self):
         """Draw the item."""
         pass
-
-    @staticmethod
-    def draw_collection(collection: List[compas.base.Base]):
-        """Draw a collection of items."""
-        raise NotImplementedError
 
     def redraw(self):
         """Trigger a redraw."""

--- a/src/compas_blender/artists/meshartist.py
+++ b/src/compas_blender/artists/meshartist.py
@@ -135,9 +135,6 @@ class MeshArtist(BaseArtist):
     # components
     # ==========================================================================
 
-    # @staticmethod
-    # def draw_collection(meshes, colors=(1.0, 1.0, 1.0), name=None, clear)
-
     def draw(self):
         """Draw the mesh using the chosen visualisation settings.
 

--- a/src/compas_ghpython/artists/_artist.py
+++ b/src/compas_ghpython/artists/_artist.py
@@ -16,10 +16,6 @@ class BaseArtist(object):
     def draw(self):
         raise NotImplementedError
 
-    @staticmethod
-    def draw_collection(collection):
-        raise NotImplementedError
-
 
 # ==============================================================================
 # Main

--- a/src/compas_ghpython/artists/circleartist.py
+++ b/src/compas_ghpython/artists/circleartist.py
@@ -35,23 +35,6 @@ class CircleArtist(PrimitiveArtist):
         return compas_ghpython.draw_circles(circles)[0]
 
     @staticmethod
-    def draw_collection(collection):
-        """Draw the collection of circles.
-
-        Parameters
-        ----------
-        collection : list of compas.geometry.Circle
-            A collection of ``Circle`` objects.
-
-        Returns
-        -------
-        list of :class:`Rhino.Geometry.Circle`
-
-        """
-        circles = [CircleArtist._get_args(primitive) for primitive in collection]
-        return compas_ghpython.draw_circles(circles)
-
-    @staticmethod
     def _get_args(primitive):
         point = list(primitive.plane.point)
         normal = list(primitive.plane.normal)

--- a/src/compas_ghpython/artists/frameartist.py
+++ b/src/compas_ghpython/artists/frameartist.py
@@ -2,8 +2,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-import itertools
-
 import compas_ghpython
 from compas_ghpython.artists._primitiveartist import PrimitiveArtist
 
@@ -60,31 +58,6 @@ class FrameArtist(PrimitiveArtist):
         point, lines = self._get_args(self.primitive, self.scale, self.color_origin, self.color_xaxis, self.color_yaxis, self.color_zaxis)
         geometry = [None, None]
         geometry[0] = compas_ghpython.draw_points([point])
-        geometry[1] = compas_ghpython.draw_lines(lines)
-        return geometry
-
-    @staticmethod
-    def draw_collection(collection):
-        """Draw the collections of frames.
-
-        Parameters
-        ----------
-        collection : list of compas.geometry.Frame
-            A collection of ``Frame`` objects.
-
-        Returns
-        -------
-        geometry : list
-
-            * geometry[0] : list of :class:`Rhino.Geometry.Point`
-            * geometry[1] : list of :class:`Rhino.Geometry.Line`
-
-        """
-        args = [FrameArtist._get_args(primitive) for primitive in collection]
-        points, lines = zip(*args)
-        lines = itertools.chain(*lines)
-        geometry = [None, None]
-        geometry[0] = compas_ghpython.draw_points(points)
         geometry[1] = compas_ghpython.draw_lines(lines)
         return geometry
 

--- a/src/compas_ghpython/artists/lineartist.py
+++ b/src/compas_ghpython/artists/lineartist.py
@@ -35,23 +35,6 @@ class LineArtist(PrimitiveArtist):
         return compas_ghpython.draw_lines(lines)[0]
 
     @staticmethod
-    def draw_collection(collection):
-        """Draw the collection of lines.
-
-        Parameters
-        ----------
-        collection : list of compas.geometry.Line
-            A collection of ``Line`` objects.
-
-        Returns
-        -------
-        list of :class:`Rhino.Geometry.Line`
-
-        """
-        lines = [LineArtist._get_args(primitive) for primitive in collection]
-        return compas_ghpython.draw_lines(lines)
-
-    @staticmethod
     def _get_args(primitive):
         start = list(primitive.start)
         end = list(primitive.end)

--- a/src/compas_ghpython/artists/pointartist.py
+++ b/src/compas_ghpython/artists/pointartist.py
@@ -35,23 +35,6 @@ class PointArtist(PrimitiveArtist):
         return compas_ghpython.draw_points(points)[0]
 
     @staticmethod
-    def draw_collection(collection):
-        """Draw a collection of points.
-
-        Parameters
-        ----------
-        collection : list of compas.geometry.Point
-            A collection of ``Point`` objects.
-
-        Returns
-        -------
-        list of :class:`Rhino.Geometry.Point3d`
-
-        """
-        points = [PointArtist._get_args(primitive) for primitive in collection]
-        return compas_ghpython.draw_points(points)
-
-    @staticmethod
     def _get_args(primitive):
         return {'pos': list(primitive)}
 

--- a/src/compas_ghpython/artists/polylineartist.py
+++ b/src/compas_ghpython/artists/polylineartist.py
@@ -34,23 +34,6 @@ class PolylineArtist(PrimitiveArtist):
         return compas_ghpython.draw_polylines(polylines)
 
     @staticmethod
-    def draw_collection(collection):
-        """Draw a collection of polylines.
-
-        Parameters
-        ----------
-        collection : list of compas.geometry.Polyline
-            A collection of ``Polyline`` objects.
-
-        Returns
-        -------
-        list of :class:`Rhino.Geometry.Polyline`
-
-        """
-        polylines = [PolylineArtist._get_args(primitive) for primitive in collection]
-        return compas_ghpython.draw_polylines(polylines)
-
-    @staticmethod
     def _get_args(primitive):
         return {'points': map(list, primitive.points)}
 

--- a/src/compas_ghpython/artists/robotmodelartist.py
+++ b/src/compas_ghpython/artists/robotmodelartist.py
@@ -45,7 +45,3 @@ class RobotModelArtist(BaseRobotModelArtist, BaseArtist):
 
     def draw(self):
         self.draw_visual()
-
-    @staticmethod
-    def draw_collection(collection):
-        raise NotImplementedError

--- a/src/compas_rhino/artists/robotmodelartist.py
+++ b/src/compas_rhino/artists/robotmodelartist.py
@@ -197,7 +197,3 @@ class RobotModelArtist(BaseRobotModelArtist, BaseArtist):
                 attr.Name = name
 
             obj.CommitChanges()
-
-    @staticmethod
-    def draw_collection(collection):
-        raise NotImplementedError


### PR DESCRIPTION
Closes #660.  

I simply deleted a lot of code.  But it could be argued that it would be cleaner to leave the methods in the base artists raising not implemented errors (and thus could be considered a non breaking change), but not implemented errors in my mind have an implicit "yet" attached to them.  Thoughts?

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
