### PR TITLE
fixed wrong attribute name in plotter artists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas.data.json_dumps` to include `compact=False` parameter.
 * Changed `compas.data.DataEncoder` and `compas.data.DataDecoder` to support `to_jsondata` and `from_jsondata`.
 * Moved all API level docstrings from the `__init__.py` to the correspoding `.rst` file in the docs.
+* Fixed `AttributeError` in Plotter's `PolylineArtist` and `SegementArtist`.
 
 ### Removed
 

--- a/src/compas_plotters/artists/polylineartist.py
+++ b/src/compas_plotters/artists/polylineartist.py
@@ -107,4 +107,4 @@ class PolylineArtist(PlotterArtist, PrimitiveArtist):
         self._mpl_line.set_xdata(x)
         self._mpl_line.set_ydata(y)
         self._mpl_line.set_color(self.color)
-        self._mpl_line.set_linewidth(self.width)
+        self._mpl_line.set_linewidth(self.linewidth)

--- a/src/compas_plotters/artists/segmentartist.py
+++ b/src/compas_plotters/artists/segmentartist.py
@@ -106,7 +106,7 @@ class SegmentArtist(PlotterArtist, PrimitiveArtist):
         self._mpl_line.set_xdata([self.line.start[0], self.line.end[0]])
         self._mpl_line.set_ydata([self.line.start[1], self.line.end[1]])
         self._mpl_line.set_color(self.color)
-        self._mpl_line.set_linewidth(self.width)
+        self._mpl_line.set_linewidth(self.linewidth)
         if self.draw_points:
             self._start_artist.redraw()
             self._end_artist.redraw()


### PR DESCRIPTION
Fixed wrong attribute name used in `PolylineArtist` and `SegmentArtist` of `compas_plotter`.

Fixes #1164.

@tomvanmele should we remove `SegmentArtist`? I see it's not even registered for anything.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
