### PR TITLE
Bugfix/copy twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added conversion function `frame_to_rhino_plane` to `compas_rhino.conversions`.
 * Added `RhinoSurface.from_frame` to `compas_rhino.geometry`.
 * Added representation for trims with `compas.geometry.BrepTrim`.
+* Added method `transformed` to `compas.geometry.RhinoBrep`.
 
 ### Changed
 
 * Updated workflows to v2.
+* Fixed error when copying a copied `RhinoBrep` which contains cylinder surfaces.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -213,6 +213,23 @@ class RhinoBrep(Brep):
         """
         self._brep.Transform(xform_to_rhino(matrix))
 
+    def transformed(self, matrix):
+        """Returns a transformed copy of this brep.
+
+        Parameters
+        ----------
+        matrix: :class:`~compas.geometry.Transformation`
+            The transformation matrix by which to transform this Brep.
+
+        Returns
+        -------
+        None
+
+        """
+        brep_copy = self.copy()
+        brep_copy.transform(matrix)
+        return brep_copy
+
     def trim(self, trimming_plane, tolerance=TOLERANCE):
         """Trim this brep by the given trimming plane
 

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -219,11 +219,11 @@ class RhinoBrep(Brep):
         Parameters
         ----------
         matrix: :class:`~compas.geometry.Transformation`
-            The transformation matrix by which to transform this Brep.
+            The transformation matrix by which to transform the newly created Brep.
 
         Returns
         -------
-        None
+        :class:`~compas_rhino.geometry.RhinoBrep`
 
         """
         brep_copy = self.copy()

--- a/src/compas_rhino/geometry/brep/builder.py
+++ b/src/compas_rhino/geometry/brep/builder.py
@@ -173,6 +173,6 @@ class RhinoBrepBuilder(object):
         :class:`compas_rhino.geometry.RhinoFaceBuilder`
 
         """
-        surface_index = self._brep.AddSurface(surface.rhino_surface)
+        surface_index = self._brep.AddSurface(surface)
         face = self._brep.Faces.Add(surface_index)
         return RhinoFaceBuilder(face=face, brep=self._brep)


### PR DESCRIPTION
Fixes error when copying or de-serializing a `RhinoBrep` which has already been copied or de-serialized.
Added missing `RhinoBrep.transformed`.

Initially, face surfaces where converted to `RhionNurbsSurface` before adding them to a newly created face. However, in the case of cylinder, this conversion causes loss of information (specifically the height of the cylinder). Instead a cylinder is now converted directly to a `RevSurface`.

```
Message: 'NoneType' object has no attribute 'SetDomain'

Traceback:
  line 154, in _make_surface_from_data, "C:\Users\ckasirer\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts\compas_rhino\geometry\brep\face.py"
  line 67, in data, "C:\Users\ckasirer\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts\compas_rhino\geometry\brep\face.py"
  line 92, in from_data, "C:\Users\ckasirer\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts\compas_rhino\geometry\brep\face.py"
  line 88, in data, "C:\Users\ckasirer\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts\compas_rhino\geometry\brep\brep.py"
  line 230, in from_data, "C:\Users\ckasirer\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts\compas\data\data.py"
  line 330, in copy, "C:\Users\ckasirer\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts\compas\data\data.py"
  line 29, in <module>, "C:\Users\ckasirer\Downloads\brep\boolean.py"
```

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
