### PR TITLE
Small fixes/improvements to Assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Set `jinja >= 3.0` to dev dependencies to fix docs build error.
 * Fixed removing of collections for `compas_plotters`.
-* Fixed `find` part by GUID after deserialization in `Assembly`.
+* Rebuild part index after deserialization in `Assembly`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added optional `path` parameter to `compas.rpc.Proxy` to allow for non-package calls.
 * Added Grasshopper component to call RPC functions.
 * Added `Mesh.to_lines` method and tests.
+* Added `Assembly.find_by_key` to locate parts by key.
 
 ### Changed
 
 * Set `jinja >= 3.0` to dev dependencies to fix docs build error.
 * Fixed removing of collections for `compas_plotters`.
+* Fixed `find` part by GUID after deserialization in `Assembly`.
 
 ### Removed
 

--- a/src/compas/datastructures/__init__.py
+++ b/src/compas/datastructures/__init__.py
@@ -23,6 +23,17 @@ Classes
     Part
 
 
+Exceptions
+==========
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    AssemblyError
+    FeatureError
+
+
 Functions
 =========
 
@@ -296,7 +307,9 @@ from .volmesh import (
 
 from .assembly import (
     Assembly,
-    Part
+    Part,
+    AssemblyError,
+    FeatureError,
 )
 
 if not compas.IPY:
@@ -439,6 +452,8 @@ __all__ = [
     # Assemblies
     'Assembly',
     'Part',
+    'AssemblyError',
+    'FeatureError',
 ]
 
 if not compas.IPY:

--- a/src/compas/datastructures/assembly/__init__.py
+++ b/src/compas/datastructures/assembly/__init__.py
@@ -1,6 +1,8 @@
-from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
 
-from .assembly import Assembly  # noqa: F401 F403
-from .part import Part  # noqa: F401 F403
+from .exceptions import AssemblyError  # noqa: F401
+from .exceptions import FeatureError  # noqa: F401
+from .assembly import Assembly  # noqa: F401
+from .part import Part  # noqa: F401

--- a/src/compas/datastructures/assembly/assembly.py
+++ b/src/compas/datastructures/assembly/assembly.py
@@ -30,9 +30,10 @@ class Assembly(Datastructure):
 
     def __init__(self, name=None, **kwargs):
         super(Assembly, self).__init__()
-        self.attributes = {"name": name or "Assembly", "guid_key_map": {}}
+        self.attributes = {"name": name or "Assembly"}
         self.attributes.update(kwargs)
         self.graph = Graph()
+        self._parts = {}
 
     # ==========================================================================
     # data
@@ -65,6 +66,7 @@ class Assembly(Datastructure):
     def data(self, data):
         self.attributes.update(data["attributes"] or {})
         self.graph.data = data["graph"]
+        self._parts = {part.guid: part.key for part in self.parts()}
 
     # ==========================================================================
     # properties
@@ -115,12 +117,11 @@ class Assembly(Datastructure):
             The identifier of the part in the current assembly graph.
 
         """
-        guid_key_map = self.attributes["guid_key_map"]
-        if part.guid in guid_key_map.keys():
+        if part.guid in self._parts.keys():
             raise AssemblyError("Part already added to the assembly")
         key = self.graph.add_node(key=key, part=part, **kwargs)
         part.key = key
-        guid_key_map[part.guid] = part.key
+        self._parts[part.guid] = part.key
         return key
 
     def add_connection(self, a, b, **kwargs):
@@ -198,7 +199,7 @@ class Assembly(Datastructure):
             or None if the part can't be found.
 
         """
-        key = self.attributes["guid_key_map"].get(guid)
+        key = self._parts.get(guid)
 
         if key is None:
             return None

--- a/src/compas/datastructures/assembly/assembly.py
+++ b/src/compas/datastructures/assembly/assembly.py
@@ -30,10 +30,9 @@ class Assembly(Datastructure):
 
     def __init__(self, name=None, **kwargs):
         super(Assembly, self).__init__()
-        self.attributes = {'name': name or 'Assembly'}
+        self.attributes = {"name": name or "Assembly", "guid_key_map": {}}
         self.attributes.update(kwargs)
         self.graph = Graph()
-        self._parts = {}
 
     # ==========================================================================
     # data
@@ -113,11 +112,12 @@ class Assembly(Datastructure):
             The identifier of the part in the current assembly graph.
 
         """
-        if part.guid in self._parts:
-            raise AssemblyError('Part already added to the assembly')
+        guid_key_map = self.attributes["guid_key_map"]
+        if part.guid in guid_key_map.keys():
+            raise AssemblyError("Part already added to the assembly")
         key = self.graph.add_node(key=key, part=part, **kwargs)
         part.key = key
-        self._parts[part.guid] = part
+        guid_key_map[part.guid] = part.key
         return key
 
     def add_connection(self, a, b, **kwargs):
@@ -194,4 +194,10 @@ class Assembly(Datastructure):
             or None if the part can't be found.
 
         """
-        return self._parts.get(guid)
+        key = self.attributes["guid_key_map"].get(guid)
+
+        if key is None:
+            return None
+
+        return self.graph.node_attribute(key, "part")
+

--- a/src/compas/datastructures/assembly/assembly.py
+++ b/src/compas/datastructures/assembly/assembly.py
@@ -117,7 +117,7 @@ class Assembly(Datastructure):
             The identifier of the part in the current assembly graph.
 
         """
-        if part.guid in self._parts.keys():
+        if part.guid in self._parts:
             raise AssemblyError("Part already added to the assembly")
         key = self.graph.add_node(key=key, part=part, **kwargs)
         part.key = key

--- a/src/compas/datastructures/assembly/assembly.py
+++ b/src/compas/datastructures/assembly/assembly.py
@@ -201,3 +201,22 @@ class Assembly(Datastructure):
 
         return self.graph.node_attribute(key, "part")
 
+    def find_by_key(self, key):
+        """Find a part in the assembly by its key.
+
+        Parameters
+        ----------
+        key : int | str, optional
+            The identifier of the part in the assembly.
+
+        Returns
+        -------
+        :class:`~compas.datastructures.Part` | None
+            The identified part,
+            or None if the part can't be found.
+
+        """
+        if key not in self.graph.node:
+            return None
+
+        return self.graph.node_attribute(key, "part")

--- a/src/compas/datastructures/assembly/assembly.py
+++ b/src/compas/datastructures/assembly/assembly.py
@@ -41,27 +41,30 @@ class Assembly(Datastructure):
     @property
     def DATASCHEMA(self):
         import schema
-        return schema.Schema({
-            "attributes": dict,
-            "graph": Graph,
-        })
+
+        return schema.Schema(
+            {
+                "attributes": dict,
+                "graph": Graph,
+            }
+        )
 
     @property
     def JSONSCHEMANAME(self):
-        return 'assembly'
+        return "assembly"
 
     @property
     def data(self):
         data = {
-            'attributes': self.attributes,
-            'graph': self.graph.data,
+            "attributes": self.attributes,
+            "graph": self.graph.data,
         }
         return data
 
     @data.setter
     def data(self, data):
-        self.attributes.update(data['attributes'] or {})
-        self.graph.data = data['graph']
+        self.attributes.update(data["attributes"] or {})
+        self.graph.data = data["graph"]
 
     # ==========================================================================
     # properties
@@ -69,11 +72,11 @@ class Assembly(Datastructure):
 
     @property
     def name(self):
-        return self.attributes.get('name') or self.__class__.__name__
+        return self.attributes.get("name") or self.__class__.__name__
 
     @name.setter
     def name(self, value):
-        self.attributes['name'] = value
+        self.attributes["name"] = value
 
     # ==========================================================================
     # customization
@@ -143,10 +146,11 @@ class Assembly(Datastructure):
             If `a` and/or `b` are not in the assembly.
 
         """
+        error_msg = "Both parts have to be added to the assembly before a connection can be created."
         if a.key is None or b.key is None:
-            raise AssemblyError('Both parts have to be added to the assembly before a connection can be created.')
+            raise AssemblyError(error_msg)
         if not self.graph.has_node(a.key) or not self.graph.has_node(b.key):
-            raise AssemblyError('Both parts have to be added to the assembly before a connection can be created.')
+            raise AssemblyError(error_msg)
         return self.graph.add_edge(a.key, b.key, **kwargs)
 
     def parts(self):
@@ -159,7 +163,7 @@ class Assembly(Datastructure):
 
         """
         for node in self.graph.nodes():
-            yield self.graph.node_attribute(node, 'part')
+            yield self.graph.node_attribute(node, "part")
 
     def connections(self, data=False):
         """Iterate over the connections between the parts.

--- a/src/compas/datastructures/assembly/exceptions.py
+++ b/src/compas/datastructures/assembly/exceptions.py
@@ -1,9 +1,4 @@
-
 class AssemblyError(Exception):
-    pass
-
-
-class FrameError(Exception):
     pass
 
 

--- a/tests/compas/datastructures/test_assembly.py
+++ b/tests/compas/datastructures/test_assembly.py
@@ -1,14 +1,17 @@
-from compas.datastructures import Assembly, assembly
+import pytest
+
+from compas.datastructures import Assembly
+from compas.datastructures import AssemblyError
 from compas.datastructures import Part
 
 
 def test_init():
-    assembly = Assembly(name='abc')
-    assert assembly.name == 'abc'
+    assembly = Assembly(name="abc")
+    assert assembly.name == "abc"
 
-    assembly = Assembly(attr1='value', attr2=3.14)
-    assert assembly.attributes['attr1'] == 'value'
-    assert assembly.attributes['attr2'] == 3.14
+    assembly = Assembly(attr1="value", attr2=3.14)
+    assert assembly.attributes["attr1"] == "value"
+    assert assembly.attributes["attr2"] == 3.14
 
 
 def test_add_parts():
@@ -18,6 +21,16 @@ def test_add_parts():
         assembly.add_part(Part())
 
     assert len(list(assembly.parts())) == 3
+
+
+def test_add_duplicate_parts():
+    assembly = Assembly()
+
+    part = Part()
+    assembly.add_part(part)
+
+    with pytest.raises(AssemblyError):
+        assembly.add_part(part)
 
 
 def test_add_connections():

--- a/tests/compas/datastructures/test_assembly.py
+++ b/tests/compas/datastructures/test_assembly.py
@@ -67,3 +67,11 @@ def test_find_by_key():
     assert assembly.find_by_key("6") == part
 
     assert assembly.find_by_key("100") is None
+
+
+def test_find_by_key_after_deserialization():
+    assembly = Assembly()
+    part = Part()
+    assembly.add_part(part, key=2)
+    assembly = Assembly.from_data(assembly.to_data())
+    assert assembly.find_by_key(2) == part

--- a/tests/compas/datastructures/test_assembly.py
+++ b/tests/compas/datastructures/test_assembly.py
@@ -41,3 +41,16 @@ def test_find():
 
     assembly.add_part(part)
     assert assembly.find(part.guid) == part
+
+
+def test_find_by_key():
+    assembly = Assembly()
+    part = Part()
+    assembly.add_part(part, key=2)
+    assert assembly.find_by_key(2) == part
+
+    part = Part()
+    assembly.add_part(part, key="6")
+    assert assembly.find_by_key("6") == part
+
+    assert assembly.find_by_key("100") is None


### PR DESCRIPTION
A couple of fixes/improvements to `Assembly`:
* Fixed the `find` method which relied on the `self._parts` dictionary to map guids to parts, however, that dictionary was not restored after deserialization. 
* Added a matching `find_by_key` to `Assembly` because it was not possible to lookup parts by their keys.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
