### PR TITLE
copied the create_id helper from compas_fab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `create_id` to `compas_ghpython.utilities`. (moved from `compas_fab`)
+
 ### Changed
 
 * Fixed bug that caused a new-line at the end of the `compas.HERE` constant in IronPython for Mac.

--- a/src/compas_ghpython/utilities/__init__.py
+++ b/src/compas_ghpython/utilities/__init__.py
@@ -52,6 +52,7 @@ misc
     :toctree: generated/
 
     unload_modules
+    create_id
 
 """
 from __future__ import absolute_import
@@ -93,4 +94,27 @@ __all__ = [
     "list_to_ghtree",
     "ghtree_to_list",
     "update_component",
+    "create_id",
 ]
+
+
+def create_id(component, name):
+    """Creates an identifier string using `name` and the ID of the component passed to it.
+
+    The resulting string can be used to store data elements in the global sticky dictionary.
+    This can be useful when setting variable in a condition activated by a button.
+
+    Paramaters
+    ----------
+    components : `ghpythonlib.componentbase.executingcomponent`
+        The components instance. Use `self` in advanced (SDK) mode and `ghenv.Components` otherwise.
+    name : str
+        A user chosen prefix for the identifier.
+
+    Returns
+    -------
+    str
+        For example: `somename55dd-c7cc-43c8-9d6a-65e4c8503abd`
+
+    """
+    return "{}_{}".format(name, component.InstanceGuid)


### PR DESCRIPTION
Copied over the `create_id` helper from `compas_fab` to `compas_ghpython.utilities`.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
