### PR TITLE
Decode from CLR data types as well as python dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `compas_blender.geometry.booleans` as plugin for boolean pluggables.
 * Added version-based installation for Blender.
 * Added several shape artists to `compas_ghpython`: `BoxArtist`, `CapsuleArtist`, `ConeArtist`, `CylinderArtist`, `PolygonArtist`, `PolyhedronArtist`, `SphereArtist`, `TorusArtist` and `VectorArtist`.
-
+* Added support for CLR generic dictionaries to the `compas.data` decoders.
 
 ### Changed
 

--- a/src/compas/data/encoders.py
+++ b/src/compas/data/encoders.py
@@ -3,8 +3,18 @@ from __future__ import absolute_import
 from __future__ import division
 
 import json
+import sys
 
 from compas.data.exceptions import DecoderError
+
+# We don't do this from `compas.IPY` to avoid circular imports
+if 'ironpython' in sys.version.lower():
+    try:
+        from System.Collections.Generic import IDictionary
+    except:
+        IDictionary = None
+else:
+    IDictionary = None
 
 
 def cls_from_dtype(dtype):
@@ -102,4 +112,10 @@ class DataDecoder(json.JSONDecoder):
         except AttributeError:
             raise DecoderError("The data type can't be found in the specified module: {}.".format(o['dtype']))
 
-        return cls.from_data(o['value'])
+        obj_value = o['value']
+
+        # Kick-off from_data from a rebuilt Python dictionary instead of the C# data type
+        if IDictionary and isinstance(o, IDictionary[str, object]):
+            obj_value = {key: obj_value[key] for key in obj_value.Keys}
+
+        return cls.from_data(obj_value)

--- a/src/compas/data/encoders.py
+++ b/src/compas/data/encoders.py
@@ -11,7 +11,7 @@ from compas.data.exceptions import DecoderError
 if 'ironpython' in sys.version.lower():
     try:
         from System.Collections.Generic import IDictionary
-    except:
+    except:                 # noqa: E722
         IDictionary = None
 else:
     IDictionary = None


### PR DESCRIPTION
This PR makes the decoder of `compas.data` compatible with CLR generics dictionaries (such as the ones returned by the Speckle deserialization).

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
