### PR TITLE
Fix serialization of System.Decimal data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed Grasshopper `draw_polylines` method to return `PolylineCurve` instead of `Polyline` because the latter shows as only points.
 * Fixed `area_polygon` that was, in some cases, returning a negative area.
 * Fixed uninstall post-process.
+* Fixed support for `System.Decimal` data type on json serialization.
 
 ### Removed
 

--- a/tests/compas/data/test_json.py
+++ b/tests/compas/data/test_json.py
@@ -1,32 +1,18 @@
 import compas
-
-from compas.geometry import Point, Vector, Frame
-from compas.geometry import Box
-from compas.geometry import Transformation
-
-from compas.datastructures import Network
 from compas.datastructures import Mesh
+from compas.datastructures import Network
 from compas.datastructures import VolMesh
+from compas.geometry import Box
+from compas.geometry import Frame
+from compas.geometry import Point
+from compas.geometry import Transformation
+from compas.geometry import Vector
 
 
 def test_json_native():
     before = [[], (), {}, "", 1, 1.0, True, None]
     after = compas.json_loads(compas.json_dumps(before))
     assert after == [[], [], {}, "", 1, 1.0, True, None]
-
-
-if not compas.IPY:
-    import numpy as np
-
-    def test_json_numpy():
-        before = [
-            np.array([1, 2, 3]),
-            np.array([1.0, 2.0, 3.0]),
-            np.float64(1.0),
-            np.int32(1),
-        ]
-        after = compas.json_loads(compas.json_dumps(before))
-        assert after == [[1, 2, 3], [1.0, 2.0, 3.0], 1.0, 1]
 
 
 def test_json_primitive():

--- a/tests/compas/data/test_json_dotnet.py
+++ b/tests/compas/data/test_json_dotnet.py
@@ -1,0 +1,13 @@
+import compas
+
+try:
+    import System
+
+    def test_decimal():
+        before = System.Decimal(100.0)
+
+        after = compas.json_loads(compas.json_dumps(before))
+        assert after == 100.0
+
+except:
+    pass

--- a/tests/compas/data/test_json_dotnet.py
+++ b/tests/compas/data/test_json_dotnet.py
@@ -9,5 +9,5 @@ try:
         after = compas.json_loads(compas.json_dumps(before))
         assert after == 100.0
 
-except:
+except ImportError:
     pass

--- a/tests/compas/data/test_json_numpy.py
+++ b/tests/compas/data/test_json_numpy.py
@@ -1,0 +1,17 @@
+import compas
+
+try:
+    import numpy as np
+
+    def test_json_numpy():
+        before = [
+            np.array([1, 2, 3]),
+            np.array([1.0, 2.0, 3.0]),
+            np.float64(1.0),
+            np.int32(1),
+        ]
+        after = compas.json_loads(compas.json_dumps(before))
+        assert after == [[1, 2, 3], [1.0, 2.0, 3.0], 1.0, 1]
+
+except:
+    pass

--- a/tests/compas/data/test_json_numpy.py
+++ b/tests/compas/data/test_json_numpy.py
@@ -13,5 +13,5 @@ try:
         after = compas.json_loads(compas.json_dumps(before))
         assert after == [[1, 2, 3], [1.0, 2.0, 3.0], 1.0, 1]
 
-except:
+except ImportError:
     pass


### PR DESCRIPTION
.NET has a data type called `System.Decimal` that is a higher-precision floating-point type and Grasshopper will occasionally output values of this type (I believe some sliders do this, didn't really dig into when it happens). This type, even though it is basically a float, it fails to be serialized to JSON with an incredibly unhelpful message (`0 is not JSON serializable`).

This PR adds explicit support for handling it inside the compas encoders. I mark this as a bug because the behavior and the confusing error message are annoying af.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
