### PR TITLE
Clean up ghuser dir before building components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bugs in `compas.geometry.bestfit_circle_numpy`.
 * Changed directory where ghuser components are installed.
 * Added ghuser components directory to those removed by the `clean` task.
+* Clean up the ghuser directory before building ghuser components.
 
 ### Removed
 

--- a/tasks.py
+++ b/tasks.py
@@ -193,6 +193,7 @@ def prepare_changelog(ctx):
       'ironpython': 'Command for running the IronPython executable. Defaults to `ipy`.'})
 def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None):
     """Build Grasshopper user objects from source"""
+    clean(ctx, docs=False, bytecode=False, builds=False, ghuser=True)
     with chdir(BASE_FOLDER):
         with tempfile.TemporaryDirectory('actions.ghcomponentizer') as action_dir:
             source_dir = os.path.abspath('src/compas_ghpython/components')


### PR DESCRIPTION
The componentizer action expects that there are no directories in the component directories outside of the actual components (I'm not sure of the vocabulary here.  Everything seems to be called a component.)  So, when `invoke build_ghuser_components` is called when the `ghuser` folder exists there, an error is raised.  This PR is to remove that folder at the start of the `build_ghuser_components` task.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
