### PR TITLE
fix color getattr error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `Color.__get___` AttributeError.
+
 ### Removed
 
 

--- a/src/compas/colors/color.py
+++ b/src/compas/colors/color.py
@@ -276,7 +276,7 @@ class Color(Data):
         self.private_name = '_' + name
 
     def __get__(self, obj, otype=None):
-        return getattr(obj, self.private_name) or self
+        return getattr(obj, self.private_name, None) or self
 
     def __set__(self, obj, value):
         if not obj:


### PR DESCRIPTION
Give a default value to `getattr`, to prevent it from raising `AttributeError`
<img width="614" alt="image" src="https://user-images.githubusercontent.com/17893605/184141546-ccda378f-d0a3-4ad5-bd2e-0ba168a27334.png">
