### PR TITLE
Fix backward compatibility for Configuration.from_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * `compas.robots.Axis` is now normalized upon initialization.
 
+### Fixed
+* Fixed `Configuration.from_data` to be backward-compatible with JSON data generated before `compas 1.3.0`
+
 ### Removed
 
 

--- a/src/compas/robots/configuration.py
+++ b/src/compas/robots/configuration.py
@@ -324,8 +324,8 @@ class Configuration(Data):
 
     @data.setter
     def data(self, data):
-        self._joint_values = FixedLengthList(data.get('joint_values') or [])
-        self._joint_types = FixedLengthList(data.get('joint_types') or [])
+        self._joint_values = FixedLengthList(data.get('joint_values') or data.get('values') or [])
+        self._joint_types = FixedLengthList(data.get('joint_types') or data.get('types') or [])
         self._joint_names = FixedLengthList(data.get('joint_names') or [])
 
     @property


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

This PR includes a small fix to make `compas.robots.Configuration`'s `from_data` compatible with json data generated from compas 1.0, before the `Configuration` class attributes `values` and `types` are changed to `joint_values` and `joint_types`.

While I am very eager to try out all the exciting features introduced in `compas 1.7`, I found upgrading the version turned all of my previously saved configuration data unparsable. I understand that we cannot keep compatible with everything in the past, but I found being backward-compatible for a longer time period can be very beneficial.

This PR is related to https://github.com/compas-dev/compas_fab/pull/311.

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
