### PR TITLE
add __ne__ to primitives and transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed bug where mimic joints were considered configurable.
+* Fixed bug where `!=` gave incorrect results in Rhino for compas objects.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed bug where mimic joints were considered configurable.
-* Fixed bug where `!=` gave incorrect results in Rhino for compas objects.
+* Fixed bug where `!=` gave incorrect results in Rhino for some compas objects.
 
 ### Removed
 

--- a/src/compas/base.py
+++ b/src/compas/base.py
@@ -63,10 +63,6 @@ class Base(object):
         self._guid = None
         self._name = None
 
-    def __ne__(self, other):
-        # this is not obvious to ironpython
-        return not self.__eq__(other)
-
     @property
     def DATASCHEMA(self):
         """:class:`schema.Schema` : The schema of the data of this object."""

--- a/src/compas/base.py
+++ b/src/compas/base.py
@@ -63,6 +63,10 @@ class Base(object):
         self._guid = None
         self._name = None
 
+    def __ne__(self, other):
+        # this is not obvious to ironpython
+        return not self.__eq__(other)
+
     @property
     def DATASCHEMA(self):
         """:class:`schema.Schema` : The schema of the data of this object."""

--- a/src/compas/geometry/primitives/_primitive.py
+++ b/src/compas/geometry/primitives/_primitive.py
@@ -18,6 +18,10 @@ class Primitive(Base):
     def __init__(self):
         super(Primitive, self).__init__()
 
+    def __ne__(self, other):
+        # this is not obvious to ironpython
+        return not self.__eq__(other)
+
     @classmethod
     def from_json(cls, filepath):
         """Construct a primitive from structured data contained in a json file.

--- a/src/compas/geometry/transformations/transformation.py
+++ b/src/compas/geometry/transformations/transformation.py
@@ -97,6 +97,10 @@ class Transformation(Base):
         except BaseException:
             return False
 
+    def __ne__(self, other):
+        # this is not obvious to ironpython
+        return not self.__eq__(other)
+
     def __repr__(self):
         return "Transformation({})".format(self.matrix)
 

--- a/tests/compas/geometry/test_point.py
+++ b/tests/compas/geometry/test_point.py
@@ -13,6 +13,16 @@ def test_point_operators():
     pass
 
 
+def test_point_equality():
+    p1 = Point(1, 1, 1)
+    p2 = Point(1, 1, 1)
+    p3 = Point(0, 0, 0)
+    assert p1 == p2
+    assert not (p1 != p2)
+    assert p1 != p3
+    assert not (p1 == p3)
+
+
 def test_point_inplace_operators():
     pass
 

--- a/tests/compas/geometry/test_transformations/test_transformation.py
+++ b/tests/compas/geometry/test_transformations/test_transformation.py
@@ -135,3 +135,13 @@ def test___str__():
     angle = 0.7854
     R = Rotation.from_axis_and_angle(axes, angle, point=trans)
     assert s == str(R)
+
+
+def test___eq__():
+    i1 = Transformation()
+    i2 = Transformation()
+    t = Translation.from_vector([1, 0, 0])
+    assert i1 == i2
+    assert not (i1 != i2)
+    assert i1 != t
+    assert not (i1 == t)


### PR DESCRIPTION
Apparently python2 doesn't infer that `__ne__` is `not __eq__` resulting in things like
```
from compas.geometry import Point

print(Point(1,1,1) == Point(1,1,1))
print(Point(1,1,1) != Point(1,1,1))
```
printing `True` twice.  

I discovered this while investigating why ironpython tests were failing for #774.   

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
