### PR TITLE
Fix task to build GH user components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `compas_ghpython.fetch_ghio_lib` to simplify the loading of Grasshopper's IO library for extension developers.
+
 ### Changed
 
 ### Removed
@@ -52,9 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas_rhino.install_plugin` to remove broken symlinks.
 * Changed default Rhino version for installation to `7.0`.
 * Fixed bug in `compas_ghpython` related to importing `Grasshopper` prematurely.
-* Changed `compas.artists.Artist.ITAM_ARTIST` to context-based dict.
+* Changed `compas.artists.Artist.ITEM_ARTIST` to context-based dict.
 * Changed `compas_rhino.__init__.py` functions.
 * Changed `compas_ghpython.__init__.py` functions.
+* Renamed `compas_ghpython.get_grasshopper_plugin_path` to `compas_ghpython.get_grasshopper_managedplugin_path`.
 
 ### Removed
 

--- a/src/compas_ghpython/__init__.py
+++ b/src/compas_ghpython/__init__.py
@@ -88,9 +88,11 @@ def get_grasshopper_userobjects_path(version):
     """Retrieve Grasshopper's user objects path"""
     return _get_grasshopper_special_folder(version, 'UserObjects')
 
+
 # =============================================================================
 # GH_IO Dll
 # =============================================================================
+
 
 def fetch_ghio_lib(target_folder='temp'):
     """Fetch the GH_IO.dll library from the NuGet packaging system."""

--- a/src/compas_ghpython/__init__.py
+++ b/src/compas_ghpython/__init__.py
@@ -12,7 +12,11 @@ compas_ghpython
     compas_ghpython.utilities
 
 """
+import io
 import os
+import urllib
+import zipfile
+
 import compas
 import compas_rhino
 
@@ -24,7 +28,8 @@ if compas.is_rhino():
 __all__ = [
     'get_grasshopper_managedplugin_path',
     'get_grasshopper_library_path',
-    'get_grasshopper_userobjects_path'
+    'get_grasshopper_userobjects_path',
+    'fetch_ghio_lib'
 ]
 __all_plugins__ = [
     'compas_ghpython.install',
@@ -82,3 +87,22 @@ def get_grasshopper_library_path(version):
 def get_grasshopper_userobjects_path(version):
     """Retrieve Grasshopper's user objects path"""
     return _get_grasshopper_special_folder(version, 'UserObjects')
+
+# =============================================================================
+# GH_IO Dll
+# =============================================================================
+
+def fetch_ghio_lib(target_folder='temp'):
+    """Fetch the GH_IO.dll library from the NuGet packaging system."""
+    ghio_dll = 'GH_IO.dll'
+    filename = 'lib/net48/' + ghio_dll
+
+    response = urllib.request.urlopen('https://www.nuget.org/api/v2/package/Grasshopper/')
+    dst_file = os.path.join(target_folder, ghio_dll)
+    zip_file = zipfile.ZipFile(io.BytesIO(response.read()))
+
+    with zip_file.open(filename, 'r') as zipped_dll:
+        with open(dst_file, 'wb') as fp:
+            fp.write(zipped_dll.read())
+
+    return dst_file

--- a/tasks.py
+++ b/tasks.py
@@ -189,7 +189,7 @@ def prepare_changelog(ctx):
 
 
 @task(help={
-      'gh_io_folder': 'Folder where GH_IO.dll is located. Defaults to the Rhino 6.0 installation folder (platform-specific).',
+      'gh_io_folder': 'Folder where GH_IO.dll is located. If not specified, it will try to download from NuGet.',
       'ironpython': 'Command for running the IronPython executable. Defaults to `ipy`.'})
 def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None):
     """Build Grasshopper user objects from source"""
@@ -199,9 +199,11 @@ def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None):
             source_dir = os.path.abspath('src/compas_ghpython/components')
             target_dir = os.path.join(source_dir, 'ghuser')
             ctx.run('git clone https://github.com/compas-dev/compas-actions.ghpython_components.git {}'.format(action_dir))
+
             if not gh_io_folder:
+                gh_io_folder = 'temp'
                 import compas_ghpython
-                gh_io_folder = compas_ghpython.get_grasshopper_plugin_path('6.0')
+                compas_ghpython.fetch_ghio_lib(gh_io_folder)
 
             if not ironpython:
                 ironpython = 'ipy'


### PR DESCRIPTION
One of the recently renamed functions was still used in `tasks.py` but instead of fixing that, I changed the way this was done and instead of locating the `GH_IO.dll` file on the local install, I changed to fetching it from NuGet (which is what we actually do on the github action build steps anyway, but we do that using the action, which relies on .NET NuGet to get it).
I did add a retroactive note of the change in the changelog

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
