### PR TITLE
Check if blender path exists

### DIFF
--- a/src/compas_blender/install.py
+++ b/src/compas_blender/install.py
@@ -62,6 +62,9 @@ def install(blender_path):
         print('Conda environment not found. The installation into Blender requires an active conda environment with a matching Python version to continue.')
         sys.exit(-1)
 
+    if not os.path.exists(blender_path):
+        raise FileNotFoundError('Blender version folder not found.')
+
     path, version = os.path.split(blender_path)
 
     print('Installing COMPAS for Blender {}'.format(version))


### PR DESCRIPTION
### What type of change is this?

New feature in a **backwards-compatible** manner.

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- ~~I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- ~~I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.~~
- ~~have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added necessary documentation (if appropriate)~~

I noticed that I could supply any path as blender version path.

```
(blender) C:\Users\a>python -m compas_blender.install %USERPROFILE%\scoop\apps\blender\current\2.92C:\Users\a\scoop\apps\blender\current\2.92
Installing COMPAS for Blender 2.92
Installing current conda environment into Blender...
  Renaming bundled python folder to original_python: C:\Users\a\scoop\apps\blender\current\2.92C:\Users\a\scoop\apps\blender\current\2.92\python => C:\Users\a\scoop\apps\blender\current\2.92C:\Users\a\scoop\apps\blender\current\2.92\original_python
  Creating bootstrap script: C:\Users\a\scoop\apps\blender\current\2.92C:\Users\a\scoop\apps\blender\current\2.92\scripts\startup\compas_bootstrapper.py

COMPAS for Blender 2.92 has been installed.
```

This fixes that..