### PR TITLE
Remove ghuser components on invoke clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,4 @@ data/ctralie
 .vscode
 
 # Grasshopper generated objects
-src/compas_ghpython/components/*.ghuser
+src/compas_ghpython/components/ghuser/*.ghuser

--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,4 @@ data/ctralie
 .vscode
 
 # Grasshopper generated objects
-src/compas_ghpython/components/ghuser/*.ghuser
+src/compas_ghpython/components/**/*.ghuser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Allow str or int as joint type in `compas.robots.Joint` constructor.
 * `compas_ghpython.artists.FrameArtist.draw` now draws a Rhino Plane.
+* Changed directory where ghuser components are installed.
+* Added ghuser components directory to those removed by the `clean` task.
 
 ### Removed
 

--- a/src/compas_ghpython/install.py
+++ b/src/compas_ghpython/install.py
@@ -18,6 +18,6 @@ def after_rhino_install(installed_packages):
     if 'compas_ghpython' not in installed_packages:
         return []
 
-    installed_objects = install_userobjects(os.path.join(os.path.dirname(__file__), 'components'))
+    installed_objects = install_userobjects(os.path.join(os.path.dirname(__file__), 'components', 'ghuser'))
 
     return [('compas_ghpython', 'Installed {} GH User Objects'.format(len(installed_objects)), True)]

--- a/tasks.py
+++ b/tasks.py
@@ -93,7 +93,7 @@ def clean(ctx, docs=True, bytecode=True, builds=True, ghuser=True):
             folders.append('src/compas.egg-info/')
 
         if ghuser:
-            folders.append('src/compas_fab/ghpython/components/ghuser')
+            folders.append('src/compas/ghpython/components/ghuser')
 
         for folder in folders:
             shutil.rmtree(os.path.join(BASE_FOLDER, folder), ignore_errors=True)

--- a/tasks.py
+++ b/tasks.py
@@ -62,7 +62,7 @@ def help(ctx):
     'docs': 'True to clean up generated documentation, otherwise False',
     'bytecode': 'True to clean up compiled python files, otherwise False.',
     'builds': 'True to clean up build/packaging artifacts, otherwise False.'})
-def clean(ctx, docs=True, bytecode=True, builds=True):
+def clean(ctx, docs=True, bytecode=True, builds=True, ghuser=True):
     """Cleans the local copy from compiled artifacts."""
 
     with chdir(BASE_FOLDER):
@@ -91,6 +91,9 @@ def clean(ctx, docs=True, bytecode=True, builds=True):
         if builds:
             folders.append('build/')
             folders.append('src/compas.egg-info/')
+
+        if ghuser:
+            folders.append('src/compas_fab/ghpython/components/ghuser')
 
         for folder in folders:
             shutil.rmtree(os.path.join(BASE_FOLDER, folder), ignore_errors=True)
@@ -192,7 +195,8 @@ def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None):
     """Build Grasshopper user objects from source"""
     with chdir(BASE_FOLDER):
         with tempfile.TemporaryDirectory('actions.ghcomponentizer') as action_dir:
-            target_dir = source_dir = os.path.abspath('src/compas_ghpython/components')
+            source_dir = os.path.abspath('src/compas_ghpython/components')
+            target_dir = os.path.join(source_dir, 'ghuser')
             ctx.run('git clone https://github.com/compas-dev/compas-actions.ghpython_components.git {}'.format(action_dir))
             if not gh_io_folder:
                 import compas_ghpython

--- a/tasks.py
+++ b/tasks.py
@@ -93,7 +93,7 @@ def clean(ctx, docs=True, bytecode=True, builds=True, ghuser=True):
             folders.append('src/compas.egg-info/')
 
         if ghuser:
-            folders.append('src/compas/ghpython/components/ghuser')
+            folders.append('src/compas_ghpython/components/ghuser')
 
         for folder in folders:
             shutil.rmtree(os.path.join(BASE_FOLDER, folder), ignore_errors=True)


### PR DESCRIPTION
When ghuser components have been created on the local machine, and then `invoke release` is called from that same local machine, there are manifest complaints.  This pull request adds the clean up of the ghuser components to the `clean` task, and for simplicity of that, moves the components down one file level to `src/compas_ghpython/components/ghuser`.  

Maybe this change should also be propagated to the the repository template. @brgcode what do you think?

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
