### PR TITLE
Add draw_mesh to gh python artist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `draw_mesh` method to `compas_ghpython.artists.MeshArtist` to match all other mesh artists.
+
 ### Changed
 
 * Changed new artist registration to check if subclass.

--- a/src/compas/artists/meshartist.py
+++ b/src/compas/artists/meshartist.py
@@ -327,6 +327,10 @@ class MeshArtist(Artist):
         raise NotImplementedError
 
     @abstractmethod
+    def draw_mesh(self):
+        raise NotImplementedError
+
+    @abstractmethod
     def clear_vertices(self):
         raise NotImplementedError
 

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -57,7 +57,7 @@ class MeshArtist(GHArtist, MeshArtist):
             The color specififcation for the edges.
             The default color is the value of ``~MeshArtist.default_edgecolor``.
         facecolor : tuple or dict of tuple, optional
-            The color specififcation for the faces.
+            The color specification for the faces.
             The default color is the value of ``~MeshArtist.default_facecolor``.
         color : tuple, optional
             The color of the mesh.

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -40,31 +40,32 @@ class MeshArtist(GHArtist, MeshArtist):
         Returns
         -------
         :class:`Rhino.Geometry.Mesh`
+        """
+        color = color or self.default_color
+        vertices, faces = self.mesh.to_vertices_and_faces()
+        return compas_ghpython.draw_mesh(vertices, faces, color)
+
+    def draw_mesh(self, color=None):
+        """Draw the mesh as a RhinoMesh.
+
+        This method is an alias for ``~MeshArtist.draw``.
+
+        Parameters
+        ----------
+        color : tuple, optional
+            The color of the mesh.
+            Default is the value of ``~MeshArtist.default_color``.
+
+        Returns
+        -------
+        :class:`Rhino.Geometry.Mesh`
 
         Notes
         -----
         The mesh should be a valid Rhino Mesh object, which means it should have only triangular or quadrilateral faces.
         Faces with more than 4 vertices will be triangulated on-the-fly.
         """
-        color = color or self.default_color
-        vertex_index = self.mesh.vertex_index()
-        vertex_xyz = self.vertex_xyz
-        vertices = [vertex_xyz[vertex] for vertex in self.mesh.vertices()]
-        faces = [[vertex_index[vertex] for vertex in self.mesh.face_vertices(face)] for face in self.mesh.faces()]
-        new_faces = []
-        for face in faces:
-            f = len(face)
-            if f == 3:
-                new_faces.append(face + [face[-1]])
-            elif f == 4:
-                new_faces.append(face)
-            elif f > 4:
-                centroid = len(vertices)
-                vertices.append(centroid_polygon(
-                    [vertices[index] for index in face]))
-                for a, b in pairwise(face + face[0:1]):
-                    new_faces.append([centroid, a, b, b])
-        return compas_ghpython.draw_mesh(vertices, new_faces, color)
+        return self.draw(color)
 
     def draw_vertices(self, vertices=None, color=None):
         """Draw a selection of vertices.

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -5,9 +5,7 @@ from __future__ import print_function
 import Rhino
 from functools import partial
 
-from compas.geometry import centroid_polygon
 from compas.utilities import color_to_colordict
-from compas.utilities import pairwise
 
 import compas_ghpython
 from compas.artists import MeshArtist

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -37,7 +37,7 @@ class MeshArtist(GHArtist, MeshArtist):
         self.show_faces = show_faces
 
     def draw(self, vertices=None, edges=None, faces=None, vertexcolor=None, edgecolor=None, facecolor=None, color=None, join_faces=False):
-        """Draw the mesh using the chosen visualisation settings.
+        """Draw the mesh using the chosen visualization settings.
 
         Parameters
         ----------

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -23,25 +23,63 @@ class MeshArtist(GHArtist, MeshArtist):
         A COMPAS mesh.
     """
 
-    def __init__(self, mesh, **kwargs):
+    def __init__(self,
+                 mesh,
+                 show_mesh=False,
+                 show_vertices=True,
+                 show_edges=True,
+                 show_faces=True,
+                 **kwargs):
         super(MeshArtist, self).__init__(mesh=mesh, **kwargs)
+        self.show_mesh = show_mesh
+        self.show_vertices = show_vertices
+        self.show_edges = show_edges
+        self.show_faces = show_faces
 
-    def draw(self, color=None):
-        """Draw the mesh as a RhinoMesh.
+    def draw(self, vertices=None, edges=None, faces=None, vertexcolor=None, edgecolor=None, facecolor=None, color=None, join_faces=False):
+        """Draw the mesh using the chosen visualisation settings.
 
         Parameters
         ----------
+        vertices : list, optional
+            A list of vertices to draw.
+            Default is ``None``, in which case all vertices are drawn.
+        edges : list, optional
+            A list of edges to draw.
+            The default is ``None``, in which case all edges are drawn.
+        faces : list, optional
+            A selection of faces to draw.
+            The default is ``None``, in which case all faces are drawn.
+        vertexcolor : tuple or dict of tuple, optional
+            The color specififcation for the vertices.
+            The default color is the value of ``~MeshArtist.default_vertexcolor``.
+        edgecolor : tuple or dict of tuple, optional
+            The color specififcation for the edges.
+            The default color is the value of ``~MeshArtist.default_edgecolor``.
+        facecolor : tuple or dict of tuple, optional
+            The color specififcation for the faces.
+            The default color is the value of ``~MeshArtist.default_facecolor``.
         color : tuple, optional
             The color of the mesh.
             Default is the value of ``~MeshArtist.default_color``.
+        join_faces : bool, optional
+            Join the faces into 1 mesh.
+            Default is ``False``, in which case the faces are drawn as individual meshes.
 
         Returns
         -------
         :class:`Rhino.Geometry.Mesh`
         """
-        color = color or self.default_color
-        vertices, faces = self.mesh.to_vertices_and_faces()
-        return compas_ghpython.draw_mesh(vertices, faces, color)
+        geometry = []
+        if self.show_mesh:
+            geometry.append(self.draw_mesh(color=color))
+        if self.show_vertices:
+            geometry.extend(self.draw_vertices(vertices=vertices, color=vertexcolor))
+        if self.show_edges:
+            geometry.extend(self.draw_edges(edges=edges, color=edgecolor))
+        if self.show_faces:
+            geometry.extend(self.draw_faces(faces=faces, color=facecolor, join_faces=join_faces))
+        return geometry
 
     def draw_mesh(self, color=None):
         """Draw the mesh as a RhinoMesh.
@@ -63,7 +101,10 @@ class MeshArtist(GHArtist, MeshArtist):
         The mesh should be a valid Rhino Mesh object, which means it should have only triangular or quadrilateral faces.
         Faces with more than 4 vertices will be triangulated on-the-fly.
         """
-        return self.draw(color)
+        color = color or self.default_color
+        print(self.default_color)
+        vertices, faces = self.mesh.to_vertices_and_faces()
+        return compas_ghpython.draw_mesh(vertices, faces, color)
 
     def draw_vertices(self, vertices=None, color=None):
         """Draw a selection of vertices.

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -102,7 +102,6 @@ class MeshArtist(GHArtist, MeshArtist):
         Faces with more than 4 vertices will be triangulated on-the-fly.
         """
         color = color or self.default_color
-        print(self.default_color)
         vertices, faces = self.mesh.to_vertices_and_faces()
         return compas_ghpython.draw_mesh(vertices, faces, color)
 

--- a/src/compas_ghpython/artists/meshartist.py
+++ b/src/compas_ghpython/artists/meshartist.py
@@ -51,10 +51,10 @@ class MeshArtist(GHArtist, MeshArtist):
             A selection of faces to draw.
             The default is ``None``, in which case all faces are drawn.
         vertexcolor : tuple or dict of tuple, optional
-            The color specififcation for the vertices.
+            The color specification for the vertices.
             The default color is the value of ``~MeshArtist.default_vertexcolor``.
         edgecolor : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~MeshArtist.default_edgecolor``.
         facecolor : tuple or dict of tuple, optional
             The color specification for the faces.
@@ -68,7 +68,7 @@ class MeshArtist(GHArtist, MeshArtist):
 
         Returns
         -------
-        :class:`Rhino.Geometry.Mesh`
+        list of :class:`Rhino.Geometry.Mesh`, :class:`Rhino.Geometry.Point3d` and :class:`Rhino.Geometry.Line` depending on the selection.
         """
         geometry = []
         if self.show_mesh:
@@ -114,7 +114,7 @@ class MeshArtist(GHArtist, MeshArtist):
             A selection of vertices to draw.
             Default is ``None``, in which case all vertices are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the vertices.
+            The color specification for the vertices.
             The default is the value of ``~MeshArtist.default_vertexcolor``.
 
         Returns
@@ -143,7 +143,7 @@ class MeshArtist(GHArtist, MeshArtist):
             A selection of faces to draw.
             The default is ``None``, in which case all faces are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the faces.
+            The color specification for the faces.
             The default color is the value of ``~MeshArtist.default_facecolor``.
         join_faces : bool, optional
             Join the faces into 1 mesh.
@@ -181,7 +181,7 @@ class MeshArtist(GHArtist, MeshArtist):
             A selection of edges to draw.
             The default is ``None``, in which case all edges are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~MeshArtist.default_edgecolor``.
 
         Returns

--- a/src/compas_ghpython/artists/networkartist.py
+++ b/src/compas_ghpython/artists/networkartist.py
@@ -44,7 +44,7 @@ class NetworkArtist(GHArtist, NetworkArtist):
             The selection of nodes that should be drawn.
             Default is ``None``, in which case all nodes are drawn.
         color: 3-tuple or dict of 3-tuple, optional
-            The color specififcation for the nodes.
+            The color specification for the nodes.
             The default color is ``(255, 255, 255)``.
 
         Returns
@@ -72,7 +72,7 @@ class NetworkArtist(GHArtist, NetworkArtist):
             A list of edges to draw.
             The default is ``None``, in which case all edges are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~NetworkArtist.default_edgecolor``.
 
         Returns

--- a/src/compas_ghpython/artists/volmeshartist.py
+++ b/src/compas_ghpython/artists/volmeshartist.py
@@ -40,7 +40,7 @@ class VolMeshArtist(GHArtist, VolMeshArtist):
             A list of vertices to draw.
             Default is ``None``, in which case all vertices are drawn.
         color : str, tuple, dict
-            The color specififcation for the vertices.
+            The color specification for the vertices.
             The default color of the vertices is ``~VolMeshArtist.default_vertexcolor``.
 
         Returns
@@ -68,7 +68,7 @@ class VolMeshArtist(GHArtist, VolMeshArtist):
             A list of edges to draw.
             The default is ``None``, in which case all edges are drawn.
         color : str, tuple, dict
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is ``~VolMeshArtist.default_edgecolor``.
 
         Returns
@@ -97,7 +97,7 @@ class VolMeshArtist(GHArtist, VolMeshArtist):
             A list of faces to draw.
             The default is ``None``, in which case all faces are drawn.
         color : str, tuple, dict
-            The color specififcation for the faces.
+            The color specification for the faces.
             The default color is ``~VolMeshArtist.default_facecolor``.
 
         Returns

--- a/src/compas_plotters/plotter.py
+++ b/src/compas_plotters/plotter.py
@@ -161,7 +161,7 @@ class Plotter(metaclass=Singleton):
         Parameters
         ----------
         value : str, tuple
-            The color specififcation for the figure background.
+            The color specification for the figure background.
             Colors should be specified in the form of a string (hex colors) or
             as a tuple of normalized RGB components.
 

--- a/src/compas_rhino/artists/meshartist.py
+++ b/src/compas_rhino/artists/meshartist.py
@@ -120,13 +120,13 @@ class MeshArtist(RhinoArtist, MeshArtist):
             A selection of faces to draw.
             The default is ``None``, in which case all faces are drawn.
         vertexcolor : tuple or dict of tuple, optional
-            The color specififcation for the vertices.
+            The color specification for the vertices.
             The default color is the value of ``~MeshArtist.default_vertexcolor``.
         edgecolor : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~MeshArtist.default_edgecolor``.
         facecolor : tuple or dict of tuple, optional
-            The color specififcation for the faces.
+            The color specification for the faces.
             The default color is the value of ``~MeshArtist.default_facecolor``.
         join_faces : bool, optional
             Join the faces into 1 mesh.
@@ -200,7 +200,7 @@ class MeshArtist(RhinoArtist, MeshArtist):
             A selection of vertices to draw.
             Default is ``None``, in which case all vertices are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the vertices.
+            The color specification for the vertices.
             The default is the value of ``~MeshArtist.default_vertexcolor``.
 
         Returns
@@ -231,7 +231,7 @@ class MeshArtist(RhinoArtist, MeshArtist):
             A selection of edges to draw.
             The default is ``None``, in which case all edges are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~MeshArtist.default_edgecolor``.
 
         Returns
@@ -263,7 +263,7 @@ class MeshArtist(RhinoArtist, MeshArtist):
             A selection of faces to draw.
             The default is ``None``, in which case all faces are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the faces.
+            The color specification for the faces.
             The default color is the value of ``~MeshArtist.default_facecolor``.
         join_faces : bool, optional
             Join the faces into 1 mesh.

--- a/src/compas_rhino/artists/meshartist.py
+++ b/src/compas_rhino/artists/meshartist.py
@@ -106,7 +106,7 @@ class MeshArtist(RhinoArtist, MeshArtist):
     # ==========================================================================
 
     def draw(self, vertices=None, edges=None, faces=None, vertexcolor=None, edgecolor=None, facecolor=None, join_faces=False):
-        """Draw the mesh using the chosen visualisation settings.
+        """Draw the mesh using the chosen visualization settings.
 
         Parameters
         ----------

--- a/src/compas_rhino/artists/meshartist.py
+++ b/src/compas_rhino/artists/meshartist.py
@@ -106,7 +106,7 @@ class MeshArtist(RhinoArtist, MeshArtist):
     # ==========================================================================
 
     def draw(self, vertices=None, edges=None, faces=None, vertexcolor=None, edgecolor=None, facecolor=None, join_faces=False):
-        """Draw the network using the chosen visualisation settings.
+        """Draw the mesh using the chosen visualisation settings.
 
         Parameters
         ----------

--- a/src/compas_rhino/artists/networkartist.py
+++ b/src/compas_rhino/artists/networkartist.py
@@ -97,10 +97,10 @@ class NetworkArtist(RhinoArtist, NetworkArtist):
             A list of edges to draw.
             The default is ``None``, in which case all edges are drawn.
         nodecolor : tuple or dict of tuple, optional
-            The color specififcation for the nodes.
+            The color specification for the nodes.
             The default color is the value of ``~NetworkArtist.default_nodecolor``.
         edgecolor : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~NetworkArtist.default_edgecolor``.
 
         Returns
@@ -122,7 +122,7 @@ class NetworkArtist(RhinoArtist, NetworkArtist):
             A list of nodes to draw.
             Default is ``None``, in which case all nodes are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the nodes.
+            The color specification for the nodes.
             The default color is the value of ``~NetworkArtist.default_nodecolor``.
 
         Returns
@@ -151,7 +151,7 @@ class NetworkArtist(RhinoArtist, NetworkArtist):
             A list of edges to draw.
             The default is ``None``, in which case all edges are drawn.
         color : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~NetworkArtist.default_edgecolor``.
 
         Returns

--- a/src/compas_rhino/artists/volmeshartist.py
+++ b/src/compas_rhino/artists/volmeshartist.py
@@ -55,16 +55,16 @@ class VolMeshArtist(RhinoArtist, VolMeshArtist):
             A selection of cells to draw.
             The default is ``None``, in which case all cells are drawn.
         vertexcolor : tuple or dict of tuple, optional
-            The color specififcation for the vertices.
+            The color specification for the vertices.
             The default color is the value of ``~VolMeshArtist.default_vertexcolor``.
         edgecolor : tuple or dict of tuple, optional
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is the value of ``~VolMeshArtist.default_edgecolor``.
         facecolor : tuple or dict of tuple, optional
-            The color specififcation for the faces.
+            The color specification for the faces.
             The default color is the value of ``~VolMeshArtist.default_facecolor``.
         cellcolor : tuple or dict of tuple, optional
-            The color specififcation for the cells.
+            The color specification for the cells.
             The default color is the value of ``~VolMeshArtist.default_cellcolor``.
 
         Returns
@@ -88,7 +88,7 @@ class VolMeshArtist(RhinoArtist, VolMeshArtist):
             A list of vertices to draw.
             Default is ``None``, in which case all vertices are drawn.
         color : str, tuple, dict
-            The color specififcation for the vertices.
+            The color specification for the vertices.
             The default color of the vertices is ``~VolMeshArtist.default_vertexcolor``.
 
         Returns
@@ -118,7 +118,7 @@ class VolMeshArtist(RhinoArtist, VolMeshArtist):
             A list of edges to draw.
             The default is ``None``, in which case all edges are drawn.
         color : str, tuple, dict
-            The color specififcation for the edges.
+            The color specification for the edges.
             The default color is ``~VolMeshArtist.default_edgecolor``.
 
         Returns
@@ -149,7 +149,7 @@ class VolMeshArtist(RhinoArtist, VolMeshArtist):
             A list of faces to draw.
             The default is ``None``, in which case all faces are drawn.
         color : str, tuple, dict
-            The color specififcation for the faces.
+            The color specification for the faces.
             The default color is ``~VolMeshArtist.default_facecolor``.
 
         Returns
@@ -179,7 +179,7 @@ class VolMeshArtist(RhinoArtist, VolMeshArtist):
             A list of cells to draw.
             The default is ``None``, in which case all cells are drawn.
         color : str, tuple, dict
-            The color specififcation for the cells.
+            The color specification for the cells.
             The default color is ``~VolMeshArtist.default_cellcolor``.
 
         Returns


### PR DESCRIPTION
I would say this is a bug, but can also be considered a "feature". The GH python mesh artist was missing the `draw_mesh` method which is usually demo'ed in most examples and slides. In the process I noticed that `draw` (which is equivalent in GH python) was doing extra work that `compas_ghpython.drawing.draw_mesh` seems to be already doing and better (because we added n-gon support recently).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
