### PR TITLE
fix parameter name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
     
     outputs:
       commit_type: ${{ steps.docs.outputs.commit_type }}
-      current_patch: ${{ steps.docs.outputs.current_patch }}
+      current_version: ${{ steps.docs.outputs.current_version }}
   
   docVersions:
     needs: build
@@ -49,7 +49,7 @@ jobs:
 
       - uses: compas-dev/compas-actions.docversions@v1.2.0
         with:
-          current_patch: ${{ needs.build.outputs.current_patch }}
+          current_version: ${{ needs.build.outputs.current_version }}
 
       - name: Deploy docs
         if: success()


### PR DESCRIPTION
The parameter name of the docs workflow was outdated. Because of this the older patches of minor versions has not been removed. #933 