### PR TITLE
Add Mesh.to_lines() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Data.sha256` for computing a hash value of data objects, for example for comparisons during version control.
 * Added optional `path` parameter to `compas.rpc.Proxy` to allow for non-package calls.
 * Added Grasshopper component to call RPC functions.
+* Added `Mesh.to_lines` method and tests.
 
 ### Changed
 

--- a/src/compas/datastructures/mesh/mesh.py
+++ b/src/compas/datastructures/mesh/mesh.py
@@ -377,15 +377,15 @@ class Mesh(HalfEdge):
         return mesh
 
     def to_lines(self):
-        """Convert the mesh to a collection of lines.
+        """Return the lines of the mesh as pairs of start and end point coordinates.
 
         Returns
         -------
         list[tuple[list[float], list[float]]]
-            A list of lines each defined by a pair of points.
+            A list of lines each defined by a pair of point coordinates.
 
         """
-        raise NotImplementedError
+        return [self.edge_coordinates(u, v) for u, v in self.edges()]
 
     @classmethod
     def from_polylines(cls, boundary_polylines, other_polylines):

--- a/src/compas/datastructures/network/network.py
+++ b/src/compas/datastructures/network/network.py
@@ -221,6 +221,7 @@ class Network(Graph):
         Returns
         -------
         :class:`~compas.datastructures.Network`
+            A network object.
 
         """
         network = cls()
@@ -256,6 +257,7 @@ class Network(Graph):
         Returns
         -------
         list[list[float]]
+            A list with the coordinates of the vertices of the network.
 
         """
         return [self.node_coordinates(key) for key in self.nodes()]
@@ -266,6 +268,7 @@ class Network(Graph):
         Returns
         -------
         list[tuple[list[float], list[float]]]
+            A list of lines each defined by a pair of point coordinates.
 
         """
         return [self.edge_coordinates(u, v) for u, v in self.edges()]

--- a/tests/compas/datastructures/test_mesh.py
+++ b/tests/compas/datastructures/test_mesh.py
@@ -203,6 +203,14 @@ def test_to_vertices_and_faces_triangulated():
     assert len(vertices) == 32
     assert len(faces) == 60
 
+
+def test_to_lines():
+    lines = compas.json_load(compas.get('lines.json'))
+    mesh = Mesh.from_lines(lines)
+    lines = mesh.to_lines()
+    assert len(lines) == mesh.number_of_edges()
+
+
 # --------------------------------------------------------------------------
 # helpers
 # --------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the method `Mesh.to_lines()` which was missing to the `class compas.datastructures.Mesh`.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [X] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
