### PR TITLE
Fixed uncentered viewbox and aspect ratio in `Plotter.zoom_extents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rebuild part index after deserialization in `Assembly`.
 * Fixed bug in `compas.artists.colordict.ColorDict`.
 * Change `Mesh.mesh_dual` with option of including the boundary. 
+* Fixed uncentered viewbox in `Plotter.zoom_extents()`
 
 ### Removed
 

--- a/src/compas_plotters/plotter.py
+++ b/src/compas_plotters/plotter.py
@@ -262,7 +262,7 @@ class Plotter:
             ypad = (yspan * (scale - 1.0)) / 2.0
             ymin -= ypad
             ymax += ypad
-        
+
         assert allclose([fig_aspect], [(xmax - xmin) / (ymax - ymin)])
 
         xlim = [xmin, xmax]


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)


### Problem?

The current values of `xlim` and `ylim` computed after invoking `Plotter.zoom_extents()` assumes that the objects added to the `Plotter` are centered and symmetric around `[0.0, 0.0]`. If the added geometry is uncentered, then the resulting plot is shifted to one side which can be disorienting. 

This issue is caused because of a) a miscalculation in the `scale` factor for `data_aspect` to match `fig_aspect`, and b) `scale` multiplies `xmin`  and  `xmax` of `xlim` (or equivalents for `y`) equally.

See a toy example below:

```
from compas.datastructures import Network
from compas_plotters import Plotter


# create network
network = Network()
network.add_node(0, x=0.0, y=0.0)
network.add_node(1, x=1.0, y=0.0)
network.add_node(2, x=1.0, y=-1.0)
network.add_node(3, x=0.0, y=-1.0)
network.add_edge(0, 1)
network.add_edge(1, 2)
network.add_edge(2, 3)
network.add_edge(3, 0)

# plot
plotter = Plotter()
plotter.add(network, nodesize=0.1)
plotter.zoom_extents()
plotter.show()
```

![zoom_wrong](https://user-images.githubusercontent.com/13332619/169149108-b942bdd2-a3d4-420a-9ee5-9955563e0073.png)

### Proposed solution

The current solution proposes to distribute the distance required to make `data_aspect==fig_aspect` in two halves.
Each of half is added to `xmin` and  `xmax` (or equivalents for `y`). Moreover, the proposed approach fixes a bug in the calculation of `xspan` and `yspan` that made the assertion `allclose([fig_aspect], [(xmax - xmin) / (ymax - ymin)])` fail.

The result is a viewbox positioned at the center of the input geometry whose `data_aspect` is equal to the `figsize` of the `Plotter`, as shown below.

![zoom_right](https://user-images.githubusercontent.com/13332619/169149043-5f358efc-f1b2-48ed-b6f5-65ed2bcc50ab.png)
