### PR TITLE
new: serialize/deserialize meshes on mesh descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added optional `triangulated` flag to `Mesh.to_vertices_and_faces`.
+* Added geometry information of active meshes to the serialization/deserialization of robot model's `MeshDescriptor`.
 
 ### Changed
 

--- a/src/compas/robots/model/geometry.py
+++ b/src/compas/robots/model/geometry.py
@@ -173,6 +173,7 @@ class MeshDescriptor(Data):
             'filename': self.filename,
             'scale': self.scale,
             'attr': _attr_to_data(self.attr),
+            'meshes': [m.data for m in self.meshes],
         }
 
     @data.setter
@@ -180,6 +181,7 @@ class MeshDescriptor(Data):
         self.filename = data['filename']
         self.scale = data['scale']
         self.attr = _attr_from_data(data['attr']) if 'attr' in data else {}
+        self.meshes = [Mesh.from_data(md) for md in data['meshes']] if 'meshes' in data else []
 
     @classmethod
     def from_data(cls, data):

--- a/src/compas/robots/model/geometry.py
+++ b/src/compas/robots/model/geometry.py
@@ -366,6 +366,7 @@ TYPE_CLASS_ENUM_BY_DATA = {
     ('point', 'radius'): compas.geometry.Sphere,
     ('line', 'radius'): compas.geometry.Capsule,
     ('attr', 'filename', 'scale'): MeshDescriptor,
+    ('attr', 'filename', 'meshes', 'scale'): MeshDescriptor,
 }
 
 


### PR DESCRIPTION
This could almost be considered a bug, but let's say it's a new feature. The mesh descriptors were being serialized only with file names, but not with the loaded meshes, which makes the serialization relatively useless in a lot of context, so, even if it creates larger files, it makes a lot of sense to serialize the meshes together with the descriptor.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
