### PR TITLE
replaced autopep8 with black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rebuild part index after deserialization in `Assembly`.
 * Fixed bug in `compas.artists.colordict.ColorDict`.
 * Change `Mesh.mesh_dual` with option of including the boundary. 
+* Moved from `autopep8` to `black`
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,15 +37,16 @@ In short, this is how that works.
    ```
 
 5. Start making your changes to the **master** branch (or branch off of it).
-6. Make sure all tests still pass:
+6. Auto-format your code using `black -l 180 <path_to_source_file>`.
+7. Make sure all tests still pass:
 
    ```bash
    invoke test
    ```
 
-7. Add yourself to `AUTHORS.md`.
-8. Commit your changes and push your branch to GitHub.
-9. Create a [pull request](https://help.github.com/articles/about-pull-requests/) through the GitHub website.
+8. Add yourself to `AUTHORS.md`.
+9. Commit your changes and push your branch to GitHub.
+10. Create a [pull request](https://help.github.com/articles/about-pull-requests/) through the GitHub website.
 
 During development, use [pyinvoke](http://docs.pyinvoke.org/) tasks on the
 command line to ease recurring operations:

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -74,7 +74,7 @@ The procedure for submitting a PR is the following.
 Style guide
 ===========
 
-Please run `black -180 <path_to_source_file>` to auto-format your code.
+Please run `black -l 180 <path_to_source_file>` to auto-format your code.
 
 The command ``invoke lint`` runs the entire codebase through ``flake8``.
 As described in the `docs <https://flake8.pycqa.org/en/latest/manpage.html>`_,

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -74,6 +74,8 @@ The procedure for submitting a PR is the following.
 Style guide
 ===========
 
+Please run `black -180 <path_to_source_file>` to auto-format your code.
+
 The command ``invoke lint`` runs the entire codebase through ``flake8``.
 As described in the `docs <https://flake8.pycqa.org/en/latest/manpage.html>`_,
 ``flake8`` includes lint checks provided by the PyFlakes project,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-autopep8
+black
 attrs >=17.4
 bump2version >=1.0.1
 check-manifest >=0.36


### PR DESCRIPTION
Changed auto-format tool from `autopep8` to `black`. Made corresponding changes to contributor docs.
 
### What type of change is this?

- [x ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I have added necessary documentation (if appropriate)
