### PR TITLE
use black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added Rhino `Brep` plugin in `compas_rhino.geometry.brep`.
 * Added boolean operations to the `compas_rhino` `Brep` backend.
 * Added boolean operation operator overloads in `compas.geometry.Brep`
+* Added `format` task using `black` formatter.
 
 ### Changed
 * Based all gltf data classes on `BaseGLTFDataClass`
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `Color.__get___` AttributeError.
 * Fixed `cylinder_to_rhino` conversion to match `compas.geometry.Cylinder` location.
 * Changed linter to `black`.
+* Automatically trigger `invoke format` during `invoke release`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed `Color.__get___` AttributeError.
 * Fixed `cylinder_to_rhino` conversion to match `compas.geometry.Cylinder` location.
+* Changed linter to `black`.
 
 ### Removed
 

--- a/src/compas/artists/meshartist.py
+++ b/src/compas/artists/meshartist.py
@@ -94,7 +94,7 @@ class MeshArtist(Artist):
 
     color = Color.from_hex("#0092D2").lightened(50)
 
-    default_vertexcolor = Color.from_hex('#0092D2')
+    default_vertexcolor = Color.from_hex("#0092D2")
     default_edgecolor = Color.from_hex("#0092D2")
     default_facecolor = Color.from_hex("#0092D2").lightened(50)
 

--- a/src/compas/artists/meshartist.py
+++ b/src/compas/artists/meshartist.py
@@ -94,7 +94,7 @@ class MeshArtist(Artist):
 
     color = Color.from_hex("#0092D2").lightened(50)
 
-    default_vertexcolor = Color.from_hex("#0092D2")
+    default_vertexcolor = Color.from_hex('#0092D2')
     default_edgecolor = Color.from_hex("#0092D2")
     default_facecolor = Color.from_hex("#0092D2").lightened(50)
 

--- a/tasks.py
+++ b/tasks.py
@@ -129,8 +129,8 @@ def docs(ctx, doctest=False, rebuild=False, check_links=False):
 @task()
 def lint(ctx):
     """Check the consistency of coding style."""
-    log.write("Running flake8 python linter...")
-    ctx.run("flake8 src")
+    log.write("Running black python linter...")
+    ctx.run("black --check --diff --color src tests")
 
 
 @task()

--- a/tasks.py
+++ b/tasks.py
@@ -134,6 +134,13 @@ def lint(ctx):
 
 
 @task()
+def format(ctx):
+    """Reformat the code base using black."""
+    log.write("Running black python formatter...")
+    ctx.run("black src tests")
+
+
+@task()
 def testdocs(ctx, rebuild=False):
     """Test the examples in the docstrings."""
     log.write("Running doctest...")
@@ -253,6 +260,9 @@ def release(ctx, release_type):
         raise Exit(
             "The release type parameter is invalid.\nMust be one of: major, minor, patch"
         )
+
+    # Run formmatter
+    ctx.run("invoke format")
 
     # Run checks
     ctx.run("invoke check test")


### PR DESCRIPTION
- Use black in `invoke lint`
- Added `invoke format` with black
- Trigger `invoke format` automatically during `invoke release`

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
