### PR TITLE
Correct exception type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed bug in parameter list of function `mesh_bounding_box` bound as method `Mesh.bounding_box`.
+* Changed exception type when subdivide scheme argument is incorrect on `mesh_subdivide`.
 
 ### Removed
 

--- a/src/compas/datastructures/mesh/subdivision.py
+++ b/src/compas/datastructures/mesh/subdivision.py
@@ -100,7 +100,7 @@ def mesh_subdivide(mesh, scheme='catmullclark', **options):
     ----------
     mesh : Mesh
         A mesh object.
-    scheme : {'tri', 'corner', 'catmullclark', 'doosabin'}, optional
+    scheme : {'tri', 'quad', 'corner', 'catmullclark', 'doosabin'}, optional
         The scheme according to which the mesh should be subdivided.
         Default is ``'catmullclark'``.
     options : dict
@@ -113,7 +113,7 @@ def mesh_subdivide(mesh, scheme='catmullclark', **options):
 
     Raises
     ------
-    NotImplementedError
+    ValueError
         If the scheme is not supported.
 
     """
@@ -128,7 +128,7 @@ def mesh_subdivide(mesh, scheme='catmullclark', **options):
     if scheme == 'doosabin':
         return mesh_subdivide_doosabin(mesh, **options)
 
-    raise NotImplementedError
+    raise ValueError('Scheme is not supported')
 
 
 def mesh_subdivide_tri(mesh, k=1):


### PR DESCRIPTION
Changed the exception type from `NotImplementedError` to `ValueError` since that the method is actually implemented, but the error mode is that the argument is an invalid one (which fits the description of what `ValueError` is).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
