### PR TITLE
Point docs site by default to latest release instead of dev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: compas-dev/compas-actions.docs@v1.2.0
+      - uses: compas-dev/compas-actions.docs@v1.2.1
         id: docs
         with:
           dest: deploy


### PR DESCRIPTION
https://github.com/compas-dev/compas-actions.docs/commit/a9742e43bc1c4d8891ff14d146b7aed173856c23
Index.html will be updated each time when a version is uploaded. 