### PR TITLE
Bugfix/nurbs point count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed strange point values in RhinoNurbsCurve caused by conversion `ControlPoint` to COMPAS instead of `ControlPoint.Location`.
+* Fixed flipped order of NURBS point count values when creating RhinoNurbsSurface from parameters.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/surfaces/nurbs.py
+++ b/src/compas_rhino/geometry/surfaces/nurbs.py
@@ -67,7 +67,15 @@ def rhino_surface_from_parameters(
     v_point_count = len(points[0])
     is_rational = True  # TODO: check if all weights are equal? https://developer.rhino3d.com/guides/opennurbs/nurbs-geometry-overview/
     dimensions = 3
-    rhino_surface = Rhino.Geometry.NurbsSurface.Create(dimensions, is_rational, u_order, v_order, u_point_count, v_point_count)
+    rhino_surface = Rhino.Geometry.NurbsSurface.Create(
+            dimensions, is_rational, u_order, v_order, u_point_count, v_point_count
+        )
+
+    if not rhino_surface:
+        message = "dimensions: {} is_rational: {} u_order: {} v_order: {} u_points: {} v_points: {}".format(
+            dimensions, is_rational, u_order, v_order, u_point_count, v_point_count
+        )
+        raise ValueError("Failed to create NurbsSurface with params:\n{}".format(message))
 
     u_knotvector = [knot for knot, mult in zip(u_knots, u_mults) for _ in range(mult)]
     v_knotvector = [knot for knot, mult in zip(v_knots, v_mults) for _ in range(mult)]

--- a/src/compas_rhino/geometry/surfaces/nurbs.py
+++ b/src/compas_rhino/geometry/surfaces/nurbs.py
@@ -68,8 +68,8 @@ def rhino_surface_from_parameters(
     is_rational = True  # TODO: check if all weights are equal? https://developer.rhino3d.com/guides/opennurbs/nurbs-geometry-overview/
     dimensions = 3
     rhino_surface = Rhino.Geometry.NurbsSurface.Create(
-            dimensions, is_rational, u_order, v_order, u_point_count, v_point_count
-        )
+        dimensions, is_rational, u_order, v_order, u_point_count, v_point_count
+    )
 
     if not rhino_surface:
         message = "dimensions: {} is_rational: {} u_order: {} v_order: {} u_points: {} v_points: {}".format(

--- a/src/compas_rhino/geometry/surfaces/nurbs.py
+++ b/src/compas_rhino/geometry/surfaces/nurbs.py
@@ -61,7 +61,7 @@ def rhino_surface_from_parameters(
     is_u_periodic=False,
     is_v_periodic=False,
 ):
-    u_order = u_degree + 1 
+    u_order = u_degree + 1
     v_order = v_degree + 1
     u_point_count = len(points)
     v_point_count = len(points[0])

--- a/src/compas_rhino/geometry/surfaces/nurbs.py
+++ b/src/compas_rhino/geometry/surfaces/nurbs.py
@@ -61,18 +61,21 @@ def rhino_surface_from_parameters(
     is_u_periodic=False,
     is_v_periodic=False,
 ):
-    rhino_surface = Rhino.Geometry.NurbsSurface.Create(3, True, u_degree + 1, v_degree + 1, len(points[0]), len(points))
+    u_order = u_degree + 1 
+    v_order = v_degree + 1
+    u_point_count = len(points)
+    v_point_count = len(points[0])
+    is_rational = True  # TODO: check if all weights are the same
+    dimensions = 3
+    rhino_surface = Rhino.Geometry.NurbsSurface.Create(dimensions, is_rational, u_order, v_order, u_point_count, v_point_count)
+
     u_knotvector = [knot for knot, mult in zip(u_knots, u_mults) for _ in range(mult)]
     v_knotvector = [knot for knot, mult in zip(v_knots, v_mults) for _ in range(mult)]
-    u_count = len(points[0])
-    v_count = len(points)
-    u_order = u_degree + 1
-    v_order = v_degree + 1
     # account for superfluous knots
     # https://developer.rhino3d.com/guides/opennurbs/superfluous-knots/
-    if len(u_knotvector) == u_count + u_order:
+    if len(u_knotvector) == u_point_count + u_order:
         u_knotvector[:] = u_knotvector[1:-1]
-    if len(v_knotvector) == v_count + v_order:
+    if len(v_knotvector) == v_point_count + v_order:
         v_knotvector[:] = v_knotvector[1:-1]
     # add knots
     for index, knot in enumerate(u_knotvector):
@@ -80,8 +83,8 @@ def rhino_surface_from_parameters(
     for index, knot in enumerate(v_knotvector):
         rhino_surface.KnotsV[index] = knot
     # add control points
-    for i in range(v_count):
-        for j in range(u_count):
+    for i in range(u_point_count):
+        for j in range(v_point_count):
             rhino_surface.Points.SetPoint(i, j, point_to_rhino(points[i][j]), weights[i][j])
     return rhino_surface
 

--- a/src/compas_rhino/geometry/surfaces/nurbs.py
+++ b/src/compas_rhino/geometry/surfaces/nurbs.py
@@ -65,7 +65,7 @@ def rhino_surface_from_parameters(
     v_order = v_degree + 1
     u_point_count = len(points)
     v_point_count = len(points[0])
-    is_rational = True  # TODO: check if all weights are the same
+    is_rational = True  # TODO: check if all weights are equal? https://developer.rhino3d.com/guides/opennurbs/nurbs-geometry-overview/
     dimensions = 3
     rhino_surface = Rhino.Geometry.NurbsSurface.Create(dimensions, is_rational, u_order, v_order, u_point_count, v_point_count)
 


### PR DESCRIPTION
The order of referencing U and V control points in `rhino_surface_from_parameters` was flipped.
This was the issue behind https://github.com/compas-dev/compas/issues/1094.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
