### PR TITLE
GitHub loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * `compas.robots.Axis` is now normalized upon initialization.
 * Fixed a bug in `compas.numerical.dr_numpy` when using numpy array as inputs.
-* `compas.robots.GithubPackageMeshLoader` allows for varying repository file structures.
+* Allowed for varying repository file structures in `compas.robots.GithubPackageMeshLoader`.
 
 ### Fixed
 * Fixed `Configuration.from_data` to be backward-compatible with JSON data generated before `compas 1.3.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * `compas.robots.Axis` is now normalized upon initialization.
+* `compas.robots.GithubPackageMeshLoader` allows for varying repository file structures.
 
 ### Fixed
-* Fixed `Configuration.from_data` to be backward-compatible with JSON data generated before `compas 1.3.0`
+* Fixed `Configuration.from_data` to be backward-compatible with JSON data generated before `compas 1.3.0`.
 
 ### Removed
 


### PR DESCRIPTION
Closes #861  I used the following script to expose the issue and fix it:
```
import compas
from compas.robots import GithubPackageMeshLoader
from compas.robots import RobotModel
from compas_rhino.artists import RobotModelArtist

# Set high precision to import meshes defined in meters
compas.PRECISION = '12f'

# Select Github repository, package and branch where the model is stored
# abb arm model
abb_repository = 'gramaziokohler/abb_irb4600_40_255'
abb_package = 'abb_irb4600_40_255'
abb_branch = 'master'
abb_github = GithubPackageMeshLoader(abb_repository, abb_package, abb_branch, '.')
abb_urdf = abb_github.load_urdf('abb_irb4600_40_255.urdf')


# rfl model
rfl_repository = 'gramaziokohler/rfl_description'
rfl_package = 'rfl_description'
rfl_branch = 'master'
rfl_github = GithubPackageMeshLoader(rfl_repository, rfl_package, rfl_branch)
rfl_urdf = rfl_github.load_urdf('rfl.urdf')


# Create robot model from URDF
model = RobotModel.from_urdf_file(rfl_urdf)

# Also load geometry
model.load_geometry(rfl_github, abb_github)

artist = RobotModelArtist(model)
artist.draw()
```

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
