### PR TITLE
fix for offset_polygon not working with a Polygon input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `area_polygon` that was, in some cases, returning a negative area.
 * Fixed uninstall post-process.
 * Fixed support for `System.Decimal` data type on json serialization.
+* Fixed `offset_polygon` raising a TypeError when inputing a Polygon instead of a list of Points.
 
 ### Removed
 

--- a/src/compas/geometry/offset/offset.py
+++ b/src/compas/geometry/offset/offset.py
@@ -135,6 +135,11 @@ def offset_polygon(polygon, distance, tol=1e-6):
 
     Examples
     --------
+    >>> from compas.geometry import Polygon
+    >>> polygon = Polygon([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)])
+    >>> offsetted_polygon = offset_polygon(polygon, 0.5)
+    >>> offsetted_polygon
+    Polygon[[0.5, 0.5, 0.0], [0.5, 0.5, 0.0], [0.5, 0.5, 0.0], [0.5, 0.5, 0.0]]
     >>>
 
     """
@@ -144,7 +149,7 @@ def offset_polygon(polygon, distance, tol=1e-6):
         distance = [distance]
     distances = iterable_like(polygon, distance, distance[-1])
 
-    polygon = polygon + polygon[:1]
+    polygon = polygon[:] + polygon[:1]
     segments = offset_segments(polygon, distances, normal)
 
     offset = []


### PR DESCRIPTION
Fix a bug in `offset_polygon` raising a TypeError when the input was a Polygon instead of a list of Points. Added an example in the docstring that correctly runs with a Polygon as an input. 
The fix is rather simple, in the line `polygon = polygon + polygon[:1]` we just need to add a `[:]` after the `polygon` in order to get the list in both input cases (Polygon or list of Points).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
