### PR TITLE
add boundary faces option to mesh_dual

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -32,3 +32,4 @@
 - Mattis Koh <<mattiskoh@gmail.com>> [@mattiskoh](https://github.com/mattiskoh)
 - Andrea Ghensi <<a.ghensi@swsglobal.com>> [@sanzoghenzo](https://github.com/sanzoghenzo)
 - Nizar Taha <<taha@arch.ethz.ch>> [@nizartaha](https://github.com/nizartaha)
+- Gene Ting-Chun Kao <<kao@arch.ethz.ch>> [@GeneKao](https://github.com/GeneKao)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Data.guid` to JSON serialization.
 * Added `Data.guid` to pickle state.
 * Added `Assembly.find_by_key` to locate parts by key.
-* Added `Mesh.mesh_dual` with additional option to include boundary faces. 
 
 ### Changed
 
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug in `compas.robots.Configuration`.
 * Rebuild part index after deserialization in `Assembly`.
 * Fixed bug in `compas.artists.colordict.ColorDict`.
+* Change `Mesh.mesh_dual` with option of including the boundary. 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Data.guid` to JSON serialization.
 * Added `Data.guid` to pickle state.
 * Added `Assembly.find_by_key` to locate parts by key.
+* Added `Mesh.mesh_dual` with additional option to include boundary faces. 
 
 ### Changed
 

--- a/src/compas/datastructures/mesh/duality.py
+++ b/src/compas/datastructures/mesh/duality.py
@@ -35,6 +35,7 @@ def mesh_dual(mesh, cls=None, boundary=0):
 
     Examples
     --------
+    >>> import compas
     >>> from compas.datastructures import Mesh
     >>> mesh = Mesh.from_obj(compas.get('faces.obj'))
     >>> mesh.delete_face(11)

--- a/src/compas/datastructures/mesh/duality.py
+++ b/src/compas/datastructures/mesh/duality.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 from __future__ import division
 
 from math import pi
-
+from compas.utilities import flatten
+from compas.utilities import geometric_key
 
 __all__ = ['mesh_dual']
 
@@ -11,7 +12,7 @@ __all__ = ['mesh_dual']
 PI2 = 2.0 * pi
 
 
-def mesh_dual(mesh, cls=None):
+def mesh_dual(mesh, cls=None, boundary=0):
     """Construct the dual of a mesh.
 
     Parameters
@@ -21,6 +22,9 @@ def mesh_dual(mesh, cls=None):
     cls : Type[:class:`~compas.datastructures.Mesh`], optional
         The type of the dual mesh.
         Defaults to the type of the provided mesh object.
+    boundary: float, optional
+        boundary mode for the dual mesh
+        Default mode is 0, not create faces on boundaries
 
     Returns
     -------
@@ -34,16 +38,44 @@ def mesh_dual(mesh, cls=None):
     dual = cls()
 
     face_centroid = {face: mesh.face_centroid(face) for face in mesh.faces()}
-    inner = list(set(mesh.vertices()) - set(mesh.vertices_on_boundary()))
+    outer = list(flatten(mesh.vertices_on_boundaries()))
     vertex_xyz = {}
     face_vertices = {}
+    boundary_xyz = {}
 
-    for vertex in inner:
+    # safe guarded if face index is arbitrary, random, not starting from 0
+    num_faces = max(max(list(mesh.faces())) + 1, mesh.number_of_faces())
+    for vertex in mesh.vertices():
         faces = mesh.vertex_faces(vertex, ordered=True)
         for face in faces:
             if face not in vertex_xyz:
                 vertex_xyz[face] = face_centroid[face]
         face_vertices[vertex] = faces
+
+        if not boundary:
+            continue
+        if vertex not in outer or len(faces) <= 1:
+            continue
+
+        nbr_vertices = reversed(mesh.vertex_neighbors(vertex, ordered=True))
+        boundary_vertices = faces
+
+        for nbr_vertex in nbr_vertices:
+
+            if mesh.is_edge_on_boundary(vertex, nbr_vertex):
+                pt = mesh.edge_midpoint(vertex, nbr_vertex)
+
+                if geometric_key(pt) not in boundary_xyz and num_faces not in vertex_xyz:
+                    vertex_xyz[num_faces] = pt
+                    boundary_xyz[geometric_key(pt)] = num_faces
+                    num_faces += 1
+
+                if geometric_key(pt) in boundary_xyz:
+                    boundary_vertices.append(boundary_xyz[geometric_key(pt)])
+                else:
+                    boundary_vertices.append(num_faces)
+
+        face_vertices[vertex] = boundary_vertices
 
     for vertex in vertex_xyz:
         x, y, z = vertex_xyz[vertex]

--- a/src/compas/datastructures/mesh/duality.py
+++ b/src/compas/datastructures/mesh/duality.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 from math import pi
 from compas.utilities import flatten
-from compas.utilities import geometric_key
 
 __all__ = ['mesh_dual']
 
@@ -24,12 +23,26 @@ def mesh_dual(mesh, cls=None, boundary=0):
         Defaults to the type of the provided mesh object.
     boundary: float, optional
         boundary mode for the dual mesh
-        Default mode is 0, not create faces on boundaries
+        Default mode is 0, not create faces on boundaries.
+        1, create faces on mesh edges, not include original mesh boundary vertices.
+        2. create faces on mesh edges and include original mesh boundary vertices on the corner.
+        3. create faces on mesh edges and include all original mesh boundary vertices.
 
     Returns
     -------
     :class:`~compas.datastructures.Mesh`
         The dual mesh object.
+
+    Examples
+    --------
+    >>> from compas.datastructures import Mesh
+    >>> mesh = Mesh.from_obj(compas.get('faces.obj'))
+    >>> mesh.delete_face(11)
+    >>> mesh.delete_face(6)
+    >>> mesh.delete_face(7)
+    >>> mesh.quads_to_triangles()
+    >>> mesh = mesh.subdivide('corner')
+    >>> dual = mesh.dual(boundary=3)
 
     """
     if not cls:
@@ -37,11 +50,14 @@ def mesh_dual(mesh, cls=None, boundary=0):
 
     dual = cls()
 
+    mesh.unify_cycles()
+    mesh.flip_cycles()
+
     face_centroid = {face: mesh.face_centroid(face) for face in mesh.faces()}
     outer = list(flatten(mesh.vertices_on_boundaries()))
     vertex_xyz = {}
     face_vertices = {}
-    boundary_xyz = {}
+    edge_vertex = {}
 
     # safe guarded if face index is arbitrary, random, not starting from 0
     num_faces = max(max(list(mesh.faces())) + 1, mesh.number_of_faces())
@@ -54,28 +70,53 @@ def mesh_dual(mesh, cls=None, boundary=0):
 
         if not boundary:
             continue
-        if vertex not in outer or len(faces) <= 1:
+
+        if boundary > 3:
+            raise ValueError("edge mode from 0 to 3!")
+
+        if vertex not in outer or len(faces) < 1:
             continue
 
-        nbr_vertices = reversed(mesh.vertex_neighbors(vertex, ordered=True))
-        boundary_vertices = faces
+        boundary_fids = faces[:]
+        current_face = vertex
+        corner_count = 0
+        edge_count = 0
 
-        for nbr_vertex in nbr_vertices:
+        for nbr_vertex in reversed(mesh.vertex_neighbors(vertex, ordered=True)):
 
-            if mesh.is_edge_on_boundary(vertex, nbr_vertex):
-                pt = mesh.edge_midpoint(vertex, nbr_vertex)
+            if not mesh.is_edge_on_boundary(vertex, nbr_vertex):
+                continue
+            pt = mesh.edge_midpoint(vertex, nbr_vertex)
 
-                if geometric_key(pt) not in boundary_xyz and num_faces not in vertex_xyz:
-                    vertex_xyz[num_faces] = pt
-                    boundary_xyz[geometric_key(pt)] = num_faces
-                    num_faces += 1
+            if num_faces not in vertex_xyz and len(faces) == 1 and corner_count == 0 and (boundary == 2 or boundary == 3):
+                vertex_xyz[num_faces] = mesh.vertex_coordinates(vertex)
+                current_face = num_faces
+                num_faces += 1
+                corner_count += 1
 
-                if geometric_key(pt) in boundary_xyz:
-                    boundary_vertices.append(boundary_xyz[geometric_key(pt)])
-                else:
-                    boundary_vertices.append(num_faces)
+            if num_faces not in vertex_xyz and len(faces) != 1 and edge_count == 0 and boundary == 3:
+                vertex_xyz[num_faces] = mesh.vertex_coordinates(vertex)
+                current_face = num_faces
+                num_faces += 1
+                edge_count += 1
 
-        face_vertices[vertex] = boundary_vertices
+            if num_faces not in vertex_xyz and ((vertex, nbr_vertex) not in edge_vertex and
+                                                (nbr_vertex, vertex) not in edge_vertex):
+
+                vertex_xyz[num_faces] = pt
+                edge_vertex[vertex, nbr_vertex] = edge_vertex[nbr_vertex, vertex] = num_faces
+                boundary_fids.append(num_faces)
+                num_faces += 1
+            else:
+                boundary_fids.append(edge_vertex[vertex, nbr_vertex])
+
+        if vertex in outer and len(faces) == 1 and (boundary == 2 or boundary == 3):
+            boundary_fids.insert(len(faces) + 1, current_face)
+
+        if vertex in outer and len(faces) != 1 and boundary == 3:
+            boundary_fids.insert(len(faces) + 1, current_face)
+
+        face_vertices[vertex] = boundary_fids
 
     for vertex in vertex_xyz:
         x, y, z = vertex_xyz[vertex]

--- a/src/compas/datastructures/mesh/duality.py
+++ b/src/compas/datastructures/mesh/duality.py
@@ -11,7 +11,7 @@ __all__ = ['mesh_dual']
 PI2 = 2.0 * pi
 
 
-def mesh_dual(mesh, cls=None, include_boundary=False, preserve_boundary_vertices=False, preserve_corner_vertices=False):
+def mesh_dual(mesh, cls=None, include_boundary=False):
     """Construct the dual of a mesh.
 
     Parameters
@@ -24,12 +24,6 @@ def mesh_dual(mesh, cls=None, include_boundary=False, preserve_boundary_vertices
     include_boundary: str, optional
         Whether to include boundary faces for the dual mesh
         Default mode is False, don't create faces on boundaries.
-    preserve_boundary_vertices: str, optional
-        Whether to preserve boundary vertices from the original mesh
-        Default mode is False, include the boundary without the original vertices.
-    preserve_corner_vertices: str, optional
-        Whether to preserve corner vertices (only connect to one face) from the original mesh
-        Default mode is False, include the boundary with the original vertices only on corners.
 
     Returns
     -------
@@ -46,7 +40,7 @@ def mesh_dual(mesh, cls=None, include_boundary=False, preserve_boundary_vertices
     >>> mesh.delete_face(7)
     >>> mesh.quads_to_triangles()
     >>> mesh = mesh.subdivide('corner')
-    >>> dual = mesh.dual(include_boundary=True, preserve_boundary_vertices=True, preserve_corner_vertices=False)
+    >>> dual = mesh.dual(include_boundary=True)
 
     """
     if not cls:
@@ -54,69 +48,18 @@ def mesh_dual(mesh, cls=None, include_boundary=False, preserve_boundary_vertices
 
     dual = cls()
 
-    mesh.flip_cycles()
-
     face_centroid = {face: mesh.face_centroid(face) for face in mesh.faces()}
-    outer = list(flatten(mesh.vertices_on_boundaries()))
+    outer = set(flatten(mesh.vertices_on_boundaries()))
+    inner = list(set(mesh.vertices()) - outer)
     vertex_xyz = {}
     face_vertices = {}
-    edge_vertex = {}
 
-    # safe guarded if face index is arbitrary, random, not starting from 0
-    num_faces = max(max(list(mesh.faces())) + 1, mesh.number_of_faces())
-    for vertex in mesh.vertices():
+    for vertex in inner:
         faces = mesh.vertex_faces(vertex, ordered=True)
         for face in faces:
             if face not in vertex_xyz:
                 vertex_xyz[face] = face_centroid[face]
         face_vertices[vertex] = faces
-
-        if not include_boundary:
-            continue
-
-        if vertex not in outer or len(faces) < 1:
-            continue
-
-        boundary_fids = faces[:]
-        current_face = vertex
-        corner_count = 0
-        edge_count = 0
-
-        for nbr_vertex in reversed(mesh.vertex_neighbors(vertex, ordered=True)):
-
-            if not mesh.is_edge_on_boundary(vertex, nbr_vertex):
-                continue
-            pt = mesh.edge_midpoint(vertex, nbr_vertex)
-
-            if num_faces not in vertex_xyz and len(faces) == 1 and corner_count == 0 and (preserve_corner_vertices or preserve_boundary_vertices):
-                vertex_xyz[num_faces] = mesh.vertex_coordinates(vertex)
-                current_face = num_faces
-                num_faces += 1
-                corner_count += 1
-
-            if num_faces not in vertex_xyz and len(faces) != 1 and edge_count == 0 and preserve_boundary_vertices:
-                vertex_xyz[num_faces] = mesh.vertex_coordinates(vertex)
-                current_face = num_faces
-                num_faces += 1
-                edge_count += 1
-
-            if num_faces not in vertex_xyz and ((vertex, nbr_vertex) not in edge_vertex and
-                                                (nbr_vertex, vertex) not in edge_vertex):
-
-                vertex_xyz[num_faces] = pt
-                edge_vertex[vertex, nbr_vertex] = edge_vertex[nbr_vertex, vertex] = num_faces
-                boundary_fids.append(num_faces)
-                num_faces += 1
-            else:
-                boundary_fids.append(edge_vertex[vertex, nbr_vertex])
-
-        if vertex in outer and len(faces) == 1 and (preserve_corner_vertices or preserve_boundary_vertices):
-            boundary_fids.insert(len(faces) + 1, current_face)
-
-        if vertex in outer and len(faces) != 1 and preserve_boundary_vertices:
-            boundary_fids.insert(len(faces) + 1, current_face)
-
-        face_vertices[vertex] = boundary_fids
 
     for vertex in vertex_xyz:
         x, y, z = vertex_xyz[vertex]
@@ -124,5 +67,40 @@ def mesh_dual(mesh, cls=None, include_boundary=False, preserve_boundary_vertices
 
     for face in face_vertices:
         dual.add_face(face_vertices[face], fkey=face)
+
+    if not include_boundary:
+        return dual
+
+    for boundary in mesh.faces_on_boundaries():
+        for face in boundary:
+            if not dual.has_vertex(face):
+                x, y, z = face_centroid[face]
+                dual.add_vertex(key=face, x=x, y=y, z=z)
+
+    edge_vertex = {}
+    for boundary in mesh.edges_on_boundaries():
+        for u, v in boundary:
+            x, y, z = mesh.edge_midpoint(u, v)
+            edge_vertex[u, v] = edge_vertex[v, u] = dual.add_vertex(x=x, y=y, z=z)
+
+    vertex_vertex = {}
+    for boundary in mesh.vertices_on_boundaries():
+        if boundary[0] == boundary[-1]:
+            boundary = boundary[:-1]
+        for vertex in boundary:
+            x, y, z = mesh.vertex_coordinates(vertex)
+            vertex_vertex[vertex] = dual.add_vertex(x=x, y=y, z=z)
+
+    for boundary in mesh.vertices_on_boundaries():
+        if boundary[0] == boundary[-1]:
+            boundary = boundary[:-1]
+        for vertex in boundary:
+            vertices = [vertex_vertex[vertex]]
+            nbrs = mesh.vertex_neighbors(vertex, ordered=True)[::-1]
+            vertices.append(edge_vertex[vertex, nbrs[0]])
+            for nbr in nbrs[:-1]:
+                vertices.append(mesh.halfedge_face(vertex, nbr))
+            vertices.append(edge_vertex[vertex, nbrs[-1]])
+            dual.add_face(vertices[::-1])
 
     return dual

--- a/src/compas/datastructures/mesh/duality.py
+++ b/src/compas/datastructures/mesh/duality.py
@@ -21,9 +21,9 @@ def mesh_dual(mesh, cls=None, include_boundary=False):
     cls : Type[:class:`~compas.datastructures.Mesh`], optional
         The type of the dual mesh.
         Defaults to the type of the provided mesh object.
-    include_boundary: str, optional
+    include_boundary: bool, optional
         Whether to include boundary faces for the dual mesh
-        Default mode is False, don't create faces on boundaries.
+        If True, create faces on boundaries including all original mesh boundary vertices.
 
     Returns
     -------

--- a/src/compas/datastructures/mesh/duality.py
+++ b/src/compas/datastructures/mesh/duality.py
@@ -51,7 +51,6 @@ def mesh_dual(mesh, cls=None, boundary=0):
 
     dual = cls()
 
-    mesh.unify_cycles()
     mesh.flip_cycles()
 
     face_centroid = {face: mesh.face_centroid(face) for face in mesh.faces()}


### PR DESCRIPTION
@brgcode @Licini I have extended the `mesh_dual` function with an optional parameter to construction boundary faces. 
An optional parameter `boundary` is set to `0` by default (Can later have more options number for how we deal with boundary) without boundary faces making sure the compatibility with old code such as TNA form-finding usages.  

<img width="1312" alt="Screenshot 2022-04-28 at 14 29 50" src="https://user-images.githubusercontent.com/1162842/165752386-ae191bbc-f6be-4aaa-8573-6f84628fca4b.png">
<img width="1312" alt="Screenshot 2022-04-28 at 14 29 09" src="https://user-images.githubusercontent.com/1162842/165752399-02c49a76-bbd7-4c9c-b759-deaa1d549e8c.png">



<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [X] Bug fix in a **backwards-compatible** manner.
- [X] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)
