### PR TITLE
separate origin from current_origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fix Rhino7 Mac installation path
-* Separate `compas.robots.Joint.origin` into the parent-relative origin `origin` and the world-relative origin `current_origin`.
+* Separate `compas.robots.Joint.origin` into the static parent-relative `origin` and the dynamic world-relative `current_origin`.
+* Separate `compas.robots.Joint.axis` into the static parent-relative `axis` and the dynamic world-relative `current_axis`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Separate `compas.robots.Joint.origin` into the parent-relative origin `origin` and the world-relative origin `current_origin`.
+
 ### Removed
 
 

--- a/src/compas/robots/model/joint.py
+++ b/src/compas/robots/model/joint.py
@@ -181,7 +181,6 @@ class Dynamics(Base):
             'friction': self.friction,
         }
         attributes.update(self.attr)
-        attributes = dict(filter(lambda x: x[1], attributes.items()))
         return URDFElement('dynamics', attributes)
 
     @property
@@ -609,6 +608,7 @@ class Joint(Base):
         self.attr = kwargs
         self.child_link = None
         self.position = 0
+        self.current_origin = Origin(self.origin.point, self.origin.xaxis, self.origin.yaxis)
 
     def get_urdf_element(self):
         attributes = {
@@ -681,10 +681,7 @@ class Joint(Base):
     @property
     def current_transformation(self):
         """Current transformation of the joint."""
-        if self.origin:
-            return Transformation.from_frame(self.origin)
-        else:
-            return Transformation()
+        return Transformation.from_frame(self.current_origin)
 
     def transform(self, transformation):
         """Transform the joint in place.
@@ -698,10 +695,8 @@ class Joint(Base):
         -------
         None
         """
-        if self.origin:
-            self.origin.transform(transformation)
-        if self.axis:
-            self.axis.transform(transformation)
+        self.current_origin.transform(transformation)
+        self.axis.transform(transformation)
 
     def _create(self, transformation):
         """Internal method to initialize the transformation tree.
@@ -715,10 +710,8 @@ class Joint(Base):
         -------
         None
         """
-        if self.origin:
-            self.origin.transform(transformation)
-        if self.axis:
-            self.axis.transform(self.current_transformation)
+        self.current_origin.transform(transformation)
+        self.axis.transform(self.current_transformation)
 
     def calculate_revolute_transformation(self, position):
         """Returns a transformation of a revolute joint.
@@ -758,7 +751,7 @@ class Joint(Base):
         :class:`Rotation`
             Transformation of type rotation for the continuous joint.
         """
-        return Rotation.from_axis_and_angle(self.axis.vector, position, self.origin.point)
+        return Rotation.from_axis_and_angle(self.axis.vector, position, self.current_origin.point)
 
     def calculate_prismatic_transformation(self, position):
         """Returns a transformation of a prismatic joint.
@@ -857,7 +850,7 @@ class Joint(Base):
         -------
         None
         """
-        self.origin.scale(factor)
+        self.current_origin.scale(factor)
         if self.is_scalable():
             self.limit.scale(factor)
 

--- a/src/compas/robots/model/joint.py
+++ b/src/compas/robots/model/joint.py
@@ -608,7 +608,10 @@ class Joint(Base):
         self.attr = kwargs
         self.child_link = None
         self.position = 0
-        self.current_origin = Origin(self.origin.point, self.origin.xaxis, self.origin.yaxis)
+        # The following are world-relative frames representing the origin and the axis, which change with
+        # the joint state, while `origin` and `axis` above are parent-relative and static.
+        self.current_origin = self.origin.copy()
+        self.current_axis = self.axis.copy()
 
     def get_urdf_element(self):
         attributes = {
@@ -696,7 +699,7 @@ class Joint(Base):
         None
         """
         self.current_origin.transform(transformation)
-        self.axis.transform(transformation)
+        self.current_axis.transform(transformation)
 
     def _create(self, transformation):
         """Internal method to initialize the transformation tree.
@@ -711,7 +714,7 @@ class Joint(Base):
         None
         """
         self.current_origin.transform(transformation)
-        self.axis.transform(self.current_transformation)
+        self.current_axis.transform(self.current_transformation)
 
     def calculate_revolute_transformation(self, position):
         """Returns a transformation of a revolute joint.
@@ -751,7 +754,7 @@ class Joint(Base):
         :class:`Rotation`
             Transformation of type rotation for the continuous joint.
         """
-        return Rotation.from_axis_and_angle(self.axis.vector, position, self.current_origin.point)
+        return Rotation.from_axis_and_angle(self.current_axis.vector, position, self.current_origin.point)
 
     def calculate_prismatic_transformation(self, position):
         """Returns a transformation of a prismatic joint.
@@ -774,7 +777,7 @@ class Joint(Base):
             raise ValueError('Prismatic joints are required to define a limit')
 
         position = max(min(position, self.limit.upper), self.limit.lower)
-        return Translation.from_vector(self.axis.vector * position)
+        return Translation.from_vector(self.current_axis.vector * position)
 
     # does this ever happen?
     def calculate_fixed_transformation(self, position):

--- a/src/compas/robots/model/robot.py
+++ b/src/compas/robots/model/robot.py
@@ -588,7 +588,7 @@ class RobotModel(Base):
         frames = []
         for link in self.iter_links():
             if len(link.visual) and link.parent_joint:
-                frames.append(link.parent_joint.origin.copy())
+                frames.append(link.parent_joint.current_origin.copy())
         return frames
 
     @property
@@ -741,7 +741,7 @@ class RobotModel(Base):
         Frame(Point(0.000, 0.000, 0.000), Vector(0.362, 0.932, 0.000), Vector(-0.932, 0.362, 0.000))
         """
         transformations = self.compute_transformations(joint_state)
-        return [j.origin.transformed(transformations[j.name]) for j in self.iter_joints()]
+        return [j.current_origin.transformed(transformations[j.name]) for j in self.iter_joints()]
 
     def transformed_axes(self, joint_state):
         """Returns the transformed axes based on the joint_state.
@@ -798,7 +798,7 @@ class RobotModel(Base):
         joint = ee_link.parent_joint
         if joint:
             transformations = self.compute_transformations(joint_state)
-            return joint.origin.transformed(transformations[joint.name])
+            return joint.current_origin.transformed(transformations[joint.name])
         else:
             return Frame.worldXY()  # if we ask forward from base link
 

--- a/src/compas/robots/model/robot.py
+++ b/src/compas/robots/model/robot.py
@@ -602,8 +602,7 @@ class RobotModel(Base):
         """
         axes = []
         for joint in self.iter_joints():
-            if joint.axis:
-                axes.append(joint.axis.vector)
+            axes.append(joint.current_axis.vector)
         return axes
 
     def __str__(self):
@@ -765,7 +764,7 @@ class RobotModel(Base):
         [Vector(0.000, 0.000, 1.000), Vector(0.000, 0.000, 1.000)]
         """
         transformations = self.compute_transformations(joint_state)
-        return [j.axis.transformed(transformations[j.name]) for j in self.iter_joints() if j.axis.vector.length]
+        return [j.current_axis.transformed(transformations[j.name]) for j in self.iter_joints() if j.current_axis.vector.length]
 
     def forward_kinematics(self, joint_state, link_name=None):
         """Calculate the robot's forward kinematic.


### PR DESCRIPTION
`compas.robots.RobotModel` uses and modifies the attribute `origin` of its `Joint`s, losing the information necessary for recreating the associated URDF.  This PR is to separate `origin` (that which should be included in a URDF) from `current_origin` (that which is used for calculating and visualizing forward kinematics).  This is somewhere between a bug fix and a new feature.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
