### PR TITLE
Fix volmesh constructor from data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed bug in constructor `@data.setter` in `compas.datastructures.HalfFace`.
 * Fixed bug in `compas_blender.draw_texts`.
 * Changed default resolution for shape discretisation to 16 for both u and v where relevant.
 * Changed base class of `compas.geometry.Primitive` and `compas.geometry.Shape` to `compas.geometry.Geometry`.

--- a/src/compas/datastructures/halfface/halfface.py
+++ b/src/compas/datastructures/halfface/halfface.py
@@ -161,6 +161,7 @@ class HalfFace(Datastructure):
         dfa = data.get('dfa') or {}
         dca = data.get('dca') or {}
         vertex = data.get('vertex') or {}
+        halfface = data.get('halfface') or {}
         cell = data.get('cell') or {}
         edge_data = data.get('edge_data') or {}
         face_data = data.get('face_data') or {}
@@ -190,12 +191,17 @@ class HalfFace(Datastructure):
             attr = vertex[v] or {}
             self.add_vertex(int(v), attr_dict=attr)
 
+        for f in halfface:
+            attr = face_data.get(f) or {}
+            self.add_halfface(halfface[f], fkey=int(f), attr_dict=attr)
+
         for c in cell:
             attr = cell_data.get(c) or {}
             faces = []
             for u in cell[c]:
                 for v in cell[c][u]:
-                    faces.append(cell[c][u][v])
+                    f = cell[c][u][v]
+                    faces.append(halfface[str(f)])
             self.add_cell(faces, ckey=int(c), attr_dict=attr)
 
         for e in edge_data:


### PR DESCRIPTION
The default VolMesh (halfface.py) constructor from data failed.
The @data.setter called add_cell() with a flat list of vertices, where a nested list of vertices per face was expected.
Internal halfface dictionary was not being set in the constructor call.

resolves issue #905.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
