### PR TITLE
compas-dev.github.io updated to compas.dev

### DIFF
--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -13,7 +13,7 @@ Citing
     @misc{compas-dev,
         title  = {{COMPAS}: A framework for computational research in architecture and structures.},
         author = {Tom Van Mele and many others},
-        note   = {http://compas-dev.github.io/},
+        note   = {http://compas.dev},
         year   = {2017-2019},
         doi    = {10.5281/zenodo.2594510},
         url    = {https://doi.org/10.5281/zenodo.2594510},

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,7 +252,7 @@ plot_html_show_formats = False
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),
-    "compas": ("https://compas-dev.github.io/compas", None),
+    "compas": ("https://compas.dev/compas/latest/", None),
 }
 
 

--- a/docs/tutorial/geometry.rst
+++ b/docs/tutorial/geometry.rst
@@ -8,7 +8,7 @@ Geometry
 
 This tutorial provides a quick tour of the functionality in :mod:`compas.geometry`.
 For a complete overview, visit the API Reference:
-https://compas-dev.github.io/main/api/compas.geometry.html
+https://compas.dev/compas/latest/api/compas.geometry.html
 
 
 Points and Vectors

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     description='The COMPAS framework',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='http://compas-dev.github.io',
+    url='http://compas.dev',
     author='Tom Van Mele',
     author_email='van.mele@arch.ethz.ch',
     license='MIT',
@@ -52,7 +52,7 @@ setup(
     ],
     keywords=['architecture', 'engineering', 'fabrication', 'construction'],
     project_urls={
-        "Documentation": "http://compas-dev.github.io",
+        "Documentation": "http://compas.dev",
         "Forum": "https://forum.compas-framework.org/",
         "Repository": "https://github.com/compas-dev/compas",
         "Issues": "https://github.com/compas-dev/compas/issues",


### PR DESCRIPTION
Some references to the old URL updated.