### PR TITLE
Rhino box bug

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,3 +33,4 @@
 - Andrea Ghensi <<a.ghensi@swsglobal.com>> [@sanzoghenzo](https://github.com/sanzoghenzo)
 - Nizar Taha <<taha@arch.ethz.ch>> [@nizartaha](https://github.com/nizartaha)
 - Gene Ting-Chun Kao <<kao@arch.ethz.ch>> [@GeneKao](https://github.com/GeneKao)
+- Chen Kasirer <<kasirer@arch.ethz.ch>> [@chenkasirer](https://github.com/chenkasirer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed uncentered viewbox in `Plotter.zoom_extents()`
 * Changed `RobotModelArtists.atteched_tool_models` to dictionary to support multiple tools.
 * Locked `sphinx` to 4.5.
+* Fixed conversion bug of transformed box in `compas_rhino.conversions._shapes`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rebuild part index after deserialization in `Assembly`.
 * Fixed bug in `compas.artists.colordict.ColorDict`.
 * Change `Mesh.mesh_dual` with option of including the boundary. 
-* Fixed type error in `compas_rhino.conversions._shapes.box_to_rhino`.
+* Fixed type error in `compas_rhino.conversions.box_to_rhino`.
 * Moved from `autopep8` to `black`
 * Fixed bug in `compas.utilities.linspace` for number series with high precision start and stop values.
 * Fixed uncentered viewbox in `Plotter.zoom_extents()`
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Locked `sphinx` to 4.5.
 * Fixed source directory path in `compas_ghpython.uninstall` plugin.
 * Fixed bug in`compas_ghpython.components`that ignored input list of `.ghuser` objects to uninstall.
-* Fixed conversion bug of transformed box in `compas_rhino.conversions._shapes`
+* Fixed conversion bug of transformed `Box` in `compas_rhino.conversions`
 
 ### Removed
 

--- a/src/compas_rhino/conversions/_shapes.py
+++ b/src/compas_rhino/conversions/_shapes.py
@@ -41,9 +41,9 @@ def box_to_compas(box):
     ysize = box.Y.Length
     zsize = box.Z.Length
     frame = plane_to_compas_frame(box.Plane)
-    frame.point.x += 0.5 * xsize
-    frame.point.y += 0.5 * ysize
-    frame.point.z += 0.5 * zsize
+    frame.point += frame.xaxis * 0.5 * xsize
+    frame.point += frame.yaxis * 0.5 * ysize
+    frame.point += frame.zaxis * 0.5 * zsize
     return Box(frame, xsize, ysize, zsize)
 
 
@@ -59,7 +59,12 @@ def box_to_rhino(box):
     :rhino:`Rhino.Geometry.Box`
 
     """
-    return RhinoBox(frame_to_rhino(box.frame), Interval(0., box.xsize), Interval(0., box.ysize), Interval(0., box.zsize))
+    # compas frame is center of box, intervals are in frame space
+    base_plane = box.frame.copy()
+    base_plane.point -= base_plane.xaxis * 0.5 * box.xsize
+    base_plane.point -= base_plane.yaxis * 0.5 * box.ysize
+    base_plane.point -= base_plane.zaxis * 0.5 * box.zsize
+    return RhinoBox(frame_to_rhino(base_plane), Interval(0, box.xsize), Interval(0, box.ysize), Interval(0, box.zsize))
 
 
 def sphere_to_compas(sphere):


### PR DESCRIPTION
This is to address two issues related to conversion to/from RhinoBox.

**CompasBox => RhinoBox** 
Was missing the offsetting of the frame point to account for the difference in frame location in box in COMPAS and Rhino (center vs. corner)

**RhinoBox => CompasBox**
Was missing scaling the offset values by the axes, causing a discrepancy when converting a transformed (rotated) Box. 

This might be considered a breaking change since client code compensating for this will now behave differently. But open for debate.

- [x] Breaking change: bug fix or new feature that involve incompatible API changes. (?)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
