### PR TITLE
sorted out some linting issues

### DIFF
--- a/src/compas/numerical/ga/ga.py
+++ b/src/compas/numerical/ga/ga.py
@@ -267,7 +267,7 @@ class GA(object):
         best = self.best_individual_index, self.current_pop['scaled'][self.best_individual_index]
         try:
             fit = self.current_pop['fit_value'][self.best_individual_index]
-        except(Exception):
+        except Exception:
             fit = None
         return TPL.format(fit_name, fit_type, num_gen, num_pop, num_var, best, fit)
 

--- a/src/compas/numerical/ga/moga.py
+++ b/src/compas/numerical/ga/moga.py
@@ -306,7 +306,7 @@ class MOGA(object):
             fitl = [list(x) for x in zip(*self.parent_pop['fit_values'])]
             best = [self.get_sorting_indices(l, reverse=False)[0] if self.fit_types[i] == 'min' else self.get_sorting_indices(l, reverse=True)[0] for i, l in enumerate(fitl)]
             fit = [min(x) if self.fit_types[i] == 'min' else max(x) for i, x in enumerate(fitl)]
-        except(Exception):
+        except Exception:
             best = None
             fit = None
         return TPL.format(fit_names, fit_types, num_gen, num_pop, num_var, best, fit)

--- a/src/compas_rhino/geometry/trimesh/curvature.py
+++ b/src/compas_rhino/geometry/trimesh/curvature.py
@@ -290,7 +290,7 @@ def trimesh_principal_curvature(M):
 
     # (3) Main - loop over all vertices
     for i in range(mesh.Vertices.Count):
-        if(A[i] == 0):
+        if A[i] == 0:
             k1.append(None)
             k2.append(None)
             continue


### PR DESCRIPTION
Sorted out linting issues in some old code that are just now detected/enforced in newer `flake8` versions (`5.0.4` currently).

Update: This was actually added to the latest [`pycodestyle`](https://github.com/PyCQA/pycodestyle) which is used by `flake8` as can be seen in their [change log](https://github.com/PyCQA/pycodestyle/blob/main/CHANGES.txt):
_* E275: requires whitespace around keywords.  PR #1063._

### What type of change is this?

- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
