### PR TITLE
* Set `jinja >= 3.0` to dev dependencies to fix docs build error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Set `jinja >= 3.0` to dev dependencies to fix docs build error.
+
 ### Removed
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,5 @@ sphinx_compas_theme >=0.15.18
 sphinx >=3.4
 twine
 wheel
+jinja2 >= 3.0
 -e .


### PR DESCRIPTION
Fixing this: https://github.com/compas-dev/compas/runs/5721182179?check_suite_focus=true