### PR TITLE
Fix/uninstall ghplugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved from `autopep8` to `black`
 * Fixed bug in `compas.utilities.linspace` for number series with high precision start and stop values.
 * Fixed uncentered viewbox in `Plotter.zoom_extents()`
+* Fixed source directory path in `compas_ghpython.uninstall` plugin.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug in `compas.utilities.linspace` for number series with high precision start and stop values.
 * Fixed uncentered viewbox in `Plotter.zoom_extents()`
 * Fixed source directory path in `compas_ghpython.uninstall` plugin.
+* Fixed bug in`compas_ghpython.components`that ignored input list of `.ghuser` objects to uninstall.
 
 ### Removed
 

--- a/src/compas_ghpython/components/__init__.py
+++ b/src/compas_ghpython/components/__init__.py
@@ -76,14 +76,16 @@ def install_userobjects(source):
     return list(zip(symlinks_to_add, created))
 
 
-def uninstall_userobjects(userobjects):
+def uninstall_userobjects(userobjects=None):
     """
     Uninstalls Grasshopper user objects.
 
     Parameters
     ----------
-    userobjects : list of str
+    userobjects : list of str, optional
         List of user object names to uninstall, eg. ``['Compas_Info.ghuser']``
+        Defaults to ``None``, in which case the uninstaller will search for user objects
+        whose name starts with the string 'compas'.
 
     Returns
     -------
@@ -93,10 +95,11 @@ def uninstall_userobjects(userobjects):
     version = get_version_from_args()
     dstdir = get_grasshopper_userobjects_path(version)
 
-    userobjects = []
-    for name in os.listdir(dstdir):
-        if name.lower().startswith('compas'):
-            userobjects.append(name)
+    if not userobjects:
+        userobjects = []
+        for name in os.listdir(dstdir):
+            if name.lower().startswith('compas'):
+                userobjects.append(name)
 
     symlinks = []
     for obj in userobjects:
@@ -108,7 +111,4 @@ def uninstall_userobjects(userobjects):
     return list(zip(symlinks, removed))
 
 
-__all__ = [
-    'install_userobjects',
-    'uninstall_userobjects'
-]
+__all__ = ['install_userobjects', 'uninstall_userobjects']

--- a/src/compas_ghpython/uninstall.py
+++ b/src/compas_ghpython/uninstall.py
@@ -14,7 +14,7 @@ def after_rhino_uninstall(uninstalled_packages):
     if 'compas_ghpython' not in uninstalled_packages:
         return []
 
-    srcdir = os.path.join(os.path.dirname(__file__), 'components')
+    srcdir = os.path.join(os.path.dirname(__file__), 'components', 'ghuser')
     userobjects = [os.path.basename(ghuser) for ghuser in glob.glob(os.path.join(srcdir, '*.ghuser'))]
     uninstalled_objects = uninstall_userobjects(userobjects)
 


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

### What are the issues?

The source directory path in `compas_ghpython.uninstall` to uninstall the COMPAS gh plugin was missing the "ghuser"  subfolder. Thus, there is a mismatch with the install path specified by `compas_ghpython.install`.

Most relevantly, `compas_ghpython.components.uninstall_userobjects` internally discarded the input list with the names of the .ghuser objects to uninstall. 

This silent bug did not cause any apparent trouble with the installation of the main library since the names of the COMPAS gh components were prefixed with "compas".  However, this bug makes the gh components of other COMPAS extensions (e.g. COMPAS CEM) to not be uninstalled if they happen to follow a different naming convention (e.g. CEM_AddTrailEdge).

As a result, I propose to gather all the gh components whose names start with "compas" during the uninstall as the fallback option, not the main one, particularly since we are already searching for all the gh components names --prefixed by "compas" or not-- in line 18 of `compas_ghpython.uninstall`.