### PR TITLE
Brep boolean ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added pluggable `Brep` support with `compas.geometry.brep`.
 * Added Rhino `Brep` plugin in `compas_rhino.geometry.brep`.
+* Added boolean operations to the `compas_rhino` `Brep` backend.
+* Added boolean operation operator overloads in `compas.geometry.Brep`
 
 ### Changed
 * Based all gltf data classes on `BaseGLTFDataClass`
 
 * Fixed `Color.__get___` AttributeError.
+* Fixed `cylinder_to_rhino` conversion to match `compas.geometry.Cylinder` location.
 
 ### Removed
 

--- a/src/compas/geometry/brep/brep.py
+++ b/src/compas/geometry/brep/brep.py
@@ -607,6 +607,63 @@ class Brep(Geometry):
         """
         raise NotImplementedError
 
+    def __sub__(self, other):
+        """Compute the boolean difference using the "-" operator of this shape and another.
+
+        Parameters
+        ----------
+        other : :class:`~compas.geometry.Brep`
+            The other Brep to create a union with.
+
+        Returns
+        -------
+        :class:`~compas.geometry.Brep`
+            The Brep resulting from the difference operation.
+
+        """
+        results = type(self).from_boolean_difference(self, other)
+        if isinstance(results, list):
+            results = results[0]
+        return results
+
+    def __and__(self, other):
+        """Compute the boolean intersection using the "&" operator of this shape and another.
+
+        Parameters
+        ----------
+        other : :class:`~compas.geometry.Brep`
+            The other Brep to create a union with.
+
+        Returns
+        -------
+        :class:`~compas.geometry.Brep`
+            The Brep resulting from the intersection operation.
+
+        """
+        results = type(self).from_boolean_intersection(self, other)
+        if isinstance(results, list):
+            results = results[0]
+        return results
+
+    def __add__(self, other):
+        """Compute the boolean union using the "+" operator of this Brep and another.
+
+        Parameters
+        ----------
+        other : :class:`~compas.geometry.Brep`
+            The other Brep to create a union with.
+
+        Returns
+        -------
+        :class:`~compas.geometry.Brep`
+            The Brep resulting from the union operation.
+
+        """
+        results = type(self).from_boolean_union(self, other)
+        if isinstance(results, list):
+            results = results[0]
+        return results
+
     # ==============================================================================
     # Converters
     # ==============================================================================

--- a/src/compas_rhino/conversions/_shapes.py
+++ b/src/compas_rhino/conversions/_shapes.py
@@ -158,4 +158,7 @@ def cylinder_to_rhino(cylinder):
     :rhino:`Rhino.Geometry.Cylinder`
 
     """
-    return RhinoCylinder(circle_to_rhino(cylinder.circle), cylinder.height)
+    circle = cylinder.circle.copy()
+    height = cylinder.height
+    circle.plane.point += circle.plane.normal * (-0.5 * height)
+    return RhinoCylinder(circle_to_rhino(circle), cylinder.height)

--- a/src/compas_rhino/geometry/brep/__init__.py
+++ b/src/compas_rhino/geometry/brep/__init__.py
@@ -36,3 +36,8 @@ def from_brep(*args, **kwargs):
 @plugin(category="factories", requires=["Rhino"])
 def from_box(*args, **kwargs):
     return RhinoBrep.from_box(*args, **kwargs)
+
+
+@plugin(category="factories", requires=["Rhino"])
+def from_cylinder(*args, **kwargs):
+    return RhinoBrep.from_cylinder(*args, **kwargs)

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -235,9 +235,9 @@ class RhinoBrep(Brep):
 
         Parameters
         ----------
-        brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        breps_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
             One or more Breps from which to substract.
-        brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        breps_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
             One or more Breps to substract.
 
         Returns
@@ -288,9 +288,9 @@ class RhinoBrep(Brep):
 
         Parameters
         ----------
-        brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        breps_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
             One or more Breps to instrsect.
-        brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        breps_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
             Another one or more Breps to intersect.
 
         Returns

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -8,6 +8,7 @@ from compas_rhino.conversions import box_to_rhino
 from compas_rhino.conversions import point_to_rhino
 from compas_rhino.conversions import xform_to_rhino
 from compas_rhino.conversions import frame_to_rhino
+from compas_rhino.conversions import cylinder_to_rhino
 
 import Rhino
 
@@ -166,6 +167,23 @@ class RhinoBrep(Brep):
         rhino_box = box_to_rhino(box)
         return cls.from_brep(rhino_box.ToBrep())
 
+    @classmethod
+    def from_cylinder(cls, cylinder):
+        """Create a RhinoBrep from a box.
+
+        Parameters
+        ----------
+        box : :class:`~compas.geometry.Box`
+            The box geometry of the brep.
+
+        Returns
+        -------
+        :class:`~compas_rhino.geometry.RhinoBrep`
+
+        """
+        rhino_cylinder = cylinder_to_rhino(cylinder)
+        return cls.from_brep(rhino_cylinder.ToBrep(True, True))
+
     # ==============================================================================
     # Methods
     # ==============================================================================
@@ -210,6 +228,81 @@ class RhinoBrep(Brep):
             raise BrepTrimmingError("Trim operation ended with no result")
 
         self._brep = results[0]
+
+    @classmethod
+    def from_boolean_difference(cls, breps_a, breps_b):
+        """Construct a Brep from the boolean difference of two groups of Breps.
+
+        Parameters
+        ----------
+        brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+
+        Returns
+        -------
+        list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            list of one or more resulting Breps.
+
+        """
+        if not isinstance(brep_a, list):
+            brep_a = [brep_a]
+        if not isinstance(brep_b, list):
+            brep_b = [brep_b]
+        resulting_breps = Rhino.Geometry.Brep.CreateBooleanDifference(
+            [b.native_brep for b in brep_a],
+            [b.native_brep for b in brep_b],
+            TOLERANCE
+        )
+        return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
+
+    @classmethod
+    def from_boolean_union(cls, breps_a, breps_b):
+        """Construct a Brep from the boolean union of two groups of Breps.
+
+        Parameters
+        ----------
+        brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+
+        Returns
+        -------
+        list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            list of one or more resulting Breps.
+
+        """
+        if not isinstance(brep_a, list):
+            brep_a = [brep_a]
+        if not isinstance(brep_b, list):
+            brep_b = [brep_b]
+
+        resulting_breps = Rhino.Geometry.Brep.CreateBooleanUnion([b.native_brep for b in brep_a + brep_b], TOLERANCE)
+        return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
+
+    @classmethod
+    def from_boolean_intersection(cls, brep_a, brep_b):
+        """Construct a Brep from the boolean intersection of two groups of Breps.
+
+        Parameters
+        ----------
+        brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+
+        Returns
+        -------
+        list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            list of one or more resulting Breps.
+
+        """
+        if not isinstance(brep_a, list):
+            brep_a = [brep_a]
+        if not isinstance(brep_b, list):
+            brep_b = [brep_b]
+        resulting_breps = Rhino.Geometry.Brep.CreateBooleanIntersection(
+            [b.native_brep for b in brep_a],
+            [b.native_brep for b in brep_b],
+            TOLERANCE
+        )
+        return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
 
     # ==============================================================================
     # Other Methods

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -236,7 +236,9 @@ class RhinoBrep(Brep):
         Parameters
         ----------
         brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            One or more Breps from which to substract.
         brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            One or more Breps to substract.
 
         Returns
         -------
@@ -244,13 +246,13 @@ class RhinoBrep(Brep):
             list of one or more resulting Breps.
 
         """
-        if not isinstance(brep_a, list):
-            brep_a = [brep_a]
-        if not isinstance(brep_b, list):
-            brep_b = [brep_b]
+        if not isinstance(breps_a, list):
+            breps_a = [breps_a]
+        if not isinstance(breps_b, list):
+            breps_b = [breps_b]
         resulting_breps = Rhino.Geometry.Brep.CreateBooleanDifference(
-            [b.native_brep for b in brep_a],
-            [b.native_brep for b in brep_b],
+            [b.native_brep for b in breps_a],
+            [b.native_brep for b in breps_b],
             TOLERANCE
         )
         return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
@@ -261,8 +263,10 @@ class RhinoBrep(Brep):
 
         Parameters
         ----------
-        brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
-        brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+        breps_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            One of more breps to join.
+        breps_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            Another one of more breps to join.
 
         Returns
         -------
@@ -270,22 +274,24 @@ class RhinoBrep(Brep):
             list of one or more resulting Breps.
 
         """
-        if not isinstance(brep_a, list):
-            brep_a = [brep_a]
-        if not isinstance(brep_b, list):
-            brep_b = [brep_b]
+        if not isinstance(breps_a, list):
+            breps_a = [breps_a]
+        if not isinstance(breps_b, list):
+            breps_b = [breps_b]
 
-        resulting_breps = Rhino.Geometry.Brep.CreateBooleanUnion([b.native_brep for b in brep_a + brep_b], TOLERANCE)
+        resulting_breps = Rhino.Geometry.Brep.CreateBooleanUnion([b.native_brep for b in breps_a + breps_b], TOLERANCE)
         return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
 
     @classmethod
-    def from_boolean_intersection(cls, brep_a, brep_b):
+    def from_boolean_intersection(cls, breps_a, breps_b):
         """Construct a Brep from the boolean intersection of two groups of Breps.
 
         Parameters
         ----------
         brep_a : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            One or more Breps to instrsect.
         brep_b : :class:`~compas_rhino.geometry.RhinoBrep` or list(:class:`~compas_rhino.geometry.RhinoBrep`)
+            Another one or more Breps to intersect.
 
         Returns
         -------
@@ -293,13 +299,13 @@ class RhinoBrep(Brep):
             list of one or more resulting Breps.
 
         """
-        if not isinstance(brep_a, list):
-            brep_a = [brep_a]
-        if not isinstance(brep_b, list):
-            brep_b = [brep_b]
+        if not isinstance(breps_a, list):
+            breps_a = [breps_a]
+        if not isinstance(breps_b, list):
+            breps_b = [breps_b]
         resulting_breps = Rhino.Geometry.Brep.CreateBooleanIntersection(
-            [b.native_brep for b in brep_a],
-            [b.native_brep for b in brep_b],
+            [b.native_brep for b in breps_a],
+            [b.native_brep for b in breps_b],
             TOLERANCE
         )
         return [RhinoBrep.from_brep(brep) for brep in resulting_breps]

--- a/src/compas_rhino/geometry/brep/face.py
+++ b/src/compas_rhino/geometry/brep/face.py
@@ -47,7 +47,9 @@ class RhinoBrepFace(BrepFace):
     def data(self):
         boundary = self._loops[0].data
         holes = [loop.data for loop in self._loops[1:]]
-        return {"boundary": boundary, "surface": self._surface.data, "holes": holes}
+        surface = {"type": "nurbs"}
+        surface.update(self.surface.data)
+        return {"boundary": boundary, "surface": surface, "holes": holes}
 
     @data.setter
     def data(self, value):


### PR DESCRIPTION
Added boolean operations (Intersection/union/difference) to `compas_rhino` `Brep` backend.
Added operator overloads which map to boolean operations in `compas.geometry.Brep`
Fixed cylinder location when converting to rhino to match the one of a COMPAS cylinder

![image](https://user-images.githubusercontent.com/3398309/187847794-fdf8ee53-a859-4af8-9b76-4e5b0e8cec6d.png)


### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
