### PR TITLE
Fix NetworkX support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix Rhino7 Mac installation path
 * Separate `compas.robots.Joint.origin` into the static parent-relative `origin` and the dynamic world-relative `current_origin`.
 * Separate `compas.robots.Joint.axis` into the static parent-relative `axis` and the dynamic world-relative `current_axis`.
+* Fixed support to convert back and forth between `compas.datastructures.Graph` and NetworkX `DiGraph`.
 
 ### Removed
 

--- a/src/compas/datastructures/network/core/graph.py
+++ b/src/compas/datastructures/network/core/graph.py
@@ -704,10 +704,9 @@ class Graph(Datastructure):
 
         Yields
         ------
-        2-tuple
+        tuple
             The next edge identifier (u, v), if ``data`` is ``False``.
-        3-tuple
-            The next node as a (u, v, attr) tuple, if ``data`` is ``True``.
+            Otherwise, the next edge identifier and its attributes as a ((u, v), attr) tuple.
         """
         for u, nbrs in iter(self.edge.items()):
             for v, attr in iter(nbrs.items()):
@@ -731,10 +730,9 @@ class Graph(Datastructure):
 
         Yields
         ------
-        2-tuple
-            The next edge as a (u, v) tuple, if ``data=False``.
-        3-tuple
-            The next edge as a (u, v, data) tuple, if ``data=True``.
+        tuple
+            The next edge identifier (u, v), if ``data`` is ``False``.
+            Otherwise, the next edge identifier and its attributes as a ((u, v), attr) tuple.
         """
         for key in self.edges():
             is_match = True
@@ -779,17 +777,16 @@ class Graph(Datastructure):
         ----------
         predicate : callable
             The condition you want to evaluate.
-            The callable takes 3 parameters: ``u``, ``v``, ``attr`` and should return ``True`` or ``False``.
+            The callable takes 2 parameters: a key ``(u, v)`` tuple and ``attr`` and should return ``True`` or ``False``.
         data : bool, optional
             Yield the nodes and their data attributes.
             Default is ``False``.
 
         Yields
         ------
-        2-tuple
-            The next edge as a (u, v) tuple, if ``data=False``.
-        3-tuple
-            The next edge as a (u, v, data) tuple, if ``data=True``.
+        tuple
+            The next edge identifier (u, v), if ``data`` is ``False``.
+            Otherwise, the next edge identifier and its attributes as a ((u, v), attr) tuple.
 
         Examples
         --------

--- a/src/compas/datastructures/network/core/graph.py
+++ b/src/compas/datastructures/network/core/graph.py
@@ -242,11 +242,45 @@ class Graph(Datastructure):
 
     @classmethod
     def from_networkx(cls, graph):
-        raise NotImplementedError
+        """Create a new graph instance from a NetworkX DiGraph instance.
+
+        Parameters
+        ----------
+        graph : networkx.DiGraph
+            NetworkX instance of a directed graph.
+
+        Returns
+        -------
+        Graph
+            A newly created graph.
+        """
+        g = cls()
+
+        for node in graph.nodes():
+            g.add_node(node, **graph.nodes[node])
+
+        for edge in graph.edges():
+            g.add_edge(*edge, **graph.edges[edge])
+
+        return g
 
     def to_networkx(self):
+        """Create a new NetworkX graph instance from a graph.
+
+        Returns
+        -------
+        networkx.DiGraph
+            A newly created NetworkX DiGraph.
+        """
         import networkx as nx
-        graph = nx.Graph(self.edges())
+        graph = nx.DiGraph()
+
+        for node, attr in self.nodes(data=True):
+            graph.add_node(node, **attr)
+
+        for edge, attr in self.edges(data=True):
+            graph.add_edge(*edge, **attr)
+
         return graph
 
     # --------------------------------------------------------------------------
@@ -1393,9 +1427,9 @@ class Graph(Datastructure):
         u : hashable
             The identifier of the first node of the edge.
         v : hashable
-            The identifier of the secondt node of the edge.
+            The identifier of the second node of the edge.
         directed : bool, optional
-            Take into accoun the direction of the edge.
+            Take into account the direction of the edge.
             Default is ``True``.
 
         Returns

--- a/src/compas/datastructures/network/core/graph.py
+++ b/src/compas/datastructures/network/core/graph.py
@@ -255,6 +255,7 @@ class Graph(Datastructure):
             A newly created graph.
         """
         g = cls()
+        g.attributes.update(graph.graph)
 
         for node in graph.nodes():
             g.add_node(node, **graph.nodes[node])
@@ -274,6 +275,7 @@ class Graph(Datastructure):
         """
         import networkx as nx
         graph = nx.DiGraph()
+        graph.graph.update(self.attributes)
 
         for node, attr in self.nodes(data=True):
             graph.add_node(node, **attr)

--- a/tests/compas/datastructures/test_graph.py
+++ b/tests/compas/datastructures/test_graph.py
@@ -42,6 +42,8 @@ def test_graph_networkx_conversion():
         return
 
     g = Graph()
+    g.attributes['name'] = 'DiGraph'
+    g.attributes['val'] = (0, 0, 0)
     g.add_node(0)
     g.add_node(1, weight=1.2, height='test')
     g.add_node(2, x=1, y=1, z=0)
@@ -51,6 +53,8 @@ def test_graph_networkx_conversion():
 
     nxg = g.to_networkx()
 
+    assert nxg.graph['name'] == 'DiGraph', "Graph attributes must be preserved"
+    assert nxg.graph['val'] == (0, 0, 0), "Graph attributes must be preserved"
     assert set(nxg.nodes()) == set(g.nodes()), "Node sets must match"
     assert nxg.nodes[1]['weight'] == 1.2, "Node attributes must be preserved"
     assert nxg.nodes[1]['height'] == "test", "Node attributes must be preserved"
@@ -64,3 +68,5 @@ def test_graph_networkx_conversion():
     assert g.number_of_nodes() == g2.number_of_nodes()
     assert g.number_of_edges() == g2.number_of_edges()
     assert g2.edge_attribute((0, 1), 'attr_value') == 10
+    assert g2.attributes['name'] == 'DiGraph', "Graph attributes must be preserved"
+    assert g2.attributes['val'] == (0, 0, 0), "Graph attributes must be preserved"

--- a/tests/compas/datastructures/test_graph.py
+++ b/tests/compas/datastructures/test_graph.py
@@ -36,6 +36,7 @@ def test_graph_json_schema(graph):
 
     graph.validate_json()
 
+
 def test_graph_networkx_conversion():
     if compas.IPY:
         return

--- a/tests/compas/datastructures/test_graph.py
+++ b/tests/compas/datastructures/test_graph.py
@@ -24,10 +24,42 @@ def graph():
 
 
 def test_data_schema(graph):
-    if not compas.IPY:
-        graph.validate_data()
+    if compas.IPY:
+        return
+
+    graph.validate_data()
 
 
-def graph_json_schema(graph):
-    if not compas.IPY:
-        graph.validate_json()
+def test_graph_json_schema(graph):
+    if compas.IPY:
+        return
+
+    graph.validate_json()
+
+def test_graph_networkx_conversion():
+    if compas.IPY:
+        return
+
+    g = Graph()
+    g.add_node(0)
+    g.add_node(1, weight=1.2, height='test')
+    g.add_node(2, x=1, y=1, z=0)
+
+    g.add_edge(0, 1, attr_value=10)
+    g.add_edge(1, 2)
+
+    nxg = g.to_networkx()
+
+    assert set(nxg.nodes()) == set(g.nodes()), "Node sets must match"
+    assert nxg.nodes[1]['weight'] == 1.2, "Node attributes must be preserved"
+    assert nxg.nodes[1]['height'] == "test", "Node attributes must be preserved"
+    assert nxg.nodes[2]['x'] == 1, "Node attributes must be preserved"
+
+    assert set(nxg.edges()) == set(((0, 1), (1, 2))), "Edge sets must match"
+    assert nxg.edges[0, 1]['attr_value'] == 10, "Edge attributes must be preserved"
+
+    g2 = Graph.from_networkx(nxg)
+
+    assert g.number_of_nodes() == g2.number_of_nodes()
+    assert g.number_of_edges() == g2.number_of_edges()
+    assert g2.edge_attribute((0, 1), 'attr_value') == 10


### PR DESCRIPTION
The API of the Graph class contains methods to convert between COMPAS' Graph and NetworkX's graphs, but the implementation was incomplete for one of them and completely missing for the other. This PR fixes that by adding a complete implementation for both + unit tests. And since the API has not changed, I am setting this PR as "backwards-compatible bug fix".

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
