### PR TITLE
Update Check PR

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,5 +16,6 @@ jobs:
         uses: Zomzog/changelog-checker@v1.1.0
         with:
           fileName: CHANGELOG.md
+          checkNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Changelog check
-        uses: Zomzog/changelog-checker@v1.1.0
+        uses: Zomzog/changelog-checker@v1.2.0
         with:
           fileName: CHANGELOG.md
           checkNotification: Simple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated `pr-checks` workflow for checking Changelog entry.
+
 ### Removed
 
 


### PR DESCRIPTION
Somehow current PR-check workflow still let PRs with unchanged Changelog pass. This should fix it. See example at: https://github.com/compas-dev/compas/runs/4406776339?check_suite_focus=true