### PR TITLE
removed deprecated pip option

### DIFF
--- a/.github/workflows/ironpython.yml
+++ b/.github/workflows/ironpython.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "[RPC tests] Install CPython dependencies"
         run: |
           python -m pip install --upgrade pip
-          pip install cython --install-option='--no-cython-compile'
+          pip install cython --config-settings="--build-option=--no-cython-compile"
       - name: "[RPC tests] Install COMPAS on CPython"
         run: |
           pip install --no-cache-dir .

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -232,14 +232,7 @@ def test_area_triangle(triangle, R):
 
 def test_area_polygon():
     # create a test closed (here planar xy) non-convex polygon :
-    polygon = [
-        Point(-7, -15, 0),
-        Point(-5, 9, 0),
-        Point(13, 0, 0),
-        Point(0, -2, 0),
-        Point(0, -6, 0),
-        Point(-4, -10, 0)
-    ]
+    polygon = [Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)]
 
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -232,12 +232,18 @@ def test_area_triangle(triangle, R):
 
 def test_area_polygon():
     # create a test closed (here planar xy) non-convex polygon :
-    polygon = Polygon(
-        [Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)]
-    )
+    polygon = [
+        Point(-7, -15, 0),
+        Point(-5, 9, 0),
+        Point(13, 0, 0),
+        Point(0, -2, 0),
+        Point(0, -6, 0),
+        Point(-4, -10, 0)
+    ]
+
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :
-    polygon_ = Polygon(polygon[3:] + polygon[:3])
+    polygon_ = polygon[3:] + polygon[:3]
     assert area_polygon(polygon_) >= 0
 
 


### PR DESCRIPTION
Same change as in https://github.com/compas-dev/compas-actions.build/pull/2. 

Unrelated, but to fix the ironpython build fixed a broken unittest as well. 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
