### PR TITLE
Updates to compas_rhino.delete_layer, closes #707

### DIFF
--- a/src/compas_rhino/utilities/layers.py
+++ b/src/compas_rhino/utilities/layers.py
@@ -277,9 +277,15 @@ def delete_layers(layers):
 
     Parameters
     ----------
-    layers : dict
-        A dictionary of layers with the keys representing layer names,
-        and the values also dictionaries defining optional nested layers.
+    layers : :obj:`dict` or :obj:`list` of :obj:`str`
+        Can be given as either a list of strings or as a dictionary.
+
+        When given as a list the list elements should be name of layers given
+        with ``"::"`` as a separator between hierarchies.
+
+        It can also be defined as a dictionary of layers with the keys
+        representing layer names, and the values also dictionaries defining
+        optional nested layers.
 
     Examples
     --------
@@ -312,9 +318,15 @@ def delete_layers(layers):
 
     rs.EnableRedraw(False)
     recurse(layers)
+
     for layer in to_delete:
         if rs.IsLayer(layer):
-            rs.DeleteLayer(layer)
+            if rs.IsLayerCurrent(layer):
+                print("Can't delete {} as it is the current layer".format(layer))
+                continue
+
+            rs.PurgeLayer(layer)
+
     rs.EnableRedraw(True)
 
 


### PR DESCRIPTION
* Changed operation to `rs.PurgeLayer` as suggested in #707 
* Updated docstring to reflect that both dict and lists can be used as parameters for the function
* Added a message when layer given is also the current layer, since current layer can't be deleted.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] Doc update

### Checklist

- ~~I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- ~~I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added necessary documentation (if appropriate)~~
