### PR TITLE
Fix/networkartist ghpython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Data.guid` to JSON serialization.
 * Added `Data.guid` to pickle state.
 * Added `Assembly.find_by_key` to locate parts by key.
+* Added `clear_edges` and `clear_nodes` to `NetworkArtist` for ghpython.
 
 ### Changed
 

--- a/src/compas_ghpython/artists/networkartist.py
+++ b/src/compas_ghpython/artists/networkartist.py
@@ -95,3 +95,13 @@ class NetworkArtist(GHArtist, NetworkArtist):
                 'name': "{}.edge.{}-{}".format(self.network.name, u, v)
             })
         return compas_ghpython.draw_lines(lines)
+
+    def clear_edges(self):
+        """GH Artists are state-less. Therefore, clear does not have any effect.
+        """
+        pass
+
+    def clear_nodes(self):
+        """GH Artists are state-less. Therefore, clear does not have any effect.
+        """
+        pass


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).

### What is the problem?

The `NetworkArtist` for GHPython was missing two methods set as abstract methods in the parent class `compas.artists.NetworkArtist`.

Copying, pasting, and running this script in grasshopper yields a `Runtime error (Exception): Abstract method not implemented: <unbound method NetworkArtist.clear_edges>`

```
from compas.datastructures import Network
from compas_ghpython.artists import NetworkArtist


network = Network()

network.add_node(0, x=0.0, y=0.0)
network.add_node(1, x=1.0, y=0.0)
network.add_node(2, x=0.0, y=1.0)

network.add_edge(0, 1)
network.add_edge(1, 2)

artist = NetworkArtist(network)
artist.draw_edges()
artist.draw_nodes()
```