### PR TITLE
fix: exception calling `geometry` of compas.datastructures.Part`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `compas_ghpython.artists.VolMeshArtist.draw` and `compas_ghpython.artists.VolMeshArtist.draw_cells`.
 * Fixed `compas_rhino.artists.VolMeshArtist.draw` and `compas_rhino.artists.VolMeshArtist.draw_cells`.
 * Improved error messages when artist instance cannot be created.
+* Fixed exception when calculating geometry of `compas.datastructures.Part` without features.
 
 ### Removed
 

--- a/src/compas/datastructures/assembly/part.py
+++ b/src/compas/datastructures/assembly/part.py
@@ -144,13 +144,17 @@ class Part(Datastructure):
     def geometry(self):
         # TODO: this is a temp solution
         # TODO: add memoization or some other kind of caching
-        A = Mesh.from_shape(self.shape)
-        for shape, operation in self.features:
-            A.quads_to_triangles()
-            B = Mesh.from_shape(shape)
-            B.quads_to_triangles()
-            A = Part.operations[operation](A.to_vertices_and_faces(), B.to_vertices_and_faces())
-        geometry = Shape(*A)
+        if self.features:
+            A = Mesh.from_shape(self.shape)
+            for shape, operation in self.features:
+                A.quads_to_triangles()
+                B = Mesh.from_shape(shape)
+                B.quads_to_triangles()
+                A = Part.operations[operation](A.to_vertices_and_faces(), B.to_vertices_and_faces())
+            geometry = Shape(*A)
+        else:
+            geometry = Shape(*self.shape.to_vertices_and_faces())
+
         T = Transformation.from_frame_to_frame(Frame.worldXY(), self.frame)
         geometry.transform(T)
         return geometry

--- a/src/compas/datastructures/assembly/part.py
+++ b/src/compas/datastructures/assembly/part.py
@@ -145,12 +145,10 @@ class Part(Datastructure):
         # TODO: this is a temp solution
         # TODO: add memoization or some other kind of caching
         if self.features:
-            A = Mesh.from_shape(self.shape)
+            A = self.shape.to_vertices_and_faces(triangulated=True)
             for shape, operation in self.features:
-                A.quads_to_triangles()
-                B = Mesh.from_shape(shape)
-                B.quads_to_triangles()
-                A = Part.operations[operation](A.to_vertices_and_faces(), B.to_vertices_and_faces())
+                B = shape.to_vertices_and_faces(triangulated=True)
+                A = Part.operations[operation](A, B)
             geometry = Shape(*A)
         else:
             geometry = Shape(*self.shape.to_vertices_and_faces())


### PR DESCRIPTION
If the part has no features assigned, the call to `.geometry` causes an exception, but additionally, it's very inefficient to do all those transformations from shape to mesh back to polyhedron which, in the case of no attached features to be boolean'ed into the geometry, is not needed.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
