### PR TITLE
Fix for Multiple collections created by Blender RobotmodelArtist. 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -28,3 +28,4 @@
 - Beverly Lytle <<lytle@arch.ethz.ch>> [@beverlylytle](https://github.com/beverlylytle>)
 - Juney Lee <<juney.lee@arch.ethz.ch>> [@juney-lee](https://github.com/juney-lee)
 - Xingxin He <<xingxin.he@mail.polimi.it>> [@XingxinHE](https://github.com/XingxinHE)
+- Robin Godwyll <<rodwyll+github@gmail.com>> [@robin-gdwl](https://github.com/robin-gdwl)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased 2021-02-05
-
-### Added
-* Added Blender Python-example to the documentation section: Tutorials -> Robots
-
-### Changed
-
-* Fixed bug where initialising a `compas_blender.artists.Robotmodelartist` would create a new collection for each mesh and then also not put the mesh iton the created collection. 
-* Changed the initialisation of `compas_blender.artists.Robotmodelartist` to include a `collection`-parameter instead of a `layer`-parameter to be more consistent with Blender's nomenclature. 
-* Used a utility function from `compas_blender.utilities` to create the collection if none exists instead of using a new call to a bpy-method. 
-
-### Removed
 
 ## Unreleased
 
 ### Added
 
 * Added `RobotModel.remove_link`, `RobotModel.remove_joint`, `RobotModel.to_urdf_string`, and `RobotModel.ensure_geometry`.
+* Added Blender Python-example to the documentation section: Tutorials -> Robots
 
 ### Changed
 
@@ -34,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug regarding the computation of `Joint.current_origin`.
 * Fixed bug regarding a repeated call to `RobotModel.add_joint`.
 * Fixed bug in `compas.datastructures.mesh_slice_plane`.
+* Fixed bug where initialising a `compas_blender.artists.Robotmodelartist` would create a new collection for each mesh and then also not put the mesh iton the created collection. 
+* Changed the initialisation of `compas_blender.artists.Robotmodelartist` to include a `collection`-parameter instead of a `layer`-parameter to be more consistent with Blender's nomenclature. 
+* Used a utility function from `compas_blender.utilities` to create the collection if none exists instead of using a new call to a bpy-method. 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased 2021-02-05
+
+### Added
+* Added Blender Python-example to the documentation section: Tutorials -> Robots
+
+### Changed
+
+* Fixed bug where initialising a `compas_blender.artists.Robotmodelartist` would create a new collection for each mesh and then also not put the mesh iton the created collection. 
+* Changed the initialisation of `compas_blender.artists.Robotmodelartist` to include a `collection`-parameter instead of a `layer`-parameter to be more consistent with Blender's nomenclature. 
+* Used a utility function from `compas_blender.utilities` to create the collection if none exists instead of using a new call to a bpy-method. 
+
+### Removed
+
 ## Unreleased
 
 ### Added

--- a/docs/tutorial/robots.rst
+++ b/docs/tutorial/robots.rst
@@ -148,8 +148,29 @@ Visualizing Robots
 Before jumping into how to build a robot model, let's first see how to visualize
 one. This can be done with Blender, Rhino or Grasshopper using one of COMPAS's
 artists.  The basic procedure is the same in
-any of the CAD software (aside from the import statement), so for simplicity we
-will demonstrate the use of :class:`compas_rhino.artists.RobotModelArtist` in Rhino.
+any of the CAD software (aside from the import statement). Below you can find an example code for both Rhino and Blender. 
+
+
+.. raw:: html
+
+    <div class="card">
+        <div class="card-header">
+            <ul class="nav nav-tabs card-header-tabs">
+                <li class="nav-item">
+                    <a class="nav-link active" data-toggle="tab" href="#visualise_robot_rhino">Rhino</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" data-toggle="tab" href="#visualise_robot_blender">Blender</a>
+                </li>
+            </ul>
+        </div>
+        <div class="card-body">
+            <div class="tab-content">
+
+.. raw:: html
+
+    <div class="tab-pane active" id="visualise_robot_rhino">
+
 Be sure to first install COMPAS for Rhino.  While the following code is incomplete,
 it can be used as a scaffolding for code to be run in a Python script editor within Rhino.
 
@@ -167,8 +188,45 @@ it can be used as a scaffolding for code to be run in a Python script editor wit
     artist.clear_layer()
     artist.draw_visual()
 
+.. raw:: html
 
-See below for a complete example.
+    </div>
+    <div class="tab-pane" id="visualise_robot_blender">
+
+.. code-block:: python
+
+    import compas
+    from compas.robots import GithubPackageMeshLoader
+    from compas.robots import RobotModel
+    import compas_blender
+    from compas_blender.artists import RobotModelArtist, BaseArtist
+
+    compas_blender.clear()  # Delete all objects in the scene
+
+    compas.PRECISION = '12f'
+    # Load the urdf-file from Github 
+    github = GithubPackageMeshLoader('ros-industrial/abb', 'abb_irb6600_support', 'kinetic-devel')
+    model = RobotModel.from_urdf_file(github.load_urdf('irb6640.urdf'))
+    model.load_geometry(github)
+    
+    # Load the robot meshes into the blender scene
+    artist = RobotModelArtist(model, collection='COMPAS FAB::Example')
+
+Note that the blender ``RobotModelArtist`` is not as developed as the one for Rhino. 
+
+.. raw:: html
+
+    </div>
+
+.. raw:: html
+
+    </div>
+    </div>
+    </div>
+
+
+
+See below for a complete example in Rhino.
 
 
 Building robots models

--- a/docs/tutorial/robots.rst
+++ b/docs/tutorial/robots.rst
@@ -201,32 +201,30 @@ it can be used as a scaffolding for code to be run in a Python script editor wit
     import compas_blender
     from compas_blender.artists import RobotModelArtist, BaseArtist
 
-    compas_blender.clear()  # Delete all objects in the scene
+    compas_blender.clear()  # Delete all objects in the Blender scene
 
-    compas.PRECISION = '12f'
-    # Load the urdf-file from Github 
-    github = GithubPackageMeshLoader('ros-industrial/abb', 'abb_irb6600_support', 'kinetic-devel')
-    model = RobotModel.from_urdf_file(github.load_urdf('irb6640.urdf'))
-    model.load_geometry(github)
+    model = RobotModel('Robby')
+
+    # Add some geometry to Robby here
     
-    # Load the robot meshes into the blender scene
-    artist = RobotModelArtist(model, collection='COMPAS FAB::Example')
+    # Load the robot geometry into the blender scene
+    artist = RobotModelArtist(model, collection='COMPAS::Example Robot')
 
-Note that the blender ``RobotModelArtist`` is not as developed as the one for Rhino. 
-
-.. raw:: html
-
-    </div>
+Note that the blender ``RobotModelArtist`` is not as developed as the one for Rhino.
 
 .. raw:: html
 
     </div>
+
+.. raw:: html
+
     </div>
     </div>
+    </div>
 
 
 
-See below for a complete example in Rhino.
+See below for a complete example of how to programmatically create a Robotmodel.
 
 
 Building robots models

--- a/docs/tutorial/robots.rst
+++ b/docs/tutorial/robots.rst
@@ -196,10 +196,9 @@ it can be used as a scaffolding for code to be run in a Python script editor wit
 .. code-block:: python
 
     import compas
-    from compas.robots import GithubPackageMeshLoader
     from compas.robots import RobotModel
     import compas_blender
-    from compas_blender.artists import RobotModelArtist, BaseArtist
+    from compas_blender.artists import RobotModelArtist
 
     compas_blender.clear()  # Delete all objects in the Blender scene
 

--- a/src/compas_blender/artists/robotmodelartist.py
+++ b/src/compas_blender/artists/robotmodelartist.py
@@ -43,13 +43,9 @@ class RobotModelArtist(BaseRobotModelArtist):
 
         if self.collection:
             if self.collection not in bpy.data.collections.keys():
-                target_collection = bpy.data.collections.new(self.collection)  # create new collection if none exists
-                bpy.context.scene.collection.children.link(target_collection)  # link the new collection to the base collection
-            else:  # not necessary: linking the object to an existing collection is done in compas_blender.draw_mesh
-                target_collection = bpy.data.collections.get(self.collection)
+                compas_blender.utilities.create_collection(self.collection)
 
         v, f = geometry.to_vertices_and_faces()
-        # Draw the mesh in Blender in the specified collection
         return compas_blender.draw_mesh(vertices=v, faces=f, name=name, color=color, centroid=False, collection=self.collection)
 
     def redraw(self, timeout=None):

--- a/src/compas_blender/artists/robotmodelartist.py
+++ b/src/compas_blender/artists/robotmodelartist.py
@@ -20,8 +20,9 @@ class RobotModelArtist(BaseRobotModelArtist):
         The name of the layer that will contain the robot meshes.
     """
 
-    def __init__(self, model, layer=None):
-        self.layer = layer
+    def __init__(self, model, collection=None, layer=None):
+        self.view_layer = layer
+        self.collection = collection
         super(RobotModelArtist, self).__init__(model)
 
     def transform(self, native_mesh, transformation):
@@ -29,7 +30,6 @@ class RobotModelArtist(BaseRobotModelArtist):
 
     def draw_geometry(self, geometry, name=None, color=None):
         # Imported colors take priority over a the parameter color
-        # TODO: cleanup confusion between layers and collections
 
         if 'mesh_color.diffuse' in geometry.attributes:
             color = geometry.attributes['mesh_color.diffuse']
@@ -41,23 +41,16 @@ class RobotModelArtist(BaseRobotModelArtist):
         else:
             color = [1., 1., 1.]
 
-        if self.layer:
-            
-            current_collections = bpy.data.collections.items()
-            #print(bpy.data.collections)
-            #print(bpy.data.collections.keys())
-
-            if self.layer not in bpy.data.collections.keys():
-                collection = bpy.data.collections.new(self.layer)  # create new collection if none exists
-                bpy.context.scene.collection.children.link(collection)  # link the new collection to the base collection
-            else: 
-                collection = bpy.data.collections.get(self.layer)
-               # print(collection)
-            
+        if self.collection:
+            if self.collection not in bpy.data.collections.keys():
+                target_collection = bpy.data.collections.new(self.collection)  # create new collection if none exists
+                bpy.context.scene.collection.children.link(target_collection)  # link the new collection to the base collection
+            else:  # not necessary: linking the object to an existing collection is done in compas_blender.draw_mesh
+                target_collection = bpy.data.collections.get(self.collection)
 
         v, f = geometry.to_vertices_and_faces()
-        # Draw the mesh in blender in the specified collection
-        return compas_blender.draw_mesh(vertices=v, faces=f, name=name, color=color, centroid=False, collection=self.layer)
+        # Draw the mesh in Blender in the specified collection
+        return compas_blender.draw_mesh(vertices=v, faces=f, name=name, color=color, centroid=False, collection=self.collection)
 
     def redraw(self, timeout=None):
         bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)

--- a/src/compas_blender/artists/robotmodelartist.py
+++ b/src/compas_blender/artists/robotmodelartist.py
@@ -29,6 +29,8 @@ class RobotModelArtist(BaseRobotModelArtist):
 
     def draw_geometry(self, geometry, name=None, color=None):
         # Imported colors take priority over a the parameter color
+        # TODO: cleanup confusion between layers and collections
+
         if 'mesh_color.diffuse' in geometry.attributes:
             color = geometry.attributes['mesh_color.diffuse']
 
@@ -40,11 +42,22 @@ class RobotModelArtist(BaseRobotModelArtist):
             color = [1., 1., 1.]
 
         if self.layer:
-            collection = bpy.data.collections.new(self.layer)
-            bpy.context.scene.collection.children.link(collection)
+            
+            current_collections = bpy.data.collections.items()
+            #print(bpy.data.collections)
+            #print(bpy.data.collections.keys())
+
+            if self.layer not in bpy.data.collections.keys():
+                collection = bpy.data.collections.new(self.layer)  # create new collection if none exists
+                bpy.context.scene.collection.children.link(collection)  # link the new collection to the base collection
+            else: 
+                collection = bpy.data.collections.get(self.layer)
+               # print(collection)
+            
 
         v, f = geometry.to_vertices_and_faces()
-        return compas_blender.draw_mesh(vertices=v, faces=f, name=name, color=color, centroid=False, layer=self.layer)
+        # Draw the mesh in blender in the specified collection
+        return compas_blender.draw_mesh(vertices=v, faces=f, name=name, color=color, centroid=False, collection=self.layer)
 
     def redraw(self, timeout=None):
         bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)

--- a/src/compas_blender/utilities/drawing.py
+++ b/src/compas_blender/utilities/drawing.py
@@ -46,11 +46,11 @@ def _link_objects(objects, collection=None, layer=None):
     # if not layer:
     #     layer = bpy.context.view_layer
     # layer_collection = layer.active_layer_collection.collection
-    
+
     for o in objects:
         for c in o.users_collection:
             c.objects.unlink(o)
-        collection.objects.link(o)  # TODO: why does this not work
+        collection.objects.link(o)
         # layer_collection.objects.link(o)
 
 

--- a/src/compas_blender/utilities/drawing.py
+++ b/src/compas_blender/utilities/drawing.py
@@ -46,10 +46,11 @@ def _link_objects(objects, collection=None, layer=None):
     # if not layer:
     #     layer = bpy.context.view_layer
     # layer_collection = layer.active_layer_collection.collection
+    
     for o in objects:
         for c in o.users_collection:
             c.objects.unlink(o)
-        collection.objects.link(o)
+        collection.objects.link(o)  # TODO: why does this not work
         # layer_collection.objects.link(o)
 
 


### PR DESCRIPTION
Simple fix for the blender RobotmodelArtist. 
Responds to this Issue:  #759 

## Changed:

* Fixed bug where initialising a `compas_blender.artists.Robotmodelartist` would create a new collection for each mesh and then also not put the mesh iton the created collection. 
* Changed the initialisation of `compas_blender.artists.Robotmodelartist` to include a `collection`-parameter instead of a `layer`-parameter to be more consistent with Blender's nomenclature. 
* Used a utility function from `compas_blender.utilities` to create the collection if none exists instead of using a new call to a bpy-method. 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes. **not entirely sure about this one**
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I have added necessary documentation (if appropriate)
