### PR TITLE
add methods remove_link, remove_joint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `RobotModel.remove_link`, `RobotModel.remove_joint`, `RobotModel.to_urdf_string`, and `RobotModel.ensure_geometry`.
+
 ### Changed
 
 * Fix Rhino7 Mac installation path

--- a/src/compas/robots/model/robot.py
+++ b/src/compas/robots/model/robot.py
@@ -591,7 +591,6 @@ class RobotModel(Base):
 
                     if not shape.geometry:
                         raise Exception('Unable to load geometry for {}'.format(shape.filename))
-        self._geometry_loaded = True
 
     def ensure_geometry(self):
         """Check if geometry has been loaded.
@@ -600,9 +599,12 @@ class RobotModel(Base):
         :exc:`Exception`
             If geometry has not been loaded.
         """
-        if not self._geometry_loaded:
-            raise Exception(
-                'This method is only callable once the geometry has been loaded.')
+        for link in self.links:
+            for element in itertools.chain(link.collision, link.visual):
+                shape = element.geometry.shape
+                if not shape.geometry:
+                    raise Exception(
+                        'This method is only callable once the geometry has been loaded.')
 
     @property
     def frames(self):

--- a/src/compas/robots/model/robot.py
+++ b/src/compas/robots/model/robot.py
@@ -1012,10 +1012,10 @@ class RobotModel(Base):
             The name of the joint
         """
         joint = self.get_joint_by_name(name)
-        self.joints = [joint for joint in self.joints if joint.name != name]
+        self.joints = [j for j in self.joints if j.name != name]
         parent_link = self.get_link_by_name(joint.parent.link)
-        parent_link.joints = [joint for joint in parent_link.joints if joint.name != name]
-        self._adjacency[parent_link.name] = [joint.name for joint in parent_link.joints]
+        parent_link.joints = [j for j in parent_link.joints if j.name != name]
+        self._adjacency[parent_link.name] = [j.name for j in parent_link.joints]
         del self._links[joint.child.link]
         del self._joints[name]
         del self._adjacency[name]

--- a/src/compas/robots/model/robot.py
+++ b/src/compas/robots/model/robot.py
@@ -68,7 +68,6 @@ class RobotModel(Base):
         self._rebuild_tree()
         self._create(self.root, Transformation())
         self._scale_factor = 1.
-        self._geometry_loaded = False
 
     def get_urdf_element(self):
         attributes = {'name': self.name}

--- a/tests/compas/robots/fixtures/sample.with_shapes_only.urdf
+++ b/tests/compas/robots/fixtures/sample.with_shapes_only.urdf
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
+   <link name="panda_link0">
+      <visual>
+         <geometry>
+            <box size="1.0 2.0 3.0"/>
+         </geometry>
+      </visual>
+      <collision>
+         <geometry>
+            <sphere radius="0.2"/>
+         </geometry>
+      </collision>
+   </link>
+   <link name="panda_link1">
+      <visual>
+         <geometry>
+            <box size="0.6 0.1 0.2"/>
+         </geometry>
+      </visual>
+      <collision>
+         <geometry>
+            <cylinder length="0.6" radius="0.2"/>
+         </geometry>
+      </collision>
+   </link>
+</robot>
+

--- a/tests/compas/robots/test_model.py
+++ b/tests/compas/robots/test_model.py
@@ -25,6 +25,11 @@ def urdf_file_with_shapes():
 
 
 @pytest.fixture
+def urdf_file_with_shapes_only():
+    return os.path.join(BASE_FOLDER, 'fixtures', 'sample.with_shapes_only.urdf')
+
+
+@pytest.fixture
 def ur5_file():
     return os.path.join(BASE_FOLDER, 'fixtures', 'ur5.xacro')
 
@@ -133,10 +138,12 @@ def test_robot_link_nameless_is_allowed_with_custom_namespace():
     assert isinstance(r, RobotModel)
     assert r.name == 'NamelessLinkRobot'
 
+
 def test_link_nameless_raises_if_no_custom_namespace():
     with pytest.raises(Exception):
         r = RobotModel.from_urdf_string(
             """<?xml version="1.0" encoding="UTF-8"?><robot name="NamelessLinkRobot"><link/></robot>""")
+
 
 def test_robot_default_namespace_creates_box_shape_based_on_tagname():
     r = RobotModel.from_urdf_string(
@@ -145,12 +152,14 @@ def test_robot_default_namespace_creates_box_shape_based_on_tagname():
     assert r.links[0].name == 'base_link'
     assert isinstance(r.links[0].visual[0].geometry.shape, Box)
 
+
 def test_robot_default_namespace_to_string():
     r = RobotModel.from_urdf_string(
         """<?xml version="1.0" encoding="UTF-8"?><robot xmlns="https://drake.mit.edu" name="Acrobot"><frame/></robot>""")
     urdf_string = URDF.from_robot(r).to_string(prettify=True)
     assert b'xmlns="https://drake.mit.edu"' in urdf_string
     assert b'<ns0:frame' in urdf_string
+
 
 def test_robot_with_default_nested_namespaces():
     r = RobotModel.from_urdf_string(
@@ -159,6 +168,7 @@ def test_robot_with_default_nested_namespaces():
     urdf = URDF.from_robot(r)
     assert urdf.robot.attr['xmlns'] == 'https://ethz.ch'
     assert urdf.robot.links[0].attr['xmlns'] == 'https://ita.ethz.ch'
+
 
 def test_robot_with_default_nested_namespaces_to_string():
     r = RobotModel.from_urdf_string(
@@ -175,6 +185,7 @@ def test_robot_with_prefixed_nested_namespaces_to_string():
     assert b'xmlns="https://ethz.ch"' in urdf_string
     assert b'xmlns:ns0="https://ita.ethz.ch"' in urdf_string
     assert b'<ns0:visual' in urdf_string
+
 
 def test_programmatic_model(ur5):
     chain = list(ur5.iter_chain('base_link', 'wrist_3_link'))
@@ -550,6 +561,14 @@ def test_unknown_axis_attribute_data(urdf_with_unknown_attr):
     r_original = RobotModel.from_urdf_file(urdf_with_unknown_attr)
     r = RobotModel.from_data(r_original.data)
     assert r.joints[0].axis.attr['rpy'] == '0 0 0'
+
+
+def test_ensure_geometry(urdf_file, urdf_file_with_shapes_only):
+    robot = RobotModel.from_urdf_file(urdf_file)
+    with pytest.raises(Exception):
+        robot.ensure_geometry()
+    robot = RobotModel.from_urdf_file(urdf_file_with_shapes_only)
+    robot.ensure_geometry()
 
 
 # ==============================================================================

--- a/tests/compas/robots/test_model.py
+++ b/tests/compas/robots/test_model.py
@@ -79,6 +79,47 @@ def test_programmatic_robot_model():
     assert ['link0', 'joint1', 'link1'] == list(robot.iter_chain())
 
 
+def test_remove_joint(urdf_file):
+    robot = RobotModel.from_urdf_file(urdf_file)
+    robot.remove_joint('panda_finger_joint1')
+    links = [link.name for link in robot.iter_links()]
+    expected_links = [
+        'panda_link0',
+        'panda_link1',
+        'panda_link2',
+        'panda_link3',
+        'panda_link4',
+        'panda_link5',
+        'panda_link6',
+        'panda_link7',
+        'panda_link8',
+        'panda_hand',
+        'panda_rightfinger',
+    ]
+    assert links == expected_links
+    robot.remove_joint('panda_joint7')
+    links = [link.name for link in robot.iter_links()]
+    expected_links = [
+        'panda_link0',
+        'panda_link1',
+        'panda_link2',
+        'panda_link3',
+        'panda_link4',
+        'panda_link5',
+        'panda_link6',
+    ]
+    assert links == expected_links
+    expected_joints = [
+        'panda_joint1',
+        'panda_joint2',
+        'panda_joint3',
+        'panda_joint4',
+        'panda_joint5',
+        'panda_joint6',
+    ]
+    assert robot.get_configurable_joint_names() == expected_joints
+
+
 def test_ur5_urdf(ur5_file):
     r = RobotModel.from_urdf_file(ur5_file)
     assert r.name == 'ur5'

--- a/tests/compas/robots/test_model.py
+++ b/tests/compas/robots/test_model.py
@@ -69,6 +69,9 @@ def test_programmatic_robot_model():
     urdf = URDF.from_robot(robot)
     robot_reincarnated = RobotModel.from_urdf_string(urdf.to_string())
     assert(['link0', 'joint1', 'link1', 'joint2', 'link2'] == list(robot_reincarnated.iter_chain()))
+    robot.remove_link('link2')
+    robot.remove_joint('joint2')
+    assert ['link0', 'joint1', 'link1'] == list(robot.iter_chain())
 
 
 def test_ur5_urdf(ur5_file):


### PR DESCRIPTION
These new methods on RobotModel are necessary for the fix to the `add_attached_collision_mesh` method of the pybullet client ([#259](https://github.com/compas-dev/compas_fab/pull/259)) .  This PR will remain as a draft until after the release of version 1.0.  Remind me to update the CHANGELOG after that.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
