### PR TITLE
bugfix of RhinoNurbsSurface closest_point method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed `compas_rhino.geometry.RhinoNurbsSurface.closest_point` to fix bug of rhino_curve to rhino_surface, plus return tuple instead.
+
 ### Removed
 
 

--- a/src/compas_rhino/geometry/surfaces/nurbs.py
+++ b/src/compas_rhino/geometry/surfaces/nurbs.py
@@ -456,21 +456,21 @@ class RhinoNurbsSurface(NurbsSurface):
         point : :class:`compas.geometry.Point`
             The test point.
         return_parameters : bool, optional
-            Return the UV parameters of the closest point in addition to the point location.
+            Return the UV parameters of the closest point as tuple in addition to the point location.
 
         Returns
         -------
         :class:`compas.geometry.Point`
             If ``return_parameters`` is False.
-        :class:`compas.geometry.Point`, float, float
+        :class:`compas.geometry.Point`, (float, float)
             If ``return_parameters`` is True.
         """
-        result, u, v = self.rhino_curve.ClosestPoint(point_to_rhino(point))
+        result, u, v = self.rhino_surface.ClosestPoint(point_to_rhino(point))
         if not result:
             return
         point = self.point_at(u, v)
         if return_parameters:
-            return point, u, v
+            return point, (u, v)
         return point
 
     def aabb(self, precision=0.0, optimal=False):


### PR DESCRIPTION
- change rhino_curve to rhino_surface
- return parameters as tuple instead (for consistency with compas_occ)

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
