### PR TITLE
Ghpython moar artists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `compas_blender.artists.RobotModelArtist.clear`.
 * Added `compas_blender.geometry.booleans` as plugin for boolean pluggables.
 * Added version-based installation for Blender.
+* Added several shape artists to `compas_ghpython`: `BoxArtist`, `CapsuleArtist`, `ConeArtist`, `CylinderArtist`, `PolygonArtist`, `PolyhedronArtist`, `SphereArtist`, `TorusArtist` and `VectorArtist`.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Generalized the parameter `color` of `compas_blender.draw_texts` and various label drawing methods.
 * Changed `compas.IPY` to `compas.RHINO` in `orientation_rhino`.
 * Changed `planarity` to `requires_extra` for pip installations.
+* Fixed bug in handling of ngonal meshes in `compas_ghpython` artists / drawing functions.
 
 ### Removed
 

--- a/src/compas_ghpython/artists/__init__.py
+++ b/src/compas_ghpython/artists/__init__.py
@@ -13,11 +13,20 @@ Primitive Artists
     :toctree: generated/
     :nosignatures:
 
+    BoxArtist
+    CapsuleArtist
     CircleArtist
+    ConeArtist
+    CylinderArtist
     FrameArtist
     LineArtist
     PointArtist
+    PolygonArtist
+    PolyhedronArtist
     PolylineArtist
+    SphereArtist
+    TorusArtist
+    VectorArtist
 
 
 Datastructure Artists
@@ -61,11 +70,20 @@ from compas.artists import Artist
 from compas.artists import ShapeArtist
 from compas.artists import DataArtistNotRegistered
 
+from compas.geometry import Box
+from compas.geometry import Capsule
 from compas.geometry import Circle
+from compas.geometry import Cone
+from compas.geometry import Cylinder
 from compas.geometry import Frame
 from compas.geometry import Line
 from compas.geometry import Point
+from compas.geometry import Polygon
+from compas.geometry import Polyhedron
 from compas.geometry import Polyline
+from compas.geometry import Sphere
+from compas.geometry import Torus
+from compas.geometry import Vector
 
 from compas.datastructures import Mesh
 from compas.datastructures import Network
@@ -74,15 +92,24 @@ from compas.datastructures import VolMesh
 from compas.robots import RobotModel
 
 from .artist import GHArtist
+from .boxartist import BoxArtist
+from .capsuleartist import CapsuleArtist
 from .circleartist import CircleArtist
+from .coneartist import ConeArtist
+from .cylinderartist import CylinderArtist
 from .frameartist import FrameArtist
 from .lineartist import LineArtist
-from .pointartist import PointArtist
-from .polylineartist import PolylineArtist
 from .meshartist import MeshArtist
 from .networkartist import NetworkArtist
-from .volmeshartist import VolMeshArtist
+from .pointartist import PointArtist
+from .polygonartist import PolygonArtist
+from .polyhedronartist import PolyhedronArtist
+from .polylineartist import PolylineArtist
 from .robotmodelartist import RobotModelArtist
+from .sphereartist import SphereArtist
+from .torusartist import TorusArtist
+from .vectorartist import VectorArtist
+from .volmeshartist import VolMeshArtist
 
 ShapeArtist.default_color = (255, 255, 255)
 
@@ -120,15 +147,24 @@ def new_artist_gh(cls, *args, **kwargs):
     global artists_registered
 
     if not artists_registered:
+        GHArtist.register(Box, BoxArtist)
+        GHArtist.register(Capsule, CapsuleArtist)
         GHArtist.register(Circle, CircleArtist)
+        GHArtist.register(Cone, ConeArtist)
+        GHArtist.register(Cylinder, CylinderArtist)
         GHArtist.register(Frame, FrameArtist)
         GHArtist.register(Line, LineArtist)
-        GHArtist.register(Point, PointArtist)
-        GHArtist.register(Polyline, PolylineArtist)
         GHArtist.register(Mesh, MeshArtist)
         GHArtist.register(Network, NetworkArtist)
-        GHArtist.register(VolMesh, VolMeshArtist)
+        GHArtist.register(Point, PointArtist)
+        GHArtist.register(Polygon, PolygonArtist)
+        GHArtist.register(Polyhedron, PolyhedronArtist)
+        GHArtist.register(Polyline, PolylineArtist)
         GHArtist.register(RobotModel, RobotModelArtist)
+        GHArtist.register(Sphere, SphereArtist)
+        GHArtist.register(Torus, TorusArtist)
+        GHArtist.register(Vector, VectorArtist)
+        GHArtist.register(VolMesh, VolMeshArtist)
         artists_registered = True
 
     data = args[0]
@@ -155,13 +191,22 @@ __all__ = [
     'GHArtist',
     'PrimitiveArtist',
     'ShapeArtist',
+    'BoxArtist',
+    'CapsuleArtist',
     'CircleArtist',
+    'ConeArtist',
+    'CylinderArtist',
     'FrameArtist',
     'LineArtist',
-    'PointArtist',
-    'PolylineArtist',
     'MeshArtist',
     'NetworkArtist',
-    'VolMeshArtist',
+    'PointArtist',
+    'PolygonArtist',
+    'PolyhedronArtist',
+    'PolylineArtist',
     'RobotModelArtist'
+    'SphereArtist',
+    'TorusArtist',
+    'VectorArtist',
+    'VolMeshArtist',
 ]

--- a/src/compas_ghpython/artists/__init__.py
+++ b/src/compas_ghpython/artists/__init__.py
@@ -189,7 +189,6 @@ def new_artist_gh(cls, *args, **kwargs):
 
 __all__ = [
     'GHArtist',
-    'PrimitiveArtist',
     'ShapeArtist',
     'BoxArtist',
     'CapsuleArtist',

--- a/src/compas_ghpython/artists/boxartist.py
+++ b/src/compas_ghpython/artists/boxartist.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import ShapeArtist
+from .artist import GHArtist
+
+
+class BoxArtist(GHArtist, ShapeArtist):
+    """Artist for drawing box shapes.
+
+    Parameters
+    ----------
+    box : :class:`compas.geometry.Box`
+        A COMPAS box.
+    """
+
+    def __init__(self, box, **kwargs):
+        super(BoxArtist, self).__init__(shape=box, **kwargs)
+
+    def draw(self, color=None):
+        """Draw the box associated with the artist.
+
+        Parameters
+        ----------
+        color : tuple of float, optional
+            The RGB color of the box.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.color
+        vertices = [list(vertex) for vertex in self.shape.vertices]
+        faces = self.shape.faces
+        mesh = compas_ghpython.draw_mesh(vertices,
+                                         faces,
+                                         color=color)
+        return mesh

--- a/src/compas_ghpython/artists/capsuleartist.py
+++ b/src/compas_ghpython/artists/capsuleartist.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import ShapeArtist
+from .artist import GHArtist
+
+
+class CapsuleArtist(GHArtist, ShapeArtist):
+    """Artist for drawing capsule shapes.
+
+    Parameters
+    ----------
+    capsule : :class:`compas.geometry.Capsule`
+        A COMPAS capsule.
+    """
+
+    def __init__(self, capsule, **kwargs):
+        super(CapsuleArtist, self).__init__(shape=capsule, **kwargs)
+
+    def draw(self, color=None, u=None, v=None):
+        """Draw the capsule associated with the artist.
+
+        Parameters
+        ----------
+        color : tuple of float, optional
+            The RGB color of the capsule.
+        u : int, optional
+            Number of faces in the "u" direction.
+            Default is ``~CapsuleArtist.u``.
+        v : int, optional
+            Number of faces in the "v" direction.
+            Default is ``~CapsuleArtist.v``.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.color
+        u = u or self.u
+        v = v or self.v
+        vertices, faces = self.shape.to_vertices_and_faces(u=u, v=v)
+        vertices = [list(vertex) for vertex in vertices]
+        mesh = compas_ghpython.draw_mesh(vertices,
+                                         faces,
+                                         color=color)
+        return mesh

--- a/src/compas_ghpython/artists/coneartist.py
+++ b/src/compas_ghpython/artists/coneartist.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import ShapeArtist
+from .artist import GHArtist
+
+
+class ConeArtist(GHArtist, ShapeArtist):
+    """Artist for drawing cone shapes.
+
+    Parameters
+    ----------
+    shape : :class:`compas.geometry.Cone`
+        A COMPAS cone.
+    """
+
+    def __init__(self, cone, **kwargs):
+        super(ConeArtist, self).__init__(shape=cone, **kwargs)
+
+    def draw(self, color=None, u=None):
+        """Draw the cone associated with the artist.
+
+        Parameters
+        ----------
+        color : tuple of float, optional
+            The RGB color of the cone.
+        u : int, optional
+            Number of faces in the "u" direction.
+            Default is ``~ConeArtist.u``.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.color
+        u = u or self.u
+        vertices, faces = self.shape.to_vertices_and_faces(u=u)
+        vertices = [list(vertex) for vertex in vertices]
+        mesh = compas_ghpython.draw_mesh(vertices,
+                                         faces,
+                                         color=color)
+        return mesh

--- a/src/compas_ghpython/artists/cylinderartist.py
+++ b/src/compas_ghpython/artists/cylinderartist.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import ShapeArtist
+from .artist import GHArtist
+
+
+class CylinderArtist(GHArtist, ShapeArtist):
+    """Artist for drawing cylinder shapes.
+
+    Parameters
+    ----------
+    cylinder : :class:`compas.geometry.Cylinder`
+        A COMPAS cylinder.
+    """
+
+    def __init__(self, cylinder, **kwargs):
+        super(CylinderArtist, self).__init__(shape=cylinder, **kwargs)
+
+    def draw(self, color=None, u=None):
+        """Draw the cylinder associated with the artist.
+
+        Parameters
+        ----------
+        color : tuple of float, optional
+            The RGB color of the cylinder.
+        u : int, optional
+            Number of faces in the "u" direction.
+            Default is ``~CylinderArtist.u``.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.color
+        u = u or self.u
+        vertices, faces = self.shape.to_vertices_and_faces(u=u)
+        vertices = [list(vertex) for vertex in vertices]
+        mesh = compas_ghpython.draw_mesh(vertices,
+                                         faces,
+                                         color=color)
+        return mesh

--- a/src/compas_ghpython/artists/polygonartist.py
+++ b/src/compas_ghpython/artists/polygonartist.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import PrimitiveArtist
+from .artist import GHArtist
+
+
+class PolygonArtist(GHArtist, PrimitiveArtist):
+    """Artist for drawing polygons.
+
+    Parameters
+    ----------
+    polygon : :class:`compas.geometry.Polygon`
+        A COMPAS polygon.
+    """
+
+    def __init__(self, polygon, **kwargs):
+        super(PolygonArtist, self).__init__(primitive=polygon, **kwargs)
+
+    def draw(self, show_points=False, show_edges=False, show_face=True):
+        """Draw the polygon.
+
+        Parameters
+        ----------
+        show_points : bool, optional
+            Default is ``False``.
+        show_edges : bool, optional
+            Default is ``False``.
+        show_face : bool, optional
+            Default is ``True``.
+
+        Returns
+        -------
+        list
+            The Rhino points, lines and faces.
+        """
+        _points = map(list, self.primitive.points)
+        result = []
+        if show_points:
+            points = [{'pos': point, 'color': self.color, 'name': self.primitive.name} for point in _points]
+            result += compas_ghpython.draw_points(points)
+        if show_edges:
+            lines = [{'start': list(a), 'end': list(b), 'color': self.color, 'name': self.primitive.name} for a, b in self.primitive.lines]
+            result += compas_ghpython.draw_lines(lines)
+        if show_face:
+            polygons = [{'points': _points, 'color': self.color, 'name': self.primitive.name}]
+            result += compas_ghpython.draw_faces(polygons)
+        return result

--- a/src/compas_ghpython/artists/polygonartist.py
+++ b/src/compas_ghpython/artists/polygonartist.py
@@ -34,7 +34,7 @@ class PolygonArtist(GHArtist, PrimitiveArtist):
         Returns
         -------
         list
-            The Rhino points, lines and faces.
+            The Rhino points, lines and face.
         """
         _points = map(list, self.primitive.points)
         result = []

--- a/src/compas_ghpython/artists/polyhedronartist.py
+++ b/src/compas_ghpython/artists/polyhedronartist.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import ShapeArtist
+from .artist import GHArtist
+
+
+class PolyhedronArtist(GHArtist, ShapeArtist):
+    """Artist for drawing polyhedron shapes.
+
+    Parameters
+    ----------
+    polyhedron : :class:`compas.geometry.Polyhedron`
+        A COMPAS polyhedron.
+    """
+
+    def __init__(self, polyhedron, **kwargs):
+        super(PolyhedronArtist, self).__init__(shape=polyhedron, **kwargs)
+
+    def draw(self, color=None):
+        """Draw the polyhedron associated with the artist.
+
+        Parameters
+        ----------
+        color : tuple of float, optional
+            The RGB color of the polyhedron.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.color
+        vertices = [list(vertex) for vertex in self.shape.vertices]
+        faces = self.shape.faces
+        mesh = compas_ghpython.draw_mesh(vertices,
+                                         faces,
+                                         color=color)
+        return mesh

--- a/src/compas_ghpython/artists/sphereartist.py
+++ b/src/compas_ghpython/artists/sphereartist.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import ShapeArtist
+from .artist import GHArtist
+
+
+class SphereArtist(GHArtist, ShapeArtist):
+    """Artist for drawing sphere shapes.
+
+    Parameters
+    ----------
+    sphere : :class:`compas.geometry.Sphere`
+        A COMPAS sphere.
+    """
+
+    def __init__(self, sphere, **kwargs):
+        super(SphereArtist, self).__init__(shape=sphere, **kwargs)
+
+    def draw(self, color=None, u=None, v=None):
+        """Draw the sphere associated with the artist.
+
+        Parameters
+        ----------
+        color : tuple of float, optional
+            The RGB color of the sphere.
+        u : int, optional
+            Number of faces in the "u" direction.
+            Default is ``~SphereArtist.u``.
+        v : int, optional
+            Number of faces in the "v" direction.
+            Default is ``~SphereArtist.v``.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.color
+        u = u or self.u
+        v = v or self.v
+        vertices, faces = self.shape.to_vertices_and_faces(u=u, v=v)
+        vertices = [list(vertex) for vertex in vertices]
+        mesh = compas_ghpython.draw_mesh(vertices,
+                                         faces,
+                                         color=color)
+        return mesh

--- a/src/compas_ghpython/artists/torusartist.py
+++ b/src/compas_ghpython/artists/torusartist.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas_ghpython
+from compas.artists import ShapeArtist
+from .artist import GHArtist
+
+
+class TorusArtist(GHArtist, ShapeArtist):
+    """Artist for drawing torus shapes.
+
+    Parameters
+    ----------
+    torus : :class:`compas.geometry.Torus`
+        A COMPAS torus.
+    """
+
+    def __init__(self, torus, **kwargs):
+        super(TorusArtist, self).__init__(shape=torus,  **kwargs)
+
+    def draw(self, color=None, u=None, v=None):
+        """Draw the torus associated with the artist.
+
+        Parameters
+        ----------
+        color : tuple of float, optional
+            The RGB color of the torus.
+        u : int, optional
+            Number of faces in the "u" direction.
+            Default is ``~TorusArtist.u``.
+        v : int, optional
+            Number of faces in the "v" direction.
+            Default is ``~TorusArtist.v``.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.color
+        u = u or self.u
+        v = v or self.v
+        vertices, faces = self.shape.to_vertices_and_faces(u=u, v=v)
+        vertices = [list(vertex) for vertex in vertices]
+        mesh = compas_ghpython.draw_mesh(vertices,
+                                         faces,
+                                         color=color)
+        return mesh

--- a/src/compas_ghpython/artists/vectorartist.py
+++ b/src/compas_ghpython/artists/vectorartist.py
@@ -33,7 +33,7 @@ class VectorArtist(GHArtist, PrimitiveArtist):
         Returns
         -------
         list
-            The Rhino lines.
+            The Rhino line and endpoints, if requested.
 
         """
         if not point:

--- a/src/compas_ghpython/artists/vectorartist.py
+++ b/src/compas_ghpython/artists/vectorartist.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import compas_ghpython
+from compas.artists import PrimitiveArtist
+from compas.geometry import Point
+
+from .artist import GHArtist
+
+
+class VectorArtist(GHArtist, PrimitiveArtist):
+    """Artist for drawing vectors.
+
+    Parameters
+    ----------
+    vector : :class:`compas.geometry.Vector`
+        A COMPAS vector.
+    """
+
+    def __init__(self, vector, **kwargs):
+        super(VectorArtist, self).__init__(primitive=vector, **kwargs)
+
+    def draw(self, point=None, show_point=False):
+        """Draw the vector.
+
+        Parameters
+        ----------
+        point : [float, float, float] or :class:`compas.geometry.Point`, optional
+            Point of application of the vector.
+            Default is ``Point(0, 0, 0)``.
+
+        Returns
+        -------
+        list
+            The Rhino lines.
+
+        """
+        if not point:
+            point = [0, 0, 0]
+        start = Point(*point)
+        end = start + self.primitive
+        start = list(start)
+        end = list(end)
+        result = []
+        if show_point:
+            points = [{'pos': start, 'color': self.color, 'name': self.primitive.name}]
+            result += compas_ghpython.draw_points(points)
+        lines = [{'start': start, 'end': end, 'arrow': 'end', 'color': self.color, 'name': self.primitive.name}]
+        result += compas_ghpython.draw_lines(lines)
+        return result

--- a/src/compas_ghpython/utilities/drawing.py
+++ b/src/compas_ghpython/utilities/drawing.py
@@ -11,6 +11,9 @@ from System.Drawing import Color
 import rhinoscriptsyntax as rs
 import scriptcontext as sc
 
+from compas.geometry import centroid_points
+from compas.utilities import pairwise
+
 from Rhino.Geometry import Point3d
 from Rhino.Geometry import Vector3d
 from Rhino.Geometry import Line
@@ -25,6 +28,11 @@ from Rhino.Geometry import Sphere
 from Rhino.Geometry import Mesh
 from Rhino.Geometry import Vector3f
 from Rhino.Geometry import Point2f
+
+try:
+    from Rhino.Geometry import MeshNgon
+except ImportError:
+    MeshNgon = False
 
 TOL = sc.doc.ModelAbsoluteTolerance
 
@@ -374,10 +382,22 @@ def draw_mesh(vertices, faces, color=None, vertex_normals=None, texture_coordina
     for a, b, c in vertices:
         mesh.Vertices.Add(a, b, c)
     for face in faces:
-        if len(face) < 4:
-            mesh.Faces.AddFace(face[0], face[1], face[2])
+        f = len(face)
+        if f < 3:
+            continue
+        if f == 3:
+            mesh.Faces.AddFace(*face)
+        elif f == 4:
+            mesh.Faces.AddFace(*face)
         else:
-            mesh.Faces.AddFace(face[0], face[1], face[2], face[3])
+            if MeshNgon:
+                centroid = centroid_points([vertices[index] for index in face])
+                c = mesh.Vertices.Add(*centroid)
+                facets = []
+                for i, j in pairwise(face + face[:1]):
+                    facets.append(mesh.Faces.AddFace(i, j, c))
+                ngon = MeshNgon.Create(face, facets)
+                mesh.Ngons.AddNgon(ngon)
 
     if vertex_normals:
         count = len(vertex_normals)
@@ -394,7 +414,7 @@ def draw_mesh(vertices, faces, color=None, vertex_normals=None, texture_coordina
         mesh.TextureCoordinates.SetTextureCoordinates(tcs)
 
     if color:
-        count = len(vertices)
+        count = len(mesh.Vertices)
         colors = CreateInstance(Color, count)
         for i in range(count):
             colors[i] = rs.coercecolor(color)


### PR DESCRIPTION
Added a bunch of missing Grasshopper python artists:
```markdown
Object      Artist              Rhino    Blender  GH       Plotters
------------------------------------------------------------------
Box         BoxArtist           [x]      [x]      [x]      [n/a]
Capsule     CapsuleArtist       [x]      [x]      [x]      [n/a]
Circle      CircleArtist        [x]      [ ]      [x]      [x]
Cone        ConeArtist          [x]      [x]      [x]      [n/a]
Cylinder    CylinderArtist      [x]      [x]      [x]      [n/a]
Ellipse     EllipseArtist       [ ]      [ ]      [ ]      [x]
Frame       FrameArtist         [x]      [x]      [x]      [n/a]
Line        LineArtist          [x]      [ ]      [x]      [x]
Mesh        MeshArtist          [x]      [x]      [x]      [x]
Network     NetworkArtist       [x]      [x]      [x]      [x]
Plane       PlaneArtist         [x]      [ ]      [ ]      [n/a]
Point       PointArtist         [x]      [ ]      [x]      [x]
Polygon     PolygonArtist       [x]      [ ]      [x]      [x]
Polyhedron  PolyhedronArtist    [x]      [x]      [x]      [n/a]
Polyline    PolylineArtist      [x]      [ ]      [x]      [x]
RobotModel  RobotModelArtist    [x]      [x]      [x]      [n/a]
Segment     SegmentArtist       [ ]      [ ]      [ ]      [x]
Sphere      SphereArtist        [x]      [x]      [x]      [n/a]
Torus       TorusArtist         [x]      [x]      [x]      [n/a]
Vector      VectorArtist        [x]      [ ]      [x]      [x]
VolMesh     VolMeshArtist       [x]      [x]      [x]      [n/a]
```

The artist test looks like this now:
![image](https://user-images.githubusercontent.com/933277/137000741-2e16a195-a996-4d6a-bf58-f388e90e0a92.png)

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
