### PR TITLE
LTS backports/sync 230423

### DIFF
--- a/.github/workflows/ironpython.yml
+++ b/.github/workflows/ironpython.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "[RPC tests] Install CPython dependencies"
         run: |
           python -m pip install --upgrade pip
-          pip install cython --install-option='--no-cython-compile'
+          pip install cython --config-settings="--build-option=--no-cython-compile"
       - name: "[RPC tests] Install COMPAS on CPython"
         run: |
           pip install --no-cache-dir .

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -36,3 +36,4 @@
 - Chen Kasirer <<kasirer@arch.ethz.ch>> [@chenkasirer](https://github.com/chenkasirer)
 - Nickolas Maslarinos <<maslarinosnickolas@gmail.com>> [@nmaslarinos](https://github.com/nmaslarinos)
 - Katerina Toumpektsi <<e.toumpeksti@gmail.com>> [@katarametin](https://github.com/katarametin)
+- Joelle Baehr-Bruyere <<joelle.baehr-bruyere@epfl.ch>> [@baehrjo](https://github.com/baehrjo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed Grasshopper `draw_polylines` method to return `PolylineCurve` instead of `Polyline` because the latter shows as only points.
 * Fixed uninstall post-process.
 * Fixed `area_polygon` that was, in some cases, returning a negative area
+* Fixed support for `System.Decimal` data type on json serialization.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug that caused a new-line at the end of the `compas.HERE` constant in IronPython for Mac.
 * Fixed Grasshopper `draw_polylines` method to return `PolylineCurve` instead of `Polyline` because the latter shows as only points.
 * Fixed uninstall post-process.
+* Fixed `area_polygon` that was, in some cases, returning a negative area
 
 ### Removed
 

--- a/src/compas/geometry/_core/size.py
+++ b/src/compas/geometry/_core/size.py
@@ -65,7 +65,7 @@ def area_polygon(polygon):
             area += 0.5 * length_vector(n)
         else:
             area -= 0.5 * length_vector(n)
-    return area
+    return abs(area)
 
 
 def area_polygon_xy(polygon):

--- a/tests/compas/data/test_json.py
+++ b/tests/compas/data/test_json.py
@@ -1,32 +1,18 @@
 import compas
-
-from compas.geometry import Point, Vector, Frame
-from compas.geometry import Box
-from compas.geometry import Transformation
-
-from compas.datastructures import Network
 from compas.datastructures import Mesh
+from compas.datastructures import Network
 from compas.datastructures import VolMesh
+from compas.geometry import Box
+from compas.geometry import Frame
+from compas.geometry import Point
+from compas.geometry import Transformation
+from compas.geometry import Vector
 
 
 def test_json_native():
     before = [[], (), {}, "", 1, 1.0, True, None]
     after = compas.json_loads(compas.json_dumps(before))
     assert after == [[], [], {}, "", 1, 1.0, True, None]
-
-
-if not compas.IPY:
-    import numpy as np
-
-    def test_json_numpy():
-        before = [
-            np.array([1, 2, 3]),
-            np.array([1.0, 2.0, 3.0]),
-            np.float64(1.0),
-            np.int32(1),
-        ]
-        after = compas.json_loads(compas.json_dumps(before))
-        assert after == [[1, 2, 3], [1.0, 2.0, 3.0], 1.0, 1]
 
 
 def test_json_primitive():

--- a/tests/compas/data/test_json_dotnet.py
+++ b/tests/compas/data/test_json_dotnet.py
@@ -1,0 +1,13 @@
+import compas
+
+try:
+    import System
+
+    def test_decimal():
+        before = System.Decimal(100.0)
+
+        after = compas.json_loads(compas.json_dumps(before))
+        assert after == 100.0
+
+except:
+    pass

--- a/tests/compas/data/test_json_dotnet.py
+++ b/tests/compas/data/test_json_dotnet.py
@@ -9,5 +9,5 @@ try:
         after = compas.json_loads(compas.json_dumps(before))
         assert after == 100.0
 
-except:
+except ImportError:
     pass

--- a/tests/compas/data/test_json_numpy.py
+++ b/tests/compas/data/test_json_numpy.py
@@ -1,0 +1,17 @@
+import compas
+
+try:
+    import numpy as np
+
+    def test_json_numpy():
+        before = [
+            np.array([1, 2, 3]),
+            np.array([1.0, 2.0, 3.0]),
+            np.float64(1.0),
+            np.int32(1),
+        ]
+        after = compas.json_loads(compas.json_dumps(before))
+        assert after == [[1, 2, 3], [1.0, 2.0, 3.0], 1.0, 1]
+
+except:
+    pass

--- a/tests/compas/data/test_json_numpy.py
+++ b/tests/compas/data/test_json_numpy.py
@@ -13,5 +13,5 @@ try:
         after = compas.json_loads(compas.json_dumps(before))
         assert after == [[1, 2, 3], [1.0, 2.0, 3.0], 1.0, 1]
 
-except:
+except ImportError:
     pass

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -237,9 +237,7 @@ def test_area_polygon():
     )
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :
-    polygon_ = Polygon(
-        [Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)]
-    )
+    polygon_ = Polygon(polygon[3:] + polygon[:3])
     assert area_polygon(polygon_) >= 0
 
 

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -3,7 +3,7 @@ from math import pi, radians, sqrt
 import pytest
 
 from compas.geometry import Polyhedron
-from compas.geometry import Polygon
+from compas.geometry import Point, Polygon
 from compas.geometry import Rotation
 from compas.geometry import allclose
 from compas.geometry import angle_vectors
@@ -229,6 +229,14 @@ def test_area_triangle(triangle, R):
     assert close(area_triangle_xy(triangle.points), 0.0)
     assert close(triangle.area, 0.5)
 
+
+def test_area_polygon():
+    # create a test closed (here planar xy) non-convex polygon :
+    polygon = Polygon([Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)])
+    assert area_polygon(polygon) >= 0
+    # the same polygon with vertices list shifted by 3 positions :
+    polygon_ = Polygon([Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)])
+    assert area_polygon(polygon_) >= 0
 
 # ==============================================================================
 # normals

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -232,11 +232,16 @@ def test_area_triangle(triangle, R):
 
 def test_area_polygon():
     # create a test closed (here planar xy) non-convex polygon :
-    polygon = Polygon([Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)])
+    polygon = Polygon(
+        [Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)]
+    )
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :
-    polygon_ = Polygon([Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)])
+    polygon_ = Polygon(
+        [Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0), Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0)]
+    )
     assert area_polygon(polygon_) >= 0
+
 
 # ==============================================================================
 # normals

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -232,14 +232,7 @@ def test_area_triangle(triangle, R):
 
 def test_area_polygon():
     # create a test closed (here planar xy) non-convex polygon :
-    polygon = [
-        Point(-7, -15, 0),
-        Point(-5, 9, 0),
-        Point(13, 0, 0),
-        Point(0, -2, 0),
-        Point(0, -6, 0),
-        Point(-4, -10, 0)
-    ]
+    polygon = [Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)]
 
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :

--- a/tests/compas/geometry/test_core.py
+++ b/tests/compas/geometry/test_core.py
@@ -232,12 +232,18 @@ def test_area_triangle(triangle, R):
 
 def test_area_polygon():
     # create a test closed (here planar xy) non-convex polygon :
-    polygon = Polygon(
-        [Point(-7, -15, 0), Point(-5, 9, 0), Point(13, 0, 0), Point(0, -2, 0), Point(0, -6, 0), Point(-4, -10, 0)]
-    )
+    polygon = [
+        Point(-7, -15, 0),
+        Point(-5, 9, 0),
+        Point(13, 0, 0),
+        Point(0, -2, 0),
+        Point(0, -6, 0),
+        Point(-4, -10, 0)
+    ]
+
     assert area_polygon(polygon) >= 0
     # the same polygon with vertices list shifted by 3 positions :
-    polygon_ = Polygon(polygon[3:] + polygon[:3])
+    polygon_ = polygon[3:] + polygon[:3]
     assert area_polygon(polygon_) >= 0
 
 


### PR DESCRIPTION
Sync the following merged pull requests into LTS 1.x:
 - https://github.com/compas-dev/compas/pull/1131
 - https://github.com/compas-dev/compas/pull/1136
 - https://github.com/compas-dev/compas/pull/1137

### What type of change is this?

- [x] Sync to LTS branch

### Process

The process to create this sync is the following:

- [x] Create a new branch off of the `LTS` branch for syncs up to current date, e.g. `lts-backports/sync-230423`
- [x] For each merged pull request that needs to be merged into LTS:
  - [x] Cherry pick ranges of commits (you can use the github commits page of the PR to copy the oldest and newest commit hash): e.g. `git cherry-pick "fdc342d15a2908f4b72f437aeb05165eba098920^..f3874fea755ba3c6bdb28fcf33d870c4dbad451e"` ([see this stackoverflow answer for details](https://stackoverflow.com/a/3933416/269335))
  - [x] Fix any pending conflicts (using the `Conflict editor` of vscode seems to be the easiest option.
  - [x] Confirm the cherry pick operation with `git cherry-pick --continue`
  - [x] Repeat for the next pull request
- [x] Push the sync branch and create a pull request to the `LTS` branch
