### PR TITLE
Fix release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
           build_ghpython_components: true
           gh_source: src/compas_ghpython/components
           gh_target: src/compas_ghpython/components/ghuser
+          release_name_prefix: COMPAS


### PR DESCRIPTION
Added a new parameter `release_name_prefix` in `compas-actions.publish` 
So that the releasees are created with name like `COMPAS 1.2.3` rather than `v1.2.3`