### PR TITLE
fix dr_numpy for np array inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * `compas.robots.Axis` is now normalized upon initialization.
+* Fixed a bug in `compas.numerical.dr_numpy` when using numpy array as inputs.
 
 ### Removed
 

--- a/src/compas/numerical/dr/dr_numpy.py
+++ b/src/compas/numerical/dr/dr_numpy.py
@@ -116,18 +116,19 @@ def dr_numpy(vertices, edges, fixed, loads, qpre,
     # --------------------------------------------------------------------------
     # input processing
     # --------------------------------------------------------------------------
-    if qpre is None:
-        qpre = zeros((num_e,), dtype=float)
-    if fpre is None:
-        fpre = zeros((num_e,), dtype=float)
-    if lpre is None:
-        lpre = zeros((num_e,), dtype=float)
-    if linit is None:
-        linit = zeros((num_e,), dtype=float)
-    if E is None:
-        E = zeros((num_e,), dtype=float)
-    if radius is None:
-        radius = zeros((num_e,), dtype=float)
+
+    def init_array(array, length):
+        if array is None or (isinstance(array, list) and len(array) == 0):
+            return zeros((length,), dtype=float)
+        else:
+            return array
+
+    qpre = init_array(qpre, num_e)
+    fpre = init_array(fpre, num_e)
+    lpre = init_array(lpre, num_e)
+    linit = init_array(linit, num_e)
+    E = init_array(E, num_e)
+    radius = init_array(radius, num_e)
     # --------------------------------------------------------------------------
     # attribute arrays
     # --------------------------------------------------------------------------

--- a/src/compas/numerical/dr/dr_numpy.py
+++ b/src/compas/numerical/dr/dr_numpy.py
@@ -116,12 +116,18 @@ def dr_numpy(vertices, edges, fixed, loads, qpre,
     # --------------------------------------------------------------------------
     # input processing
     # --------------------------------------------------------------------------
-    qpre = qpre or [0.0 for _ in range(num_e)]
-    fpre = fpre or [0.0 for _ in range(num_e)]
-    lpre = lpre or [0.0 for _ in range(num_e)]
-    linit = linit or [0.0 for _ in range(num_e)]
-    E = E or [0.0 for _ in range(num_e)]
-    radius = radius or [0.0 for _ in range(num_e)]
+    if qpre is None:
+        qpre = zeros((num_e,), dtype=float)
+    if fpre is None:
+        fpre = zeros((num_e,), dtype=float)
+    if lpre is None:
+        lpre = zeros((num_e,), dtype=float)
+    if linit is None:
+        linit = zeros((num_e,), dtype=float)
+    if E is None:
+        E = zeros((num_e,), dtype=float)
+    if radius is None:
+        radius = zeros((num_e,), dtype=float)
     # --------------------------------------------------------------------------
     # attribute arrays
     # --------------------------------------------------------------------------

--- a/src/compas/numerical/dr/dr_numpy.py
+++ b/src/compas/numerical/dr/dr_numpy.py
@@ -120,8 +120,7 @@ def dr_numpy(vertices, edges, fixed, loads, qpre,
     def init_array(array, length):
         if array is None or len(array) == 0:
             return zeros((length,), dtype=float)
-        else:
-            return array
+        return array
 
     qpre = init_array(qpre, num_e)
     fpre = init_array(fpre, num_e)

--- a/src/compas/numerical/dr/dr_numpy.py
+++ b/src/compas/numerical/dr/dr_numpy.py
@@ -118,7 +118,7 @@ def dr_numpy(vertices, edges, fixed, loads, qpre,
     # --------------------------------------------------------------------------
 
     def init_array(array, length):
-        if array is None or (isinstance(array, list) and len(array) == 0):
+        if array is None or len(array) == 0:
             return zeros((length,), dtype=float)
         else:
             return array


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

When inputs like `qpre` `fpre` `lpre` are given as numpy array, direct evaluation of these variables will throw error below:
```
Traceback (most recent call last):
  File "d:/Github/compas_cloud/examples/dr_numpy_test.py", line 99, in <module>
    kmax=100, callback=callback)
  File "d:\github\compas\src\compas\numerical\dr\dr_numpy.py", line 119, in dr_numpy
    qpre = qpre or [0.0 for _ in range(num_e)]
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

The fix is to check explicitly if these variables are `None`, if so then initiate them.