### PR TITLE
Bugfix/nurbs points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed strange point values in RhinoNurbsCurve caused by conversion `ControlPoint` to COMPAS instead of `ControlPoint.Location`.
+
 ### Removed
 
 

--- a/src/compas_rhino/geometry/curves/nurbs.py
+++ b/src/compas_rhino/geometry/curves/nurbs.py
@@ -121,7 +121,7 @@ class RhinoNurbsCurve(NurbsCurve, RhinoCurve):
     @property
     def points(self):
         if self.rhino_curve:
-            return [point_to_compas(point) for point in self.rhino_curve.Points]
+            return [point_to_compas(point.Location) for point in self.rhino_curve.Points]
 
     @property
     def weights(self):


### PR DESCRIPTION
This was the cause for https://github.com/compas-dev/compas/issues/1097. 
When querying the control points of a NURBS curve, the coordinates value of certain points would sometimes differ from the location of the original control points.

The underlying issue was the `points` property in `RhinoNurbsCurve` which converted `NurbsCurve.ControlPoint` instead of `NurbsCuve.ControlPoint.Location` to COMPAS. Since both types expose `X`, `Y` and `Z` properties, the `point_to_compas` would not fail. However, the `XYZ` values of a `ControlPoint` sometimes differ from the `XYZ` values of `ControlPoint.Location` (maybe when the point does not lie on the curve itself?). 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
