### PR TITLE
Grasshopper GHPY libraries install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `RobotModel.remove_link`, `RobotModel.remove_joint`, `RobotModel.to_urdf_string`, and `RobotModel.ensure_geometry`.
 * Added Blender Python-example to the documentation section: Tutorials -> Robots
 * Added `compas_blender.unload_modules`.
+* Added `after_rhino_install` and `after_rhino_uninstall` pluggable interfaces to extend the install/uninstall with arbitrary steps.
 
 ### Changed
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -24,9 +24,13 @@ Category: ``booleans``
 Category: ``install``
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. currentmodule:: compas_rhino.install
+.. currentmodule::
 
 * :func:`installable_rhino_packages`
+* :func:`after_rhino_install`
+
+.. currentmodule:: compas_rhino.uninstall
+* :func:`after_rhino_uninstall`
 
 
 Category: ``intersections``

--- a/src/compas/plugins.py
+++ b/src/compas/plugins.py
@@ -285,12 +285,16 @@ def pluggable(pluggable_method=None, category=None, selector='first_match', doma
 
             # Collect all matching plugins
             elif selector == 'collect_all':
+                results = []
+
                 for plugin_impl in _collect_plugins(extension_point_url):
                     try:
                         result = plugin_impl.method(*args, **kwargs)
-                        yield result
+                        results.append(result)
                     except Exception as e:
-                        yield e
+                        results.append(e)
+
+                return results
             else:
                 raise ValueError('Unexpected selector type. Must be either: first_match or collect_all')
 

--- a/src/compas/plugins.py
+++ b/src/compas/plugins.py
@@ -285,12 +285,12 @@ def pluggable(pluggable_method=None, category=None, selector='first_match', doma
 
             # Collect all matching plugins
             elif selector == 'collect_all':
-                results = []
-
                 for plugin_impl in _collect_plugins(extension_point_url):
-                    results.append(plugin_impl.method(*args, **kwargs))
-
-                return results
+                    try:
+                        result = plugin_impl.method(*args, **kwargs)
+                        yield result
+                    except Exception as e:
+                        yield e
             else:
                 raise ValueError('Unexpected selector type. Must be either: first_match or collect_all')
 

--- a/src/compas_ghpython/__init__.py
+++ b/src/compas_ghpython/__init__.py
@@ -22,7 +22,7 @@ if compas.RHINO:
 __version__ = '1.0.0'
 
 
-def _get_grasshopper_library_path(version):
+def get_grasshopper_library_path(version):
     if compas.WINDOWS:
         grasshopper_library_path = os.path.join(os.getenv('APPDATA'), 'Grasshopper', 'Libraries')
     elif compas.OSX:

--- a/src/compas_ghpython/__init__.py
+++ b/src/compas_ghpython/__init__.py
@@ -12,6 +12,7 @@ compas_ghpython
     compas_ghpython.utilities
 
 """
+import os
 import compas
 
 if compas.RHINO:
@@ -19,6 +20,17 @@ if compas.RHINO:
 
 
 __version__ = '1.0.0'
+
+
+def _get_grasshopper_library_path(version):
+    if compas.WINDOWS:
+        grasshopper_library_path = os.path.join(os.getenv('APPDATA'), 'Grasshopper', 'Libraries')
+    elif compas.OSX:
+        grasshopper_library_path = os.path.join(os.getenv('HOME'), 'Library', 'Application Support', 'McNeel', 'Rhinoceros', '{}'.format(version),
+                                                'Plug-ins', 'Grasshopper (b45a29b1-4343-4035-989e-044e8580d9cf)', 'Libraries')
+    else:
+        raise Exception('Unsupported platform')
+    return grasshopper_library_path
 
 
 __all_plugins__ = ['compas_ghpython.install']

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -211,4 +211,5 @@ __all__ = [name for name in dir() if not name.startswith('_')]
 __all_plugins__ = [
     'compas_rhino.geometry.booleans',
     'compas_rhino.install',
+    'compas_rhino.uninstall',
 ]

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -140,7 +140,7 @@ def _run_post_execution_steps(steps_generator):
                 status = 'OK' if success else 'ERROR'
                 print('   {} {}: {}'.format(package.ljust(20), status, message))
             except ValueError:
-                post_execution_errors.append(ValueError('Step successful, but result is wrongly formatted: {}'.format(str(result))))
+                post_execution_errors.append(ValueError('Step successful, but result is wrongly formatted: {}'.format(str(item))))
 
     if post_execution_errors:
         print()

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -12,7 +12,12 @@ import compas_rhino
 import compas._os
 import compas.plugins
 
-__all__ = ['install']
+__all__ = [
+    'install',
+    'installable_rhino_packages',
+    'after_rhino_install',
+    'after_rhino_uninstall',
+]
 
 
 def install(version=None, packages=None):
@@ -84,8 +89,13 @@ def install(version=None, packages=None):
     symlinks = [(link['source_path'], link['link']) for link in symlinks_to_install]
     install_results = compas._os.create_symlinks(symlinks)
 
+    installed_packages = []
     for install_data, success in zip(symlinks_to_install, install_results):
-        result = 'OK' if success else 'ERROR: Cannot create symlink, try to run as administrator.'
+        if success:
+            installed_packages.append(install_data['name'])
+            result = 'OK'
+        else:
+            result = 'ERROR: Cannot create symlink, try to run as administrator.'
         results.append((install_data['name'], result))
 
     if not all(install_results):
@@ -106,9 +116,37 @@ def install(version=None, packages=None):
         if status != 'OK':
             exit_code = -1
 
+    if len(installed_packages):
+        print()
+        print('Running post-installation steps...')
+        print()
+        _run_post_execution_steps(after_rhino_install(installed_packages))
+
     print('\nCompleted.')
     if exit_code != 0:
         sys.exit(exit_code)
+
+def _run_post_execution_steps(steps_generator):
+    post_execution_errors = []
+    for result in steps_generator:
+        if isinstance(result, Exception):
+            post_execution_errors.append(result)
+            continue
+
+        for item in result:
+            try:
+                package, message, success = item
+                status = 'OK' if success else 'ERROR'
+                print('   {} {}: {}'.format(package.ljust(20), status, message))
+            except ValueError:
+                post_execution_errors.append(ValueError('Step successful, but result is wrongly formatted: {}'.format(str(result))))
+
+    if post_execution_errors:
+        print()
+        print('One or more errors occurred:')
+        print()
+        for error in post_execution_errors:
+            print('   - {}'.format(repr(error)))
 
 
 @compas.plugins.plugin(category='install', pluggable_name='installable_rhino_packages', tryfirst=True)
@@ -142,6 +180,35 @@ def installable_rhino_packages():
     """
     pass
 
+
+@compas.plugins.pluggable(category='install', selector='collect_all')
+def after_rhino_install(installed_packages):
+    """Allows extensions to execute actions after install to Rhino is done.
+
+    Extensions providing Rhino or Grasshopper features
+    can implement this pluggable interface to perform
+    additional steps after an installation to Rhino has
+    been completed.
+
+    Parameters
+    ----------
+    installed_packages : :obj:`list` of :obj:`str`
+        List of packages that have been installed successfully.
+
+    Examples
+    --------
+    >>> import compas.plugins
+    >>> @compas.plugins.plugin(category='install')
+    ... def after_rhino_install(installed_packages):
+    ...    # Do something after package is installed to Rhino, eg, copy components, etc
+    ...    return [('compas_ghpython', 'GH Components installed', True)]
+
+    Returns
+    -------
+    :obj:`list` of 3-tuple (str, str, bool)
+        List containing a 3-tuple with component name, message and ``True``/``False`` success flag.
+    """
+    pass
 
 def _update_bootstrapper(install_path, packages):
     # Take either the CONDA environment directory or the current Python executable's directory

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -153,6 +153,7 @@ def _run_post_execution_steps(steps_generator):
 
     return True
 
+
 @compas.plugins.plugin(category='install', pluggable_name='installable_rhino_packages', tryfirst=True)
 def default_installable_rhino_packages():
     # While this list could obviously be hard-coded, I think

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -144,7 +144,7 @@ def _run_post_execution_steps(steps_generator):
                     all_steps_succeeded = False
                 print('   {} {}: {}'.format(package.ljust(20), status, message))
             except ValueError:
-                post_execution_errors.append(ValueError('Step successful, but result is wrongly formatted: {}'.format(str(item))))
+                post_execution_errors.append(ValueError('Step ran without errors but result is wrongly formatted: {}'.format(str(item))))
 
     if post_execution_errors:
         print()

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -115,11 +115,12 @@ def install(version=None, packages=None):
         if status != 'OK':
             exit_code = -1
 
-    if len(installed_packages):
+    if exit_code == 0 and len(installed_packages):
         print()
         print('Running post-installation steps...')
         print()
-        _run_post_execution_steps(after_rhino_install(installed_packages))
+        if not _run_post_execution_steps(after_rhino_install(installed_packages)):
+            exit_code = -1
 
     print('\nCompleted.')
     if exit_code != 0:
@@ -148,6 +149,9 @@ def _run_post_execution_steps(steps_generator):
         for error in post_execution_errors:
             print('   - {}'.format(repr(error)))
 
+        return False
+
+    return True
 
 @compas.plugins.plugin(category='install', pluggable_name='installable_rhino_packages', tryfirst=True)
 def default_installable_rhino_packages():

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -16,7 +16,6 @@ __all__ = [
     'install',
     'installable_rhino_packages',
     'after_rhino_install',
-    'after_rhino_uninstall',
 ]
 
 
@@ -126,6 +125,7 @@ def install(version=None, packages=None):
     if exit_code != 0:
         sys.exit(exit_code)
 
+
 def _run_post_execution_steps(steps_generator):
     post_execution_errors = []
     for result in steps_generator:
@@ -209,6 +209,7 @@ def after_rhino_install(installed_packages):
         List containing a 3-tuple with component name, message and ``True``/``False`` success flag.
     """
     pass
+
 
 def _update_bootstrapper(install_path, packages):
     # Take either the CONDA environment directory or the current Python executable's directory

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -128,7 +128,9 @@ def install(version=None, packages=None):
 
 
 def _run_post_execution_steps(steps_generator):
+    all_steps_succeeded = True
     post_execution_errors = []
+
     for result in steps_generator:
         if isinstance(result, Exception):
             post_execution_errors.append(result)
@@ -138,6 +140,8 @@ def _run_post_execution_steps(steps_generator):
             try:
                 package, message, success = item
                 status = 'OK' if success else 'ERROR'
+                if not success:
+                    all_steps_succeeded = False
                 print('   {} {}: {}'.format(package.ljust(20), status, message))
             except ValueError:
                 post_execution_errors.append(ValueError('Step successful, but result is wrongly formatted: {}'.format(str(item))))
@@ -149,9 +153,9 @@ def _run_post_execution_steps(steps_generator):
         for error in post_execution_errors:
             print('   - {}'.format(repr(error)))
 
-        return False
+        all_steps_succeeded = False
 
-    return True
+    return all_steps_succeeded
 
 
 @compas.plugins.plugin(category='install', pluggable_name='installable_rhino_packages', tryfirst=True)

--- a/src/compas_rhino/uninstall.py
+++ b/src/compas_rhino/uninstall.py
@@ -101,11 +101,12 @@ def uninstall(version=None, packages=None):
         if status != 'OK':
             exit_code = -1
 
-    if len(uninstalled_packages):
+    if exit_code == 0 and len(uninstalled_packages):
         print()
         print('Running post-uninstallation steps...')
         print()
-        _run_post_execution_steps(after_rhino_uninstall(uninstalled_packages))
+        if not _run_post_execution_steps(after_rhino_uninstall(uninstalled_packages)):
+            exit_code = -1
 
     print('\nUninstall completed.')
     if exit_code != 0:

--- a/src/compas_rhino/uninstall.py
+++ b/src/compas_rhino/uninstall.py
@@ -6,10 +6,11 @@ import itertools
 import os
 import sys
 
-import compas_rhino
-from compas_rhino.install import installable_rhino_packages
-
 import compas._os
+import compas.plugins
+import compas_rhino
+from compas_rhino.install import _run_post_execution_steps
+from compas_rhino.install import installable_rhino_packages
 
 __all__ = ['uninstall']
 
@@ -68,8 +69,13 @@ def uninstall(version=None, packages=None):
     symlinks = [link['link'] for link in symlinks_to_uninstall]
     uninstall_results = compas._os.remove_symlinks(symlinks)
 
+    uninstalled_packages = []
     for uninstall_data, success in zip(symlinks_to_uninstall, uninstall_results):
-        result = 'OK' if success else 'ERROR: Cannot remove symlink, try to run as administrator.'
+        if success:
+            uninstalled_packages.append(uninstall_data['name'])
+            result = 'OK'
+        else:
+            result = 'ERROR: Cannot remove symlink, try to run as administrator.'
         results.append((uninstall_data['name'], result))
 
     if not all(uninstall_results):
@@ -91,6 +97,12 @@ def uninstall(version=None, packages=None):
 
         if status != 'OK':
             exit_code = -1
+
+    if len(uninstalled_packages):
+        print()
+        print('Running post-uninstallation steps...')
+        print()
+        _run_post_execution_steps(after_rhino_uninstall(uninstalled_packages))
 
     print('\nUninstall completed.')
     if exit_code != 0:
@@ -124,6 +136,36 @@ def _filter_installed_packages(version, packages):
             packages.extend(legacy_packages)
 
     return packages
+
+
+@compas.plugins.pluggable(category='install', selector='collect_all')
+def after_rhino_uninstall(uninstalled_packages):
+    """Allows extensions to execute actions after uninstall from Rhino is done.
+
+    Extensions providing Rhino or Grasshopper features
+    can implement this pluggable interface to perform
+    additional steps after the uninstall from Rhino has
+    been completed.
+
+    Parameters
+    ----------
+    uninstalled_packages : :obj:`list` of :obj:`str`
+        List of packages that have been uninstalled.
+
+    Examples
+    --------
+    >>> import compas.plugins
+    >>> @compas.plugins.plugin(category='install')
+    ... def after_rhino_uninstall(uninstalled_packages):
+    ...    # Do something cleanup, eg remove copied files.
+    ...    return [('compas_ghpython', 'GH Components uninstalled', True)]
+
+    Returns
+    -------
+    :obj:`list` of 3-tuple (str, str, bool)
+        List containing a 3-tuple with component name, message and ``True``/``False`` success flag.
+    """
+    pass
 
 
 # ==============================================================================

--- a/src/compas_rhino/uninstall.py
+++ b/src/compas_rhino/uninstall.py
@@ -12,7 +12,10 @@ import compas_rhino
 from compas_rhino.install import _run_post_execution_steps
 from compas_rhino.install import installable_rhino_packages
 
-__all__ = ['uninstall']
+__all__ = [
+    'uninstall',
+    'after_rhino_uninstall',
+]
 
 
 def uninstall(version=None, packages=None):


### PR DESCRIPTION
On COMPAS FAB we started to make Grasshopper components that are compiled in a library (.GHPY) (https://github.com/compas-dev/compas_fab/pull/249).
For installing that library, it needs to be copied into the Grasshopper library path. This action is ideally executed when calling 
`python -m compas_rhino.install`

As suggested by @gonzalocasas, compas core should know how to install GH components, and other packages only need to provide the component locations.

For the time being, we're providing two extension points (`pluggable` interfaces) to allow hooking up into the install/uninstall and do arbitrary stuff. This will be a good solution until we sort out all the details of the installation (and potentially compilation) of GH components on end-user machines.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
