### PR TITLE
Normalize axis on initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* `compas.robots.Axis` is now normalized upon initialization.
 
 ### Removed
 
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Fixed bundling of ghuser components
+* Fixed bundling of ghuser components.
 
 ### Removed
 
@@ -35,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added pluggable function `trimesh_principal_curvature` in `compas_rhino`.
 * Added `copy` and `deepcopy` functionality to `compas.robots.Configuration`.
 * Added grasshopper component for drawing a frame.
-* Added `draw_origin` and `draw_axes`
+* Added `draw_origin` and `draw_axes`.
 
 ### Changed
 

--- a/src/compas/robots/model/joint.py
+++ b/src/compas/robots/model/joint.py
@@ -317,6 +317,9 @@ class Axis(Data):
         # cannot attach _urdf_source to it due to __slots__
         super(Axis, self).__init__()
         xyz = _parse_floats(xyz)
+        xyz = Vector(*xyz)
+        if xyz.length != 0:
+            xyz.unitize()
         self.x = xyz[0]
         self.y = xyz[1]
         self.z = xyz[2]


### PR DESCRIPTION
Closes #864   In the URDF spec it says that the vector specifying the axis should be normalized.  But in our panda URDFs, some fixed joints are given an axis of "0 0 0".  So I normalize the vector so long as it is not the zero vector.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
