### PR TITLE
Fixing recurring ipy build fails

### DIFF
--- a/.github/workflows/ironpython.yml
+++ b/.github/workflows/ironpython.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Install dependencies
         run: |
           choco install ironpython --version=2.7.8.1
+          curl -o ironpython-pytest.tar.gz -LJO https://pypi.debian.net/ironpython-pytest/latest
           ipy -X:Frames -m ensurepip
-          ipy -X:Frames -m pip install ironpython-pytest
+          ipy -X:Frames -m pip install --no-deps ironpython-pytest.tar.gz
       - name: Test import
         run: |
           ipy -m compas


### PR DESCRIPTION
Instead of letting the ancient pip available for IronPython do the downloading, which fails often and non-deterministically for reasons beyond human comprehension, we can download the tar files (via to the wonderful [Debian watch service](https://wiki.debian.org/debian/watch#PyPI)) and `pip install` those directly, which hopefully leads to less fails and more happiness.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
