### PR TITLE
Brep copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Updated workflows to v2.
+* Changed deepcopy of `RhinoBrep` to use the native `Rhino.Geometry` mechanism.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated workflows to v2.
 * Changed deepcopy of `RhinoBrep` to use the native `Rhino.Geometry` mechanism.
+* The normal of the cutting plane is no longer flipped in `compas_rhino.geometry.RhinoBrep`.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -92,13 +92,14 @@ class RhinoBrep(Brep):
         self._brep = builder.result
 
     def copy(self, cls=None):
-        """Creates a copy of this Brep using the native Rhino.Geometry.Brep copying mechanism.
+        """Creates a deep-copy of this Brep using the native Rhino.Geometry.Brep copying mechanism.
 
         Returns
         -------
         :class:`~compas_rhino.geometry.RhinoBrep`
 
         """
+        # Avoid reconstruction when just copying. for sake of efficiency and stability
         return RhinoBrep.from_native(self._brep.DuplicateBrep())
 
     # ==============================================================================

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -219,7 +219,7 @@ class RhinoBrep(Brep):
         Parameters
         ----------
         trimming_plane : :class:`~compas.geometry.Frame` or :class:`~compas.geometry.Plane`
-            The frame or plane to use when trimming.
+            The frame or plane to use when trimming. The discarded bit is in the direction of the frame's normal.
 
         tolerance : float
             The precision to use for the trimming operation.
@@ -232,7 +232,6 @@ class RhinoBrep(Brep):
         if isinstance(trimming_plane, Plane):
             trimming_plane = Frame.from_plane(trimming_plane)
         rhino_frame = frame_to_rhino(trimming_plane)
-        rhino_frame.Flip()
         results = self._brep.Trim(rhino_frame, tolerance)
         if not results:
             raise BrepTrimmingError("Trim operation ended with no result")

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -65,6 +65,9 @@ class RhinoBrep(Brep):
         super(RhinoBrep, self).__init__()
         self._brep = brep or Rhino.Geometry.Brep()
 
+    def __deepcopy__(self, *args, **kwargs):
+        return self.copy()
+
     # ==============================================================================
     # Data
     # ==============================================================================
@@ -87,6 +90,16 @@ class RhinoBrep(Brep):
         for f_data in data["faces"]:
             RhinoBrepFace.from_data(f_data, builder)
         self._brep = builder.result
+
+    def copy(self, cls=None):
+        """Creates a copy of this Brep using the native Rhino.Geometry.Brep copying mechanism.
+        
+        Returns
+        -------
+        :class:`~compas_rhino.geometry.RhinoBrep`
+        
+        """
+        return RhinoBrep.from_native(self._brep.DuplicateBrep())
 
     # ==============================================================================
     # Properties

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -93,11 +93,11 @@ class RhinoBrep(Brep):
 
     def copy(self, cls=None):
         """Creates a copy of this Brep using the native Rhino.Geometry.Brep copying mechanism.
-        
+
         Returns
         -------
         :class:`~compas_rhino.geometry.RhinoBrep`
-        
+
         """
         return RhinoBrep.from_native(self._brep.DuplicateBrep())
 


### PR DESCRIPTION
Two small changed on `RhinoBrep`
1. Deepcopy using either the `Data.copy()` or `copy.deepcopy` is performed now using the native `Rhino` mechanism. This skips the need for reconstruction thus allowing shapes which break the current implementation of the `Data` interface. Fragility is confined to serialization.

2. Removed an undocumented normal flipping operation in `RhinoBrep.trim()` which caused confusion and added a clarifying comment to the docstring.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
