### PR TITLE
Brep from native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug in `_core.tangent` where the Circle's Plane was accessed instead of the centre.
 * Fixed the `test_tangent` to work with a properly defined circle
 * `RhinoBrep` serialization works now with surface types other than NURBS.
+* Renamed `Brep.from_brep` to `Brep.from_native`.
 
 ### Removed
 

--- a/docs/tutorial/brep.rst
+++ b/docs/tutorial/brep.rst
@@ -82,7 +82,7 @@ Every backend is expected to implement some alternative constructors
     >>> import Rhino
     >>> from compas.geometry import Brep
     >>> ...
-    >>> Brep.from_brep(Rhino.Geometry.Brep())
+    >>> Brep.from_native(Rhino.Geometry.Brep())
 
 Brep operations
 ===============

--- a/src/compas/geometry/brep/brep.py
+++ b/src/compas/geometry/brep/brep.py
@@ -12,7 +12,7 @@ def new_brep(*args, **kwargs):
 
 
 @pluggable(category="factories")
-def from_brep(*args, **kwargs):
+def from_native(*args, **kwargs):
     raise PluginNotInstalledError()
 
 
@@ -355,8 +355,8 @@ class Brep(Geometry):
     # ==============================================================================
 
     @classmethod
-    def from_brep(cls, brep):
-        """Create a Brep from an instance of a backend Brep.
+    def from_native(cls, native_brep):
+        """Creates a Brep from an instance of a native backend Brep type.
 
         Parameters
         ----------
@@ -367,11 +367,11 @@ class Brep(Geometry):
         -------
         :class:`~compas.geometry.Brep`
         """
-        return from_brep(brep)
+        return from_native(native_brep)
 
     @classmethod
     def from_step_file(cls, filename):
-        """Conctruct a BRep from the data contained in a STEP file.
+        """Conctruct a Brep from the data contained in a STEP file.
 
         Parameters
         ----------

--- a/src/compas_rhino/geometry/brep/__init__.py
+++ b/src/compas_rhino/geometry/brep/__init__.py
@@ -16,7 +16,7 @@ __all__ = [
     "RhinoBrepLoop",
     "RhinoBrepFace",
     "new_brep",
-    "from_brep",
+    "from_native",
     "from_box",
 ]
 
@@ -29,8 +29,8 @@ def new_brep(*args, **kwargs):
 
 
 @plugin(category="factories", requires=["Rhino"])
-def from_brep(*args, **kwargs):
-    return RhinoBrep.from_brep(*args, **kwargs)
+def from_native(*args, **kwargs):
+    return RhinoBrep.from_native(*args, **kwargs)
 
 
 @plugin(category="factories", requires=["Rhino"])

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -134,8 +134,8 @@ class RhinoBrep(Brep):
     # ==============================================================================
 
     @classmethod
-    def from_brep(cls, rhino_brep):
-        """Constructs a RhinoBrep from an instance of a Rhino brep
+    def from_native(cls, rhino_brep):
+        """Constructs a RhinoBrep from an instance of a Rhino.Geometry.Brep.
 
         Parameters
         ----------
@@ -165,7 +165,7 @@ class RhinoBrep(Brep):
 
         """
         rhino_box = box_to_rhino(box)
-        return cls.from_brep(rhino_box.ToBrep())
+        return cls.from_native(rhino_box.ToBrep())
 
     @classmethod
     def from_cylinder(cls, cylinder):
@@ -182,7 +182,7 @@ class RhinoBrep(Brep):
 
         """
         rhino_cylinder = cylinder_to_rhino(cylinder)
-        return cls.from_brep(rhino_cylinder.ToBrep(True, True))
+        return cls.from_native(rhino_cylinder.ToBrep(True, True))
 
     # ==============================================================================
     # Methods
@@ -255,7 +255,7 @@ class RhinoBrep(Brep):
             [b.native_brep for b in breps_b],
             TOLERANCE,
         )
-        return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
+        return [RhinoBrep.from_native(brep) for brep in resulting_breps]
 
     @classmethod
     def from_boolean_union(cls, breps_a, breps_b):
@@ -280,7 +280,7 @@ class RhinoBrep(Brep):
             breps_b = [breps_b]
 
         resulting_breps = Rhino.Geometry.Brep.CreateBooleanUnion([b.native_brep for b in breps_a + breps_b], TOLERANCE)
-        return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
+        return [RhinoBrep.from_native(brep) for brep in resulting_breps]
 
     @classmethod
     def from_boolean_intersection(cls, breps_a, breps_b):
@@ -308,7 +308,7 @@ class RhinoBrep(Brep):
             [b.native_brep for b in breps_b],
             TOLERANCE,
         )
-        return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
+        return [RhinoBrep.from_native(brep) for brep in resulting_breps]
 
     def split(self, cutter):
         """Splits a Brep into pieces using a Brep as a cutter.
@@ -325,7 +325,7 @@ class RhinoBrep(Brep):
 
         """
         resulting_breps = self._brep.Split(cutter.native_brep, TOLERANCE)
-        return [RhinoBrep.from_brep(brep) for brep in resulting_breps]
+        return [RhinoBrep.from_native(brep) for brep in resulting_breps]
 
     # ==============================================================================
     # Other Methods

--- a/src/compas_rhino/geometry/brep/edge.py
+++ b/src/compas_rhino/geometry/brep/edge.py
@@ -2,6 +2,7 @@ from compas.geometry import BrepEdge
 from compas.geometry import Line
 from compas.geometry import Point
 from compas.geometry import Circle
+from compas.geometry import Ellipse
 from compas_rhino.geometry import RhinoNurbsCurve
 from compas_rhino.conversions import curve_to_compas_line
 from compas_rhino.conversions import curve_to_compas_circle
@@ -85,7 +86,7 @@ class RhinoBrepEdge(BrepEdge):
         elif curve_type == "circle":
             self._curve = circle_to_rhino_curve(Circle.from_data(value["value"]))  # this returns a Nurbs Curve, why?
         elif curve_type == "ellipse":
-            self._curve = ellipse_to_rhino_curve(value["value"])
+            self._curve = ellipse_to_rhino_curve(Ellipse.from_data(value["value"]))
         else:
             self._curve = RhinoNurbsCurve.from_data(value["value"]).rhino_curve
 

--- a/src/compas_rhino/geometry/brep/face.py
+++ b/src/compas_rhino/geometry/brep/face.py
@@ -1,4 +1,6 @@
 from compas.geometry import BrepFace
+from compas.geometry import Sphere
+from compas.geometry import Cylinder
 from compas_rhino.geometry import RhinoNurbsSurface
 from compas_rhino.conversions import plane_to_compas
 from compas_rhino.conversions import sphere_to_compas


### PR DESCRIPTION
Renamed  `Brep.from_brep` to `Brep.from_native` following [discussion](https://github.com/compas-dev/compas/pull/1074#issuecomment-1266072846). 

Added missing imports in `RhinoBrepFace` and `RhinoBrepEdge`.

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes **in an unreleased feature**
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
