### PR TITLE
realpath_but_for_real_this_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed symlink expansion for directories relative to the COMPAS installation folder, eg. `compas.DATA` when used from IronPython.
+* Fixed the result of `compas.__version__` on dev installs to properly include git hash.
+
 ### Removed
 
 

--- a/src/compas/__init__.py
+++ b/src/compas/__init__.py
@@ -46,7 +46,7 @@ __version__ = '1.14.0'
 version = LooseVersion(compas.__version__)
 versionstring = version.vstring.split('-')[0]
 
-HERE = os.path.dirname(__file__)
+HERE = compas._os.realpath(os.path.dirname(__file__))
 """str: Path to the location of the compas package."""
 
 HOME = compas._os.absjoin(HERE, '../..')

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -287,7 +287,7 @@ def _realpath_ipy_win(path):
         if match_name == dirname:
             return match_link
 
-    raise ValueError('path not found: {}'.format(path))
+    return path
 
 
 def _realpath_ipy_posix(path):

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -256,12 +256,13 @@ def absjoin(*parts):
 
 
 def realpath(path):
-    """Return the canonical path of the specified filename, eliminating any symbolic links encountered in the path.
+    """Return the canonical path of the specified filename, resolving any symbolic links encountered in the path.
 
     This function uses Python's stdlib `os.path.realpath` in most cases,
     except when inside IronPython because (guess what?) it is broken and
     doesn't really eliminate sym links, so, we fallback to a different
-    way to identifying symlinks in that situation."""
+    way to identifying symlinks in that situation.
+    """
     if not PY3 and is_ironpython():
         if is_windows():
             return _realpath_ipy_win(path)

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -287,7 +287,7 @@ def _realpath_ipy_win(path):
         if match_name == dirname:
             return match_link
 
-    return ValueError('path not found: {}'.format(path))
+    raise ValueError('path not found: {}'.format(path))
 
 
 def _realpath_ipy_posix(path):

--- a/src/compas/_os.py
+++ b/src/compas/_os.py
@@ -4,10 +4,11 @@ These are internal functions of the framework.
 Not intended to be used outside compas* packages.
 """
 import os
-import shutil
-import sys
+import re
 import tempfile
+import shutil
 import subprocess
+import sys
 
 try:
     NotADirectoryError
@@ -16,10 +17,12 @@ except NameError:
         pass
 
 PY3 = sys.version_info[0] == 3
+SYMLINK_REGEX = re.compile(r"\n.*\<SYMLINKD\>\s(.*)\s\[(.*)\]\r")
 
 
 __all__ = [
     'absjoin',
+    'realpath',
     'create_symlink',
     'create_symlinks',
     'remove_symlink',
@@ -250,6 +253,48 @@ def prepare_environment(env=None):
 
 def absjoin(*parts):
     return os.path.abspath(os.path.join(*parts))
+
+
+def realpath(path):
+    """Return the canonical path of the specified filename, eliminating any symbolic links encountered in the path.
+
+    This function uses Python's stdlib `os.path.realpath` in most cases,
+    except when inside IronPython because (guess what?) it is broken and
+    doesn't really eliminate sym links, so, we fallback to a different
+    way to identifying symlinks in that situation."""
+    if not PY3 and is_ironpython():
+        if is_windows():
+            return _realpath_ipy_win(path)
+        else:
+            return _realpath_ipy_posix(path)
+
+    return os.path.realpath(path)
+
+
+def _realpath_ipy_win(path):
+    dirname = os.path.basename(path)
+    parent_path = os.path.join(path, '..')
+
+    args = 'dir /c "{}" /Al'.format(parent_path)
+    process = subprocess.Popen(args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    output, _error = process.communicate()
+    matches = SYMLINK_REGEX.finditer(output)
+    for match in matches:
+        match_name = match.groups()[0].strip()
+        match_link = match.groups()[1]
+
+        if match_name == dirname:
+            return match_link
+
+    return ValueError('path not found: {}'.format(path))
+
+
+def _realpath_ipy_posix(path):
+    args = 'readlink -f "{}"'.format(path)
+    process = subprocess.Popen(args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, _error = process.communicate()
+    return output
 
 
 # Cache whatever symlink function works (native or polyfill)


### PR DESCRIPTION
As discussed, this fixes the `compas.DATA` and related stuff for dev installs that use symlinks. `compas.DATA` still does not work on a non-dev install because the folder is not even copied on install, but that's a separate issue. As a side effect, this does fix the `compas.__version__` output on dev installs to include the git commit hash.

 
### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
