### PR TITLE
Lock sphinx version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug in `compas.utilities.linspace` for number series with high precision start and stop values.
 * Fixed uncentered viewbox in `Plotter.zoom_extents()`
 * Changed `RobotModelArtists.atteched_tool_models` to dictionary to support multiple tools.
+* Locked `sphinx` to 4.5.
 
 ### Removed
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ nbsphinx
 pydocstyle
 pytest <7.1
 sphinx_compas_theme >=0.15.18
-sphinx >=3.4
+sphinx ==4.5
 twine
 wheel
 jinja2 >= 3.0


### PR DESCRIPTION
The latest sphinx 5.0 released few days ago is breaking the search box on our docs site. Let's lock it to 4.5 for now until they get it fixed (or until we figure out what we need to change to work with latest version). 