### PR TITLE
fix in `area_polygon`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -36,3 +36,4 @@
 - Chen Kasirer <<kasirer@arch.ethz.ch>> [@chenkasirer](https://github.com/chenkasirer)
 - Nickolas Maslarinos <<maslarinosnickolas@gmail.com>> [@nmaslarinos](https://github.com/nmaslarinos)
 - Katerina Toumpektsi <<e.toumpeksti@gmail.com>> [@katarametin](https://github.com/katarametin)
+- Joelle Baehr-Bruyere <<joelle.baehr-bruyere@epfl.ch>> [@baehrjo](https://github.com/baehrjo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed bug that caused a new-line at the end of the `compas.HERE` constant in IronPython for Mac.
 * Fixed Grasshopper `draw_polylines` method to return `PolylineCurve` instead of `Polyline` because the latter shows as only points.
+* Fixed `area_polygon` that was, in some cases, returning a negative area
 
 ### Removed
 

--- a/src/compas/geometry/_core/size.py
+++ b/src/compas/geometry/_core/size.py
@@ -65,7 +65,7 @@ def area_polygon(polygon):
             area += 0.5 * length_vector(n)
         else:
             area -= 0.5 * length_vector(n)
-    return area
+    return abs(area)
 
 
 def area_polygon_xy(polygon):

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -237,9 +237,7 @@ def test_area_polygon():
     )
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :
-    polygon_ = Polygon(
-        [Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)]
-    )
+    polygon_ = Polygon(polygon[3:] + polygon[:3])
     assert area_polygon(polygon_) >= 0
 
 

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -3,7 +3,7 @@ from math import pi, radians, sqrt
 import pytest
 
 from compas.geometry import Polyhedron
-from compas.geometry import Polygon
+from compas.geometry import Point, Polygon
 from compas.geometry import Rotation
 from compas.geometry import allclose
 from compas.geometry import angle_vectors
@@ -229,6 +229,14 @@ def test_area_triangle(triangle, R):
     assert close(area_triangle_xy(triangle.points), 0.0)
     assert close(triangle.area, 0.5)
 
+
+def test_area_polygon():
+    # create a test closed (here planar xy) non-convex polygon :
+    polygon = Polygon([Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)])
+    assert area_polygon(polygon) >= 0
+    # the same polygon with vertices list shifted by 3 positions :
+    polygon_ = Polygon([Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)])
+    assert area_polygon(polygon_) >= 0
 
 # ==============================================================================
 # normals

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -232,11 +232,16 @@ def test_area_triangle(triangle, R):
 
 def test_area_polygon():
     # create a test closed (here planar xy) non-convex polygon :
-    polygon = Polygon([Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)])
+    polygon = Polygon(
+        [Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)]
+    )
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :
-    polygon_ = Polygon([Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)])
+    polygon_ = Polygon(
+        [Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)]
+    )
     assert area_polygon(polygon_) >= 0
+
 
 # ==============================================================================
 # normals


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
Modified the `area_polygon` method to return abs(area) as it was sometimes returning a negative (but numerically correct) area. In the original code (below), the method is vectorially summing 'pieces' of area, with sign + or - relatively to the direction of n0 : if dot_vectors(n, n0) > 0 .... else .... 
n0 is computed starting with two vertices a and b of the polygon. If these vertices lie in a locally concave zone of the polygon (n0 direction is flipped regarding the normal of the entire polygon), the final area will return negative.
(See the test)

+ suggest : add a condition or raise an error if the polygon is self-intersecting ?
For instance a symmetric hourglass shaped polygon (e.g. two triangles joined at their summit) will have an area of 0 while the projected area will be twice the single triangle area.

``` original code
o = centroid_points(polygon)
    a = polygon[-1]
    b = polygon[0]
    oa = subtract_vectors(a, o)
    ob = subtract_vectors(b, o)
    n0 = cross_vectors(oa, ob)
    area = 0.5 * length_vector(n0)
    for i in range(0, len(polygon) - 1):
        oa = ob
        b = polygon[i + 1]
        ob = subtract_vectors(b, o)
        n = cross_vectors(oa, ob)
        if dot_vectors(n, n0) > 0:
            area += 0.5 * length_vector(n)
        else:
            area -= 0.5 * length_vector(n)
    return area
```

### What type of change is this?

- [x ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x ] I have added tests that prove my fix is effective or that my feature works.
- [x ] I have added necessary documentation (if appropriate)
