### PR TITLE
added note about usage of unload_modules

### DIFF
--- a/docs/gettingstarted/grasshopper.rst
+++ b/docs/gettingstarted/grasshopper.rst
@@ -60,3 +60,10 @@ recognizes the changes. To avoid restarting Rhino, you can use the function
 
     unload_modules('compas_fab')
 
+.. note::
+
+    Prefer using `unload_modules` as early as possible in your grasshopper
+    workflow. Re-loading modules later might result, for example,
+    in COMPAS not being able to find an `Artist` as well as other issues
+    related to a mid-workflow re-definition of Python types.
+


### PR DESCRIPTION
### What type of change is this?

Added a note to docs regarding the usage of `unload_modules` to re-load python modules into Grasshopper. This is to help users avoid the potential issues this involves.

- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I have added necessary documentation (if appropriate)
