### PR TITLE
fixed graph serialization in assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas.data.DataEncoder` and `compas.data.DataDecoder` to support `to_jsondata` and `from_jsondata`.
 * Moved all API level docstrings from the `__init__.py` to the correspoding `.rst` file in the docs.
 * Fixed `AttributeError` in Plotter's `PolylineArtist` and `SegementArtist`.
+* Fixed wrong key type when de-serializing `Graph` with integer keys leading to node not found.
 
 ### Removed
 

--- a/src/compas/datastructures/assembly/assembly.py
+++ b/src/compas/datastructures/assembly/assembly.py
@@ -60,14 +60,14 @@ class Assembly(Datastructure):
     def data(self):
         data = {
             "attributes": self.attributes,
-            "graph": self.graph.data,
+            "graph": self.graph,
         }
         return data
 
     @data.setter
     def data(self, data):
         self.attributes.update(data["attributes"] or {})
-        self.graph.data = data["graph"]
+        self.graph = data["graph"]
         self._parts = {part.guid: part.key for part in self.parts()}
 
     # ==========================================================================

--- a/tests/compas/datastructures/test_assembly.py
+++ b/tests/compas/datastructures/test_assembly.py
@@ -1,5 +1,7 @@
 import pytest
 
+from compas.data import json_dumps
+from compas.data import json_loads
 from compas.datastructures import Assembly
 from compas.datastructures import AssemblyError
 from compas.datastructures import Part
@@ -69,9 +71,22 @@ def test_find_by_key():
     assert assembly.find_by_key("100") is None
 
 
-def test_find_by_key_after_deserialization():
+def test_find_by_key_after_from_data():
     assembly = Assembly()
     part = Part()
     assembly.add_part(part, key=2)
     assembly = Assembly.from_data(assembly.to_data())
     assert assembly.find_by_key(2) == part
+
+
+def test_find_by_key_after_deserialization():
+    assembly = Assembly()
+    part = Part(name="test_part")
+    assembly.add_part(part, key=2)
+    assembly = json_loads(json_dumps(assembly))
+
+    deserialized_part = assembly.find_by_key(2)
+    assert deserialized_part.name == part.name
+    assert deserialized_part.key == part.key
+    assert deserialized_part.guid == part.guid
+    assert deserialized_part.attributes == part.attributes


### PR DESCRIPTION
Fixes `Assembly.find_by_key()` not finding parts with an int key after de-serialization. This is due to `Graph.from_jsondata()` not being called when using the `Graph.data` setter directly as was done in `Assembly.data.setter`.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
