### PR TITLE
inform version in after_rhino_install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `compas_rhino.DEFAULT_VERSION`.
 * Added `clean` option to `compas_rhino.install` to remove existing symlinks if they cannot be imported from the current environment.
+* Added `INSTALLED_VERSION` variable to `compas_rhino.install` to interally inform rhino version context post-installation steps.
 
 ### Changed
 

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -195,7 +195,7 @@ def install(version=None, packages=None, clean=False):
 
     if exit_code == 0 and len(installed_packages):
         print('\nRunning post-installation steps...\n')
-        if not _run_post_execution_steps(after_rhino_install(installed_packages)):
+        if not _run_post_execution_steps(after_rhino_install(installed_packages, version)):
             exit_code = -1
 
     print('\nInstall completed.')
@@ -265,7 +265,7 @@ def installable_rhino_packages():
 
 
 @compas.plugins.pluggable(category='install', selector='collect_all')
-def after_rhino_install(installed_packages):
+def after_rhino_install(installed_packages, version):
     """Allows extensions to execute actions after install to Rhino is done.
 
     Extensions providing Rhino or Grasshopper features

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -15,11 +15,11 @@ import compas.plugins
 __all__ = [
     'install',
     'installable_rhino_packages',
-    'after_rhino_install',
-    'INSTALLED_VERSION'
+    'after_rhino_install'
 ]
 
 INSTALLED_VERSION = None
+
 
 def install(version=None, packages=None, clean=False):
     """Install COMPAS for Rhino.

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -16,8 +16,10 @@ __all__ = [
     'install',
     'installable_rhino_packages',
     'after_rhino_install',
+    'INSTALLED_VERSION'
 ]
 
+INSTALLED_VERSION = None
 
 def install(version=None, packages=None, clean=False):
     """Install COMPAS for Rhino.
@@ -195,12 +197,15 @@ def install(version=None, packages=None, clean=False):
 
     if exit_code == 0 and len(installed_packages):
         print('\nRunning post-installation steps...\n')
-        if not _run_post_execution_steps(after_rhino_install(installed_packages, version)):
+        if not _run_post_execution_steps(after_rhino_install(installed_packages)):
             exit_code = -1
 
     print('\nInstall completed.')
     if exit_code != 0:
         sys.exit(exit_code)
+
+    global INSTALLED_VERSION
+    INSTALLED_VERSION = version
 
 
 def _run_post_execution_steps(steps_generator):
@@ -265,7 +270,7 @@ def installable_rhino_packages():
 
 
 @compas.plugins.pluggable(category='install', selector='collect_all')
-def after_rhino_install(installed_packages, version):
+def after_rhino_install(installed_packages):
     """Allows extensions to execute actions after install to Rhino is done.
 
     Extensions providing Rhino or Grasshopper features


### PR DESCRIPTION
In many occasions like RV2, IGS etc it's essential for `after_rhino_install` function to be aware of the chosen version in `compas_rhino.install()`. This commit is to pass it in as parameter, however this means all existing plugins would have to update their `after_rhino_install` to include version parameter as well. I couldn't come up with a non-breaking way of doing it yet. Maybe we can discuss here a bit what's the best way of addressing this.