### PR TITLE
float to Interval when creating a RhinoBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rebuild part index after deserialization in `Assembly`.
 * Fixed bug in `compas.artists.colordict.ColorDict`.
 * Change `Mesh.mesh_dual` with option of including the boundary. 
+* Fixed type error in `compas_rhino.conversions._shapes.box_to_rhino`.
 
 ### Removed
 

--- a/src/compas_rhino/conversions/_shapes.py
+++ b/src/compas_rhino/conversions/_shapes.py
@@ -13,6 +13,7 @@ from Rhino.Geometry import Box as RhinoBox
 from Rhino.Geometry import Sphere as RhinoSphere
 from Rhino.Geometry import Cone as RhinoCone
 from Rhino.Geometry import Cylinder as RhinoCylinder
+from Rhino.Geometry import Interval
 
 from ._primitives import plane_to_rhino
 from ._primitives import circle_to_rhino
@@ -58,7 +59,7 @@ def box_to_rhino(box):
     :rhino:`Rhino.Geometry.Box`
 
     """
-    return RhinoBox(frame_to_rhino(box.frame), box.xsize, box.ysize, box.zsize)
+    return RhinoBox(frame_to_rhino(box.frame), Interval(0., box.xsize), Interval(0., box.ysize), Interval(0., box.zsize))
 
 
 def sphere_to_compas(sphere):


### PR DESCRIPTION
Fixed argument type issue in creation of RhinoBox when converting from compas `Box`. This is to address https://github.com/compas-dev/compas/issues/1042.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.

### Checklist
- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
