### PR TITLE
Add ToString to data class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Data.guid` to pickle state.
 * Added `Assembly.find_by_key` to locate parts by key.
 * Added `clear_edges` and `clear_nodes` to `NetworkArtist` for ghpython.
+* Added `ToString` method to `Data` to ensure that Rhino/Grasshopper correctly casts objects to string.
 
 ### Changed
 

--- a/src/compas/data/data.py
+++ b/src/compas/data/data.py
@@ -185,6 +185,18 @@ class Data(object):
     def data(self, data):
         raise NotImplementedError
 
+    def ToString(self):
+        """Converts the instance to a string.
+
+        This method exists for .NET compatibility. When using IronPython,
+        the implicit string conversion that usually takes place in CPython
+        will not kick-in, and in its place, IronPython will default to
+        printing self.GetType().FullName or similar. Overriding the `ToString`
+        method of .NET object class fixes that and makes Rhino/Grasshopper
+        display proper string representations when the objects are printed or
+        connected to a panel or other type of string output."""
+        return str(self)
+
     @property
     def jsonstring(self):
         return compas.json_dumps(self.data)

--- a/tests/compas/data/test_data.py
+++ b/tests/compas/data/test_data.py
@@ -1,0 +1,12 @@
+from compas.data import Data
+
+def test_string_casting():
+    class TestClass(Data):
+        def __init__(self, i):
+            self.i = i
+
+        def __str__(self):
+            return "TestClass {}".format(self.i)
+
+    test = TestClass(42)
+    assert str(test) == "TestClass 42"


### PR DESCRIPTION
Added `ToString` method to `Data` to ensure that Rhino/Grasshopper correctly casts objects to string.

This basically solves the following behavior, which currently affects all COMPAS objects:

![image](https://user-images.githubusercontent.com/933277/171062841-9a49881f-dc02-4696-ac1c-85fee919de99.png)

Now shows as:

![image](https://user-images.githubusercontent.com/933277/171062900-474ec210-3dde-4571-b7b8-b4126339759b.png)


### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
