### PR TITLE
rename "latest" folder to "dev"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: compas-dev/compas-actions.docs@v1.0.0
+      - uses: compas-dev/compas-actions.docs@v1.2.0
         id: docs
         with:
           dest: deploy
@@ -47,7 +47,7 @@ jobs:
         with:
           ref: gh-pages
 
-      - uses: compas-dev/compas-actions.docversions@v1.0.0
+      - uses: compas-dev/compas-actions.docversions@v1.2.0
         with:
           current_patch: ${{ needs.build.outputs.current_patch }}
 


### PR DESCRIPTION
On docs site, rename "latest" to "dev", so it's not confused with "latest published release"
https://github.com/compas-dev/compas-actions.docversions/commit/cd72b42c96d92b35d8503af71c21566ee6df2bc2
https://github.com/compas-dev/compas-actions.docs/commit/9cd3d12e634bf698c5280e4e833cd614bb97edc5