### PR TITLE
Add triangulated flag to Mesh.to_vertices_and_faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added optional `triangulated` flag to `Mesh.to_vertices_and_faces`.
+
 ### Changed
 
 ### Removed

--- a/src/compas/datastructures/mesh/mesh.py
+++ b/src/compas/datastructures/mesh/mesh.py
@@ -510,16 +510,11 @@ class Mesh(HalfEdge):
                 faces.append([key_index[a], key_index[c], key_index[d]])
             else:
                 centroid = centroid_polygon([self.vertex_coordinates(key) for key in face_vertices])
+                ckey = len(vertices)
                 vertices.append(centroid)
-                vcount = len(vertices)
 
-                for i in range(len(face_vertices) - 1):
-                    a, b, c = face_vertices[i], face_vertices[i + 1], vcount - 1
-                    faces.append([key_index[a], key_index[b], c])
-
-                # last face between first, last and centroid
-                a, b, c = face_vertices[0], face_vertices[-1], vcount - 1
-                faces.append([key_index[b], key_index[a], c])
+                for a, b in pairwise(face_vertices + face_vertices[:1]):
+                    faces.append([key_index[a], key_index[b], ckey])
 
         return vertices, faces
 

--- a/src/compas/datastructures/mesh/mesh.py
+++ b/src/compas/datastructures/mesh/mesh.py
@@ -509,7 +509,7 @@ class Mesh(HalfEdge):
                 faces.append([key_index[a], key_index[b], key_index[c]])
                 faces.append([key_index[a], key_index[c], key_index[d]])
             else:
-                centroid = centroid_polygon([self.vertex_coordinates(key) for key in face_vertices])
+                centroid = centroid_polygon([vertices[key_index[key]] for key in face_vertices])
                 ckey = len(vertices)
                 vertices.append(centroid)
 

--- a/src/compas/geometry/shapes/_shape.py
+++ b/src/compas/geometry/shapes/_shape.py
@@ -10,7 +10,7 @@ class Shape(Geometry):
     """Base class for geometric shapes."""
 
     @abc.abstractmethod
-    def to_vertices_and_faces(self):
+    def to_vertices_and_faces(self, triangulated=False):
         pass
 
     def __add__(self, other):

--- a/tests/compas/datastructures/test_mesh.py
+++ b/tests/compas/datastructures/test_mesh.py
@@ -1,4 +1,3 @@
-from pickle import TRUE
 import tempfile
 
 import pytest

--- a/tests/compas/datastructures/test_mesh.py
+++ b/tests/compas/datastructures/test_mesh.py
@@ -1,3 +1,4 @@
+from pickle import TRUE
 import tempfile
 
 import pytest
@@ -7,6 +8,7 @@ from compas.datastructures import Mesh
 from compas.datastructures import meshes_join_and_weld
 from compas.geometry import Box
 from compas.geometry import Polygon
+from compas.geometry import Polyhedron
 from compas.geometry import Translation
 from compas.geometry import allclose
 
@@ -182,6 +184,25 @@ def test_to_vertices_and_faces():
     assert len(vertices) == 36
     assert len(faces) == 25
 
+
+def test_to_vertices_and_faces_triangulated():
+    # tri
+    mesh = Mesh.from_shape(Polyhedron.from_platonicsolid(4))
+    vertices, faces = mesh.to_vertices_and_faces(triangulated=True)
+    assert len(vertices) == 4
+    assert len(faces) == 4
+
+    # quad
+    mesh = Mesh.from_shape(Polyhedron.from_platonicsolid(6))
+    vertices, faces = mesh.to_vertices_and_faces(triangulated=True)
+    assert len(vertices) == 8
+    assert len(faces) == 12
+
+    # ngon
+    mesh = Mesh.from_shape(Polyhedron.from_platonicsolid(12))
+    vertices, faces = mesh.to_vertices_and_faces(triangulated=True)
+    assert len(vertices) == 32
+    assert len(faces) == 60
 
 # --------------------------------------------------------------------------
 # helpers


### PR DESCRIPTION
For consistency with the other `to_vertices_and_faces` methods in all shapes, I added the same `triangulated=False` optional flag to `Mesh` (and also to the abstract method of `Shape`)

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
