### PR TITLE
Occ from fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed `compas.geometry.surfaces.nurbs.from_fill` to accept up to 4 curves as input.
 * Changed `compas_rhino.artists.MeshArtist.draw` to draw the mesh only.
 * Changed `compas_blender.artists.MeshArtist.draw` to draw the mesh only.
 * Changed `compas_ghpython.artists.MeshArtist.draw` to draw the mesh only.

--- a/src/compas/geometry/surfaces/nurbs.py
+++ b/src/compas/geometry/surfaces/nurbs.py
@@ -320,7 +320,7 @@ class NurbsSurface(Surface):
         return new_nurbssurface_from_step(cls, filepath)
 
     @classmethod
-    def from_fill(cls, curve1, curve2, curve3=None, curve4=None, scheme='stretch'):
+    def from_fill(cls, curve1, curve2, curve3=None, curve4=None, style='stretch'):
         """Construct a NURBS surface from the infill between two, three or four contiguous NURBS curves.
 
         Parameters
@@ -329,14 +329,23 @@ class NurbsSurface(Surface):
         curve2 : :class:`~compas_occ.geometry.OCCNurbsCurve`
         curve3 : :class:`~compas_occ.geometry.OCCNurbsCurve`, optional.
         curve4 : :class:`~compas_occ.geometry.OCCNurbsCurve`, optional.
-        scheme (Literal[’stretch’, ’coons’, ‘curved’], optional) – The scheme according to which the mesh should be subdivided.
+        style : Literal['stretch', 'coons', 'curved'], optional.
+            The fill style:
+            'stretch' gives the flattest patch.
+            'coons' gives a rounded patch with less depth than that of curved.
+            'curved' gives with the most rounded patch.
+
+        Raises
+        ------
+        ValueError
+            If the fill style is not supported.
 
         Returns
         -------
         :class:`~compas.geometry.NurbsSurface`
 
         """
-        return new_nurbssurface_from_fill(cls, curve1, curve2, curve3, curve4, scheme)
+        return new_nurbssurface_from_fill(cls, curve1, curve2, curve3, curve4, style)
 
     # ==============================================================================
     # Conversions

--- a/src/compas/geometry/surfaces/nurbs.py
+++ b/src/compas/geometry/surfaces/nurbs.py
@@ -320,20 +320,23 @@ class NurbsSurface(Surface):
         return new_nurbssurface_from_step(cls, filepath)
 
     @classmethod
-    def from_fill(cls, curve1, curve2):
-        """Construct a NURBS surface from the infill between two NURBS curves.
+    def from_fill(cls, curve1, curve2, curve3=None, curve4=None, scheme='stretch'):
+        """Construct a NURBS surface from the infill between two, three or four contiguous NURBS curves.
 
         Parameters
         ----------
-        curve1 : :class:`~compas.geometry.NurbsCurve`
-        curve2 : :class:`~compas.geometry.NurbsCurve`
+        curve1 : :class:`~compas_occ.geometry.OCCNurbsCurve`
+        curve2 : :class:`~compas_occ.geometry.OCCNurbsCurve`
+        curve3 : :class:`~compas_occ.geometry.OCCNurbsCurve`, optional.
+        curve4 : :class:`~compas_occ.geometry.OCCNurbsCurve`, optional.
+        scheme (Literal[’stretch’, ’coons’, ‘curved’], optional) – The scheme according to which the mesh should be subdivided.
 
         Returns
         -------
         :class:`~compas.geometry.NurbsSurface`
 
         """
-        return new_nurbssurface_from_fill(cls, curve1, curve2)
+        return new_nurbssurface_from_fill(cls, curve1, curve2, curve3, curve4, scheme)
 
     # ==============================================================================
     # Conversions

--- a/src/compas/geometry/surfaces/nurbs.py
+++ b/src/compas/geometry/surfaces/nurbs.py
@@ -325,15 +325,15 @@ class NurbsSurface(Surface):
 
         Parameters
         ----------
-        curve1 : :class:`~compas_occ.geometry.OCCNurbsCurve`
-        curve2 : :class:`~compas_occ.geometry.OCCNurbsCurve`
-        curve3 : :class:`~compas_occ.geometry.OCCNurbsCurve`, optional.
-        curve4 : :class:`~compas_occ.geometry.OCCNurbsCurve`, optional.
+        curve1 : :class:`compas.geometry.NurbsCurve`
+        curve2 : :class:`compas.geometry.NurbsCurve`
+        curve3 : :class:`compas.geometry.NurbsCurve`, optional.
+        curve4 : :class:`compas.geometry.NurbsCurve`, optional.
         style : Literal['stretch', 'coons', 'curved'], optional.
-            The fill style:
-            'stretch' gives the flattest patch.
-            'coons' gives a rounded patch with less depth than that of curved.
-            'curved' gives with the most rounded patch.
+
+            * ``'stretch'`` produces the flattest patch.
+            * ``'curved'`` produces a rounded patch.
+            * ``'coons'`` is between stretch and coons.
 
         Raises
         ------


### PR DESCRIPTION
change input for compas_occ to extend surface from fill with up to 4 curves
together with PR #15 in compas_occ

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
