### PR TITLE
Added docstring to translation_vector property

### DIFF
--- a/src/compas/geometry/transformations/translation.py
+++ b/src/compas/geometry/transformations/translation.py
@@ -88,6 +88,7 @@ class Translation(Transformation):
 
     @property
     def translation_vector(self):
+        """:class:`compas.geometry.Vector` : The translation vector."""
         from compas.geometry import Vector
         x = self.matrix[0][3]
         y = self.matrix[1][3]


### PR DESCRIPTION
I was going to add a way to get a vector from a Translation, but then I found that it existed but was undocumented. I added a short docstring.

### What type of change is this?

Doc update.

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- ~~I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- ~~I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added necessary documentation (if appropriate)~~
