### PR TITLE
Use invocations

### DIFF
--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -74,9 +74,9 @@ The procedure for submitting a PR is the following.
 Style guide
 ===========
 
-Please run `black <path_to_source_file>` to auto-format your code.
+Please run ``invoke format`` to auto-format your code.
 
-The command ``invoke lint`` runs the entire codebase through ``flake8``.
+The command ``invoke lint`` runs the entire codebase through both ``black`` and ``flake8``.
 As described in the `docs <https://flake8.pycqa.org/en/latest/manpage.html>`_,
 ``flake8`` includes lint checks provided by the PyFlakes project,
 PEP-0008 inspired style checks provided by the PyCodeStyle project,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
-black
 attrs >=17.4
+black
 bump2version >=1.0.1
 check-manifest >=0.36
+compas_invocations
 doc8
 flake8
 graphviz
@@ -9,13 +10,13 @@ invoke >=0.14
 ipykernel
 ipython >=5.8
 isort
+jinja2 >= 3.0
 m2r2
 nbsphinx
 pydocstyle
 pytest <7.1
-sphinx_compas_theme >=0.15.18
 sphinx ==4.5
+sphinx_compas_theme >=0.15.18
 twine
 wheel
-jinja2 >= 3.0
 -e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,9 +4,8 @@ bump2version >=1.0.1
 check-manifest >=0.36
 compas_invocations
 doc8
-flake8
+flake8>=5.0.4
 graphviz
-importlib_metadata <5.0
 invoke >=0.14
 ipykernel
 ipython >=5.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ compas_invocations
 doc8
 flake8
 graphviz
+importlib_metadata <5.0
 invoke >=0.14
 ipykernel
 ipython >=5.8
@@ -14,7 +15,7 @@ jinja2 >= 3.0
 m2r2
 nbsphinx
 pydocstyle
-pytest <7.1
+pytest
 sphinx ==4.5
 sphinx_compas_theme >=0.15.18
 twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,9 @@ bump2version >=1.0.1
 check-manifest >=0.36
 compas_invocations
 doc8
-flake8>=5.0.4
+flake8
 graphviz
+importlib_metadata <5.0
 invoke >=0.14
 ipykernel
 ipython >=5.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,11 @@ universal = 1
 
 [flake8]
 max-line-length = 120
-exclude = */migrations/*
-extend-ignore = E203
+extend-ignore =
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,
+    # Only keep black line length check because flake8 forces it on comments as well
+    E501,
 
 [doc8]
 max-line-length = 120

--- a/src/compas_rhino/geometry/brep/face.py
+++ b/src/compas_rhino/geometry/brep/face.py
@@ -5,9 +5,6 @@ from compas_rhino.geometry import RhinoNurbsSurface
 from compas_rhino.conversions import plane_to_compas
 from compas_rhino.conversions import sphere_to_compas
 from compas_rhino.conversions import cylinder_to_compas
-from compas_rhino.conversions import plane_to_rhino
-from compas_rhino.conversions import sphere_to_rhino
-from compas_rhino.conversions import cylinder_to_rhino
 
 from .loop import RhinoBrepLoop
 

--- a/src/compas_rhino/geometry/brep/loop.py
+++ b/src/compas_rhino/geometry/brep/loop.py
@@ -3,7 +3,6 @@ from compas.geometry import BrepLoop
 import Rhino
 
 from .edge import RhinoBrepEdge
-from .vertex import RhinoBrepVertex
 
 
 class LoopType(object):

--- a/src/compas_rhino/geometry/surfaces/surface.py
+++ b/src/compas_rhino/geometry/surfaces/surface.py
@@ -10,7 +10,6 @@ from compas_rhino.conversions import vector_to_compas
 from compas_rhino.conversions import plane_to_compas_frame
 from compas_rhino.conversions import box_to_compas
 from compas_rhino.conversions import xform_to_rhino
-from compas_rhino.conversions import plane_to_rhino
 from compas_rhino.conversions import sphere_to_rhino
 from compas_rhino.conversions import cylinder_to_rhino
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,299 +1,35 @@
-# -*- coding: utf-8 -*-
 from __future__ import print_function
 
-import contextlib
-import glob
 import os
-import shutil
-import sys
-import tempfile
 
-from invoke import Exit
-from invoke import task
+from compas_invocations import build
+from compas_invocations import docs
+from compas_invocations import style
+from compas_invocations import tests
+from invoke import Collection
 
-BASE_FOLDER = os.path.dirname(__file__)
-
-
-class Log(object):
-    def __init__(self, out=sys.stdout, err=sys.stderr):
-        self.out = out
-        self.err = err
-
-    def flush(self):
-        self.out.flush()
-        self.err.flush()
-
-    def write(self, message):
-        self.flush()
-        self.out.write(message + "\n")
-        self.out.flush()
-
-    def info(self, message):
-        self.write("[INFO] %s" % message)
-
-    def warn(self, message):
-        self.write("[WARN] %s" % message)
-
-
-log = Log()
-
-
-def confirm(question):
-    while True:
-        response = input(question).lower().strip()
-
-        if not response or response in ("n", "no"):
-            return False
-
-        if response in ("y", "yes"):
-            return True
-
-        print("Focus, kid! It is either (y)es or (n)o", file=sys.stderr)
-
-
-@task(default=True)
-def help(ctx):
-    """Lists available tasks and usage."""
-    ctx.run("invoke --list")
-    log.write('Use "invoke -h <taskname>" to get detailed help for a task.')
-
-
-@task(
-    help={
-        "docs": "True to clean up generated documentation, otherwise False",
-        "bytecode": "True to clean up compiled python files, otherwise False.",
-        "builds": "True to clean up build/packaging artifacts, otherwise False.",
+ns = Collection(
+    docs.help,
+    style.check,
+    style.lint,
+    style.format,
+    docs.docs,
+    docs.linkcheck,
+    tests.test,
+    tests.testdocs,
+    tests.testcodeblocks,
+    build.prepare_changelog,
+    build.clean,
+    build.release,
+    build.build_ghuser_components,
+)
+ns.configure(
+    {
+        "base_folder": os.path.dirname(__file__),
+        "ghuser": {
+            "source_dir": "src/compas_ghpython/components",
+            "target_dir": "src/compas_ghpython/components/ghuser",
+            "prefix": "(COMPAS)",
+        },
     }
 )
-def clean(ctx, docs=True, bytecode=True, builds=True, ghuser=True):
-    """Cleans the local copy from compiled artifacts."""
-
-    with chdir(BASE_FOLDER):
-        if builds:
-            ctx.run("python setup.py clean")
-
-        if bytecode:
-            for root, dirs, files in os.walk(BASE_FOLDER):
-                for f in files:
-                    if f.endswith(".pyc"):
-                        os.remove(os.path.join(root, f))
-                if ".git" in dirs:
-                    dirs.remove(".git")
-
-        folders = []
-
-        if docs:
-            folders.append("docs/api/generated")
-
-        folders.append("dist/")
-
-        if bytecode:
-            for t in ("src", "tests"):
-                folders.extend(glob.glob("{}/**/__pycache__".format(t), recursive=True))
-
-        if builds:
-            folders.append("build/")
-            folders.append("src/compas.egg-info/")
-
-        if ghuser:
-            folders.append("src/compas_ghpython/components/ghuser")
-
-        for folder in folders:
-            shutil.rmtree(os.path.join(BASE_FOLDER, folder), ignore_errors=True)
-
-
-@task(
-    help={
-        "rebuild": "True to clean all previously built docs before starting, otherwise False.",
-        "doctest": "True to run doctests, otherwise False.",
-        "check_links": "True to check all web links in docs for validity, otherwise False.",
-    }
-)
-def docs(ctx, doctest=False, rebuild=False, check_links=False):
-    """Builds package's HTML documentation."""
-
-    if rebuild:
-        clean(ctx)
-
-    with chdir(BASE_FOLDER):
-        if doctest:
-            testdocs(ctx, rebuild=rebuild)
-
-        opts = "-E" if rebuild else ""
-        ctx.run("sphinx-build {} -b html docs dist/docs".format(opts))
-
-        if check_links:
-            linkcheck(ctx, rebuild=rebuild)
-
-
-@task()
-def lint(ctx):
-    """Check the consistency of coding style."""
-    log.write("Running black python linter...")
-    ctx.run("black --check --diff --color src tests")
-
-
-@task()
-def format(ctx):
-    """Reformat the code base using black."""
-    log.write("Running black python formatter...")
-    ctx.run("black src tests")
-
-
-@task()
-def testdocs(ctx, rebuild=False):
-    """Test the examples in the docstrings."""
-    log.write("Running doctest...")
-    ctx.run("pytest --doctest-modules")
-
-
-@task()
-def linkcheck(ctx, rebuild=False):
-    """Check links in documentation."""
-    log.write("Running link check...")
-    opts = "-E" if rebuild else ""
-    ctx.run("sphinx-build {} -b linkcheck docs dist/docs".format(opts))
-
-
-@task()
-def check(ctx):
-    """Check the consistency of documentation, coding style and a few other things."""
-
-    with chdir(BASE_FOLDER):
-        lint(ctx)
-
-        log.write("Checking MANIFEST.in...")
-        ctx.run("check-manifest")
-
-        log.write("Checking metadata...")
-        ctx.run("python setup.py check --strict --metadata")
-
-
-@task(
-    help={
-        "checks": "True to run all checks before testing, otherwise False.",
-        "doctest": "True to run doctest on all modules, otherwise False.",
-    }
-)
-def test(ctx, checks=False, doctest=False):
-    """Run all tests."""
-    if checks:
-        check(ctx)
-
-    with chdir(BASE_FOLDER):
-        cmd = ["pytest"]
-        if doctest:
-            cmd.append("--doctest-modules")
-
-        ctx.run(" ".join(cmd))
-
-
-@task
-def prepare_changelog(ctx):
-    """Prepare changelog for next release."""
-    UNRELEASED_CHANGELOG_TEMPLATE = (
-        "## Unreleased\n\n### Added\n\n### Changed\n\n### Removed\n\n\n## "
-    )
-
-    with chdir(BASE_FOLDER):
-        # Preparing changelog for next release
-        with open("CHANGELOG.md", "r+") as changelog:
-            content = changelog.read()
-            changelog.seek(0)
-            changelog.write(content.replace("## ", UNRELEASED_CHANGELOG_TEMPLATE, 1))
-
-        ctx.run(
-            'git add CHANGELOG.md && git commit -m "Prepare changelog for next release"'
-        )
-
-
-@task(
-    help={
-        "gh_io_folder": "Folder where GH_IO.dll is located. If not specified, it will try to download from NuGet.",
-        "ironpython": "Command for running the IronPython executable. Defaults to `ipy`.",
-    }
-)
-def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None):
-    """Build Grasshopper user objects from source"""
-    clean(ctx, docs=False, bytecode=False, builds=False, ghuser=True)
-    with chdir(BASE_FOLDER):
-        with tempfile.TemporaryDirectory("actions.ghcomponentizer") as action_dir:
-            source_dir = os.path.abspath("src/compas_ghpython/components")
-            target_dir = os.path.join(source_dir, "ghuser")
-            ctx.run(
-                "git clone https://github.com/compas-dev/compas-actions.ghpython_components.git {}".format(
-                    action_dir
-                )
-            )
-
-            if not gh_io_folder:
-                gh_io_folder = "temp"
-                import compas_ghpython
-
-                compas_ghpython.fetch_ghio_lib(gh_io_folder)
-
-            if not ironpython:
-                ironpython = "ipy"
-
-            gh_io_folder = os.path.abspath(gh_io_folder)
-            componentizer_script = os.path.join(action_dir, "componentize.py")
-
-            ctx.run(
-                '{} {} {} {} --ghio "{}"'.format(
-                    ironpython,
-                    componentizer_script,
-                    source_dir,
-                    target_dir,
-                    gh_io_folder,
-                )
-            )
-
-
-@task(
-    help={
-        "release_type": "Type of release follows semver rules. Must be one of: major, minor, patch."
-    }
-)
-def release(ctx, release_type):
-    """Releases the project in one swift command!"""
-    if release_type not in ("patch", "minor", "major"):
-        raise Exit(
-            "The release type parameter is invalid.\nMust be one of: major, minor, patch"
-        )
-
-    # Run formmatter
-    ctx.run("invoke format")
-
-    # Run checks
-    ctx.run("invoke check test")
-
-    # Bump version and git tag it
-    ctx.run("bump2version %s --verbose" % release_type)
-
-    # Build project
-    ctx.run("python setup.py clean --all sdist bdist_wheel")
-
-    # Prepare changelog for next release
-    prepare_changelog(ctx)
-
-    # Clean up local artifacts
-    clean(ctx)
-
-    # Upload to pypi
-    if confirm(
-        "Everything is ready. You are about to push to git which will trigger a release to pypi.org. Are you sure? [y/N]"
-    ):
-        ctx.run("git push --tags && git push")
-    else:
-        raise Exit("You need to manually revert the tag/commits created.")
-
-
-@contextlib.contextmanager
-def chdir(dirname=None):
-    current_dir = os.getcwd()
-    try:
-        if dirname is not None:
-            os.chdir(dirname)
-        yield
-    finally:
-        os.chdir(current_dir)

--- a/tests/compas/files/test_stl.py
+++ b/tests/compas/files/test_stl.py
@@ -1,4 +1,3 @@
-import filecmp
 import os
 
 import pytest

--- a/tests/compas/geometry/test_polyline.py
+++ b/tests/compas/geometry/test_polyline.py
@@ -261,5 +261,5 @@ def test_polyline_extend(coords, input, expected):
         ([[0, 0, 0], [1, 0, 0], [2, 0, 0], [2, 2, 0]], (1, 2), [[1, 0, 0], [2, 0, 0]]),
     ],
 )
-def test_polyline_extend(coords, input, expected):
+def test_polyline_shortened(coords, input, expected):
     assert expected == Polyline(coords).shortened(input)

--- a/tests/compas/robots/test_model.py
+++ b/tests/compas/robots/test_model.py
@@ -199,7 +199,7 @@ def test_robot_link_nameless_is_allowed_with_custom_namespace():
 
 def test_link_nameless_raises_if_no_custom_namespace():
     with pytest.raises(Exception):
-        r = RobotModel.from_urdf_string(
+        RobotModel.from_urdf_string(
             """<?xml version="1.0" encoding="UTF-8"?><robot name="NamelessLinkRobot"><link/></robot>"""
         )
 


### PR DESCRIPTION
Switch to `compas_invocations` as library for `pyinvoke` tasks and fixed some `flake8` warnings.
The pinning of `importlib-metadata <5` is due to this https://github.com/python/importlib_metadata/issues/406

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
