### PR TITLE
Simplified `Part`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed Grasshopper `draw_polylines` method to return `PolylineCurve` instead of `Polyline` because the latter shows as only points.
 * Fixed `area_polygon` that was, in some cases, returning a negative area.
 * Fixed uninstall post-process.
+* Simplified `compas.datastructures.Part` for more generic usage.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added `create_id` to `compas_ghpython.utilities`. (moved from `compas_fab`)
+* Added representation for features in `compas.datastructures.Part`.
 
 ### Changed
 

--- a/docs/tutorial/assembly_blocks.py
+++ b/docs/tutorial/assembly_blocks.py
@@ -7,24 +7,28 @@ from compas.geometry import Cylinder
 from compas.geometry import Circle
 from compas.geometry import Plane
 from compas.geometry import Translation
+from compas.geometry import Transformation
 from compas.geometry import Rotation
 from compas.geometry import Frame
 
 from compas_view2.app import App
+from compas_view2.collections import Collection
+
+
+class Block(Part):
+    def get_geometry(self, _=False):
+        transformation = Transformation.from_frame(self.frame)
+        return Box.from_width_height_depth(1, 1, 1).transformed(transformation)
 
 assembly = Assembly()
 
-a = Part(name="A", geometry=Box.from_width_height_depth(1, 1, 1))
+f1 = Frame([0, 0, 1], [1, 0, 0], [0, 1, 0])
+f2 = f1.copy()
+f2.transform(Rotation.from_axis_and_angle([0, 0, 1], radians(45)))
+f2.transform(Translation.from_vector([0, 0, 1]))
 
-b = Part(
-    name="B",
-    frame=Frame([0, 0, 1], [1, 0, 0], [0, 1, 0]),
-    shape=Box.from_width_height_depth(1, 1, 1),
-    features=[(Cylinder(Circle(Plane.worldXY(), 0.2), 1.0), "difference")],
-)
-
-b.transform(Rotation.from_axis_and_angle([0, 0, 1], radians(45)))
-b.transform(Translation.from_vector([0, 0, 1]))
+a = Block(name="A", frame=f1)
+b = Block(name="B", frame=f2)
 
 assembly.add_part(a)
 assembly.add_part(b)
@@ -32,6 +36,5 @@ assembly.add_part(b)
 assembly.add_connection(a, b)
 
 viewer = App()
-viewer.add(b.geometry)
-viewer.add(b.frame)
+viewer.add(Collection(items=[a.get_geometry(), b.get_geometry(), a.frame, b.frame]))
 viewer.show()

--- a/src/compas/datastructures/__init__.py
+++ b/src/compas/datastructures/__init__.py
@@ -21,6 +21,9 @@ Classes
     VolMesh
     Assembly
     Part
+    Feature
+    GeometricFeature
+    ParametricFeature
 
 
 Exceptions
@@ -304,6 +307,9 @@ from .assembly import (
     Part,
     AssemblyError,
     FeatureError,
+    Feature,
+    GeometricFeature,
+    ParametricFeature,
 )
 
 if not compas.IPY:
@@ -448,6 +454,9 @@ __all__ = [
     "Part",
     "AssemblyError",
     "FeatureError",
+    "Feature",
+    "GeometricFeature",
+    "ParametricFeature",
 ]
 
 if not compas.IPY:

--- a/src/compas/datastructures/assembly/__init__.py
+++ b/src/compas/datastructures/assembly/__init__.py
@@ -2,7 +2,21 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .exceptions import AssemblyError  # noqa: F401
-from .exceptions import FeatureError  # noqa: F401
-from .assembly import Assembly  # noqa: F401
-from .part import Part  # noqa: F401
+from .exceptions import AssemblyError
+from .exceptions import FeatureError
+from .assembly import Assembly
+from .part import Part
+from .part import Feature
+from .part import GeometricFeature
+from .part import ParametricFeature
+
+
+__all__ = [
+    "AssemblyError",
+    "FeatureError",
+    "Assembly",
+    "Part",
+    "Feature",
+    "GeometricFeature",
+    "ParametricFeature",
+]

--- a/src/compas/datastructures/assembly/part.py
+++ b/src/compas/datastructures/assembly/part.py
@@ -32,6 +32,27 @@ class GeometricFeature(Feature):
     An implementation of this class may offer support for various geometry types by adding an entry to OPERATIONS
     mapping the geometry type to its corresponding operation.
 
+    Examples
+    --------
+    >>>    def trim_brep_plane(brep, plane):
+    >>>         # trim brep with plane, return trimmed brep
+    >>>
+    >>>    def trim_mesh_plane(mesh, plane):
+    >>>         # trim mesh with plane, return trimmed mesh
+    >>>
+    >>>    class TrimmingFeature(GeometricFeature):
+    >>>        OPERATIONS = {Brep: trim_brep_plane, Mesh: trim_mesh_plane}
+    >>>
+    >>>            def __init__(self, trimming_plane):
+    >>>                super(TrimmingFeature, self).__init__()
+    >>>                self._geometry = trimming_plane
+    >>>
+    >>>            def apply(self, part):
+    >>>                part_geometry = part.get_geometry(with_features=True)
+    >>>                type_ = Brep if isinstance(part_geometry, Brep) else Mesh
+    >>>                operation = OPERATIONS[type_]
+    >>>                return operation(part_geometry, self._geometry)
+
     """
 
     OPERATIONS = {
@@ -55,6 +76,22 @@ class GeometricFeature(Feature):
 class ParametricFeature(Feature):
     """Base class for Features that may be applied to the parametric definition
     of a :class:`~compas.datastructures.Part`.
+
+    Examples
+    --------
+    >>> class ExtensionFeature(ParametricFeature):
+    >>>     def __init__(self, extend_by):
+    >>>         super(ExtensionFeature, self).__init__()
+    >>>         self.extend_by = extend_by
+    >>>
+    >>>     def apply(self, part):
+    >>>         part.length += self._extend_by
+    >>>
+    >>>     def restore(self, part):
+    >>>         part.length -= self._extend_by
+    >>>
+    >>>     def accumulate(self, other):
+    >>>         return BeamExtensionFeature(max(self.extend_by, other.extend_by))
 
     """
 

--- a/src/compas/datastructures/assembly/part.py
+++ b/src/compas/datastructures/assembly/part.py
@@ -2,23 +2,92 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from collections import deque
-
-# from functools import reduce
-
 from compas.geometry import Frame
-from compas.geometry import Polyhedron as Shape
-from compas.geometry import Transformation
+from compas.geometry import Brep
+from compas.geometry import Polyhedron
+from compas.datastructures import Datastructure
+from compas.data import Data
 
-# from compas.geometry import multiply_matrices
-from compas.geometry import boolean_union_mesh_mesh
-from compas.geometry import boolean_difference_mesh_mesh
-from compas.geometry import boolean_intersection_mesh_mesh
 
-from ..datastructure import Datastructure
-from ..mesh import Mesh
+class Feature(Data):
+    """Base class for a feature which may be applied to a :class:`~compas.datastructures.Part`."""
 
-from .exceptions import FeatureError
+    def apply(self, part):
+        """Apply this Feature to the given part.
+
+        Parameters
+        ----------
+        part : :class:`~compas.datastructures.Part`
+            The part onto which this feature should be applied.
+
+        """
+        raise NotImplementedError
+
+
+class GeometricFeature(Feature):
+    """Base class for geometric feature which may be applied to a :class:`~compas.datastructures.Part`.
+
+    Applies a binary operation on Part's current geometry and the feature's.
+
+    An implementation of this class may offer support for various geometry types by adding an entry to OPERATIONS
+    mapping the geometry type to its corresponding operation.
+
+    """
+
+    OPERATIONS = {
+        Brep: None,
+        Polyhedron: None,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(GeometricFeature, self).__init__(*args, **kwargs)
+        self._geometry = None
+
+    @property
+    def data(self):
+        return {"geometry": self._geometry}
+
+    @data.setter
+    def data(self, value):
+        self._geometry = value["geometry"]
+
+
+class ParametricFeature(Feature):
+    """Base class for Features that may be applied to the parametric definition
+    of a :class:`~compas.datastructures.Part`.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ParametricFeature, self).__init__(*args, **kwargs)
+
+    def restore(self, part):
+        """Reverses the effect this ParametricFeature has incured onto the given part.
+
+        Parameters
+        ----------
+        part : :class:`~compas.datastructures.Part`
+            The part onto which this feature has been previously applied and should now be reverted.
+
+        """
+        raise NotImplementedError
+
+    def accumulate(self, feature):
+        """Returns a new ParametricFeature which has the accumulative effect of this and the given feature.
+
+        A TypeError is raised if the given feature is not compatible with this.
+
+        Parameters
+        ----------
+        feature : :class:`~compas.datastructures.ParametricFeature`
+            Another compatible ParametricFeature whose effect should be accumulated with this one's.
+
+        Returns
+        -------
+        :class:`~compas.datastructures.ParametricFeatures`
+
+        """
+        raise NotImplementedError
 
 
 class Part(Datastructure):
@@ -31,10 +100,6 @@ class Part(Datastructure):
         The name will be stored in :attr:`Part.attributes`.
     frame : :class:`~compas.geometry.Frame`, optional
         The local coordinate system of the part.
-    shape : :class:`~compas.geometry.Shape`, optional
-        The base shape of the part geometry.
-    features : sequence[tuple[:class:`~compas.geometry.Shape`, str]], optional
-        The features to be added to the base shape of the part geometry.
 
     Attributes
     ----------
@@ -44,44 +109,18 @@ class Part(Datastructure):
         The identifier of the part in the connectivity graph of the parent assembly.
     frame : :class:`~compas.geometry.Frame`
         The local coordinate system of the part.
-    shape : :class:`~compas.geometry.Shape`
-        The base shape of the part geometry.
     features : list[tuple[:class:`~compas.geometry.Shape`, str]]
         The features added to the base shape of the part geometry.
-    transformations : Deque[:class:`~compas.geometry.Transformation`]
-        The stack of transformations applied to the part geometry.
-        The most recent transformation is on the left of the stack.
-        All transformations are with respect to the local coordinate system.
-    geometry : :class:`~compas.geometry.Polyhedron`, read-only
-        The geometry of the part after combining the base shape and features through the specified operations.
-
-    Class Attributes
-    ----------------
-    operations : dict[str, callable]
-        Available operations for combining features with a base shape.
 
     """
 
-    operations = {
-        "union": boolean_union_mesh_mesh,
-        "difference": boolean_difference_mesh_mesh,
-        "intersection": boolean_intersection_mesh_mesh,
-    }
-
-    def __init__(self, name=None, frame=None, shape=None, features=None, **kwargs):
+    def __init__(self, name=None, frame=None, **kwargs):
         super(Part, self).__init__()
-        self._frame = None
         self.attributes = {"name": name or "Part"}
         self.attributes.update(kwargs)
         self.key = None
-        self.frame = frame
-        self.shape = shape or Shape([], [])
-        self.features = features or []
-        self.transformations = deque()
-
-    # ==========================================================================
-    # data
-    # ==========================================================================
+        self.frame = frame or Frame.worldXY()
+        self.features = []
 
     @property
     def DATASCHEMA(self):
@@ -92,9 +131,6 @@ class Part(Datastructure):
                 "attributes": dict,
                 "key": int,
                 "frame": Frame,
-                "shape": Shape,
-                "features": list,
-                "transformations": list,
             }
         )
 
@@ -107,10 +143,7 @@ class Part(Datastructure):
         data = {
             "attributes": self.attributes,
             "key": self.key,
-            "frame": self.frame.data,
-            "shape": self.shape.data,
-            "features": [(shape.data, operation) for shape, operation in self.features],
-            "transformations": [T.data for T in self.transformations],
+            "frame": self.frame,
         }
         return data
 
@@ -118,123 +151,41 @@ class Part(Datastructure):
     def data(self, data):
         self.attributes.update(data["attributes"] or {})
         self.key = data["key"]
-        self.frame.data = data["frame"]
-        self.shape.data = data["shape"]
-        self.features = [(Shape.from_data(shape), operation) for shape, operation in data["features"]]
-        self.transformations = deque([Transformation.from_data(T) for T in data["transformations"]])
+        self.frame = data["frame"]
 
-    # ==========================================================================
-    # properties
-    # ==========================================================================
+    def get_geometry(self, with_features=False):
+        """
+        Returns a transformed copy of the part's geometry.
 
-    @property
-    def name(self):
-        return self.attributes.get("name") or self.__class__.__name__
-
-    @name.setter
-    def name(self, value):
-        self.attributes["name"] = value
-
-    @property
-    def frame(self):
-        if not self._frame:
-            self._frame = Frame.worldXY()
-        return self._frame
-
-    @frame.setter
-    def frame(self, frame):
-        self._frame = frame
-
-    @property
-    def geometry(self):
-        # TODO: this is a temp solution
-        # TODO: add memoization or some other kind of caching
-        if self.features:
-            A = self.shape.to_vertices_and_faces(triangulated=True)
-            for shape, operation in self.features:
-                B = shape.to_vertices_and_faces(triangulated=True)
-                A = Part.operations[operation](A, B)
-            geometry = Shape(*A)
-        else:
-            geometry = Shape(*self.shape.to_vertices_and_faces())
-
-        T = Transformation.from_frame_to_frame(Frame.worldXY(), self.frame)
-        geometry.transform(T)
-        return geometry
-
-    # ==========================================================================
-    # customization
-    # ==========================================================================
-
-    def __str__(self):
-        tpl = "<Part with shape {} and features {}>"
-        return tpl.format(self.shape, self.features)
-
-    # ==========================================================================
-    # constructors
-    # ==========================================================================
-
-    # ==========================================================================
-    # methods
-    # ==========================================================================
-
-    def transform(self, T):
-        """Transform the part with respect to the local cooordinate system.
+        The returned type can be drawn with an Artist.
 
         Parameters
         ----------
-        T : :class:`~compas.geometry.Transformation`
+        with_features : bool
+            True if geometry should include all the available features.
+
+        Returns
+        -------
+        :class:`~compas.geometry.Geometry`
+
+        """
+        raise NotImplementedError
+
+    def clear_features(self, features_to_clear=None):
+        raise NotImplementedError
+
+    def add_feature(self, feature, apply=False):
+        """Add a Feature to this Part.
+
+        Parameters
+        ----------
+        feature : :class:`~compas.assembly.Feature`
+            The feature to add
+        apply : :bool:
+            If True, feature is also applied. Otherwise, feature is only added and user must call `apply_features`.
 
         Returns
         -------
         None
-
         """
-        self.transformations.appendleft(T)
-        self.shape.transform(T)
-        for shape, operation in self.features:
-            shape.transform(T)
-
-    def add_feature(self, shape, operation):
-        """Add a feature to the shape of the part and the operation through which it should be integrated.
-
-        Parameters
-        ----------
-        shape : :class:`~compas.geometry.Shape`
-            The shape of the feature.
-        operation : Literal['union', 'difference', 'intersection']
-            The boolean operation through which the feature should be integrated in the base shape.
-
-        Returns
-        -------
-        None
-
-        """
-        if operation not in Part.operations:
-            raise FeatureError
-        self.features.append((shape, operation))
-
-    # def apply_transformations(self):
-    #     """Apply all transformations to the part shape."""
-    #     X = Transformation.from_frame(self.frame)
-    #     transformations = self.transformations[:]
-    #     transformations.append(X)
-    #     T = reduce(multiply_matrices, transformations)
-    #     self.shape.transform(T)
-
-    def to_mesh(self, cls=None):
-        """Convert the part geometry to a mesh.
-
-        Parameters
-        ----------
-        cls : :class:`~compas.datastructures.Mesh`, optional
-            The type of mesh to be used for the conversion.
-
-        Returns
-        -------
-        :class:`~compas.datastructures.Mesh`
-            The resulting mesh.
-
-        """
-        cls = cls or Mesh
-        return cls.from_shape(self.geometry)
+        raise NotImplementedError

--- a/src/compas/datastructures/assembly/part.py
+++ b/src/compas/datastructures/assembly/part.py
@@ -109,8 +109,8 @@ class Part(Datastructure):
         The identifier of the part in the connectivity graph of the parent assembly.
     frame : :class:`~compas.geometry.Frame`
         The local coordinate system of the part.
-    features : list[tuple[:class:`~compas.geometry.Shape`, str]]
-        The features added to the base shape of the part geometry.
+    features : list(:class:`~compas.datastructures.Feature`)
+        The features added to the base shape of the part's geometry.
 
     """
 


### PR DESCRIPTION
Introducing a simplified, more generic, version of `Part` as well as base classes for features: `Feature`, `GeometricFeature` and `ParametricFeature`.

* Handling of geometry creation is moved to an extending class (see `compas_timber.parts.Beam`).
* Added base classes for features (see `compas_timber.parts.BeamExtendingFeature` and `compas_timber.parts.BeamTrimmingFeature`)
* Removed the transformation deque
* Removed `to_mesh`

This has been used during the development of `compas_timber.parts.Beam`. Moving it over from `compas_future` to allow for open-sourcing of `compas-timber`.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
