### PR TITLE
Allow numpy > 1.19.3 on non-windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ matplotlib >= 3.1; python_version >= '3.8' and sys_platform == 'win32'
 matplotlib >= 2.2; python_version >= '3.5' and sys_platform != 'win32'
 networkx
 numba
-numpy >= 1.15.4, <= 1.19.3
+numpy >= 1.15.4, <= 1.19.3; sys_platform == 'win32'
+numpy >=1.15.4; sys_platform != 'win32'
 pillow
 planarity
 pycollada


### PR DESCRIPTION
To keep in line with https://github.com/conda-forge/compas-feedstock/blob/4ea4a1884db962fc0faace68cdb3c98e5c06a026/recipe/meta.yaml#L37

(I'm having `pip check` fail on conda-forge builds on my package since there's a numpy version mismatch)

### What type of change is this?

Other (e.g. doc update, configuration, etc)

### Checklist

- ~~I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- ~~I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added necessary documentation (if appropriate)~~
