### PR TITLE
Artist factory plugins

### DIFF
--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -393,8 +393,8 @@ There are a few additional options that plugins can use:
 * ``requires``: List of requirements. COMPAS will filter out plugins if their
   requirements list is not satisfied at runtime. This allows to have multiple implementations
   of the same operation and have them selected based on different criteria.
-  The requirement can either be a packages name string (e.g. ``requires=['scipy']``) or
-  a ``callable``, in which any arbitrary check can be implemented
+  The requirement can either be a package name string (e.g. ``requires=['scipy']``) or
+  a ``callable`` with a boolean return value, in which any arbitrary check can be implemented
   (e.g. ``requires=[lambda: is_rhino_active()]``).
 * ``tryfirst`` and ``trylast``: Plugins cannot control the exact priority they will have
   but they can indicate whether to try to prioritize them or demote them as fallback using

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -390,10 +390,12 @@ Advanced options
 
 There are a few additional options that plugins can use:
 
-* ``requires``: List of required python modules. COMPAS will filter out plugins if their
+* ``requires``: List of requirements. COMPAS will filter out plugins if their
   requirements list is not satisfied at runtime. This allows to have multiple implementations
-  of the same operation and have them selected based on which packages are installed.
-  on the system. Eg. `requires=['scipy']`.
+  of the same operation and have them selected based on different criteria.
+  The requirement can either be a packages name string (e.g. ``requires=['scipy']``) or
+  a ``callable``, in which any arbitrary check can be implemented
+  (e.g. ``requires=[lambda: is_rhino_active()]``).
 * ``tryfirst`` and ``trylast``: Plugins cannot control the exact priority they will have
   but they can indicate whether to try to prioritize them or demote them as fallback using
   these two boolean parameters.

--- a/src/compas/plugins.py
+++ b/src/compas/plugins.py
@@ -323,9 +323,9 @@ def plugin(method=None, category=None, requires=None, tryfirst=False, trylast=Fa
         An optional string to group or categorize plugins.
     requires : list, optional
         Optionally defines a list of requirements that should be fulfilled
-        for this plugin to be used. The requirement can either be a packages
-        name (``str``) or a ``callable``, in which any arbitrary check can be
-        implemented.
+        for this plugin to be used. The requirement can either be a package
+        name (``str``) or a ``callable`` with a boolean return value,
+        in which any arbitrary check can be implemented.
     tryfirst : bool, optional
         Plugins can declare a preferred priority by setting this to ``True``.
         By default ``False``.

--- a/src/compas/plugins.py
+++ b/src/compas/plugins.py
@@ -321,9 +321,11 @@ def plugin(method=None, category=None, requires=None, tryfirst=False, trylast=Fa
         The method to decorate as ``plugin``.
     category : str, optional
         An optional string to group or categorize plugins.
-    requires : list of str, optional
-        Optionally defines a list of packages that should be importable
-        for this plugin to be used.
+    requires : list, optional
+        Optionally defines a list of requirements that should be fulfilled
+        for this plugin to be used. The requirement can either be a packages
+        name (``str``) or a ``callable``, in which any arbitrary check can be
+        implemented.
     tryfirst : bool, optional
         Plugins can declare a preferred priority by setting this to ``True``.
         By default ``False``.
@@ -414,9 +416,16 @@ class Importer(object):
         return self._cache[module_name]
 
 
+def verify_requirement(manager, requirement):
+    if callable(requirement):
+        return requirement()
+
+    return manager.importer.check_importable(requirement)
+
+
 def is_plugin_selectable(plugin, manager):
     if plugin.opts['requires']:
-        importable_requirements = (manager.importer.check_importable(name) for name in plugin.opts['requires'])
+        importable_requirements = (verify_requirement(manager, requirement) for requirement in plugin.opts['requires'])
 
         if not all(importable_requirements):
             if manager.DEBUG:

--- a/src/compas_ghpython/__init__.py
+++ b/src/compas_ghpython/__init__.py
@@ -69,5 +69,9 @@ def _get_grasshopper_special_folder(version, folder_name):
     return grasshopper_library_path
 
 
-__all_plugins__ = ['compas_ghpython.install', 'compas_ghpython.uninstall']
+__all_plugins__ = [
+    'compas_ghpython.install',
+    'compas_ghpython.uninstall',
+    'compas_ghpython.artists',
+]
 __all__ = [name for name in dir() if not name.startswith('_')]

--- a/src/compas_ghpython/artists/__init__.py
+++ b/src/compas_ghpython/artists/__init__.py
@@ -71,6 +71,8 @@ from compas.datastructures import Mesh
 from compas.datastructures import Network
 from compas.datastructures import VolMesh
 
+from compas.robots import RobotModel
+
 from .artist import GHArtist
 from .circleartist import CircleArtist
 from .frameartist import FrameArtist
@@ -121,6 +123,7 @@ def new_artist_gh(cls, *args, **kwargs):
     GHArtist.register(Mesh, MeshArtist)
     GHArtist.register(Network, NetworkArtist)
     GHArtist.register(VolMesh, VolMeshArtist)
+    GHArtist.register(RobotModel, RobotModelArtist)
 
     data = args[0]
 

--- a/src/compas_ghpython/artists/__init__.py
+++ b/src/compas_ghpython/artists/__init__.py
@@ -99,7 +99,17 @@ VolMeshArtist.default_facecolor = (255, 255, 255)
 VolMeshArtist.default_cellcolor = (255, 0, 0)
 
 
-@plugin(category='factories', pluggable_name='new_artist', requires=['ghpythonlib'])
+def verify_gh_context():
+    try:
+        import Rhino
+        import scriptcontext as sc
+
+        return not isinstance(sc.doc, Rhino.RhinoDoc)
+    except:
+        return False
+
+
+@plugin(category='factories', pluggable_name='new_artist', requires=['ghpythonlib', verify_gh_context])
 def new_artist_gh(cls, *args, **kwargs):
     # "lazy registration" seems necessary to avoid item-artist pairs to be overwritten unintentionally
 
@@ -127,7 +137,7 @@ def new_artist_gh(cls, *args, **kwargs):
     for name, value in inspect.getmembers(cls):
         if inspect.ismethod(value):
             if hasattr(value, '__isabstractmethod__'):
-                raise Exception('Abstract method not implemented')
+                raise Exception('Abstract method not implemented: {}'.format(value))
 
     return super(Artist, cls).__new__(cls)
 

--- a/src/compas_rhino/artists/__init__.py
+++ b/src/compas_rhino/artists/__init__.py
@@ -141,7 +141,17 @@ VolMeshArtist.default_facecolor = (255, 255, 255)
 VolMeshArtist.default_cellcolor = (255, 0, 0)
 
 
-@plugin(category='factories', pluggable_name='new_artist', requires=['Rhino'])
+def verify_rhino_context():
+    try:
+        import Rhino
+        import scriptcontext as sc
+
+        return isinstance(sc.doc, Rhino.RhinoDoc)
+    except:
+        return False
+
+
+@plugin(category='factories', pluggable_name='new_artist', requires=['Rhino', verify_rhino_context])
 def new_artist_rhino(cls, *args, **kwargs):
     # "lazy registration" seems necessary to avoid item-artist pairs to be overwritten unintentionally
 
@@ -180,7 +190,7 @@ def new_artist_rhino(cls, *args, **kwargs):
     for name, value in inspect.getmembers(cls):
         if inspect.ismethod(value):
             if hasattr(value, '__isabstractmethod__'):
-                raise Exception('Abstract method not implemented')
+                raise Exception('Abstract method not implemented: {}'.format(value))
 
     return super(Artist, cls).__new__(cls)
 


### PR DESCRIPTION
Changed the plugin system to allow defining runtime selection based on arbitrary conditions, used that to select between rhino and ghpython artists, and fixed a few missing bits about Ghpython artists.

The ghpython artists still don't all work as expected, in particular, the "canonical" mesh artist example from all our slides fails because ghpython's meshartist is missing some abstract method implementations (`clear*` stuff). Robot and Frame artists work. I didn't test much more thou. I didn't test blender either. 