### PR TITLE
Fixing Graph.delete_edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed base class of `compas.geometry.Line` to `compas.geometry.Curve.`
 * Changed base class of `compas.geometry.Polyline` to `compas.geometry.Curve.`
 * Changed `compas.geometry.oriented_bounding_box_numpy` to minimize volume.
+* Changed `compas.datastructures.Graph.delete_edge` to delete invalid (u, u) edges and not delete edges in opposite directions (v, u)
 
 ### Removed
 

--- a/src/compas/datastructures/graph/graph.py
+++ b/src/compas/datastructures/graph/graph.py
@@ -587,15 +587,15 @@ class Graph(Datastructure):
         """
         u, v = edge
 
+        if u in self.edge and v in self.edge[u]:
+            del self.edge[u][v]
+
         if u == v:  # invalid edge
-            del self.edge[u][v]
             del self.adjacency[u][v]
-        elif v in self.edge and u in self.edge[v]:  # edge (v, u) exists
-            del self.edge[u][v]
-        else:
-            del self.edge[u][v]
+        elif v not in self.edge or u not in self.edge[v]:
             del self.adjacency[u][v]
             del self.adjacency[v][u]
+        # else: an edge in an opposite direction exists, we don't want to delete the adjacency
 
     # --------------------------------------------------------------------------
     # info

--- a/src/compas/datastructures/graph/graph.py
+++ b/src/compas/datastructures/graph/graph.py
@@ -586,12 +586,16 @@ class Graph(Datastructure):
 
         """
         u, v = edge
-        del self.adjacency[u][v]
-        del self.adjacency[v][u]
-        if u in self.edge and v in self.edge[u]:
+
+        if u == v:  # invalid edge
             del self.edge[u][v]
-        if v in self.edge and u in self.edge[v]:
-            del self.edge[v][u]
+            del self.adjacency[u][v]
+        elif v in self.edge and u in self.edge[v]:  # edge (v, u) exists
+            del self.edge[u][v]
+        else:
+            del self.edge[u][v]
+            del self.adjacency[u][v]
+            del self.adjacency[v][u]
 
     # --------------------------------------------------------------------------
     # info

--- a/tests/compas/datastructures/test_graph.py
+++ b/tests/compas/datastructures/test_graph.py
@@ -118,3 +118,22 @@ def test_graph_networkx_conversion():
     assert g2.edge_attribute((0, 1), "attr_value") == 10
     assert g2.attributes["name"] == "DiGraph", "Graph attributes must be preserved"
     assert g2.attributes["val"] == (0, 0, 0), "Graph attributes must be preserved"
+
+
+def test_invalid_edge_delete():
+    graph = Graph()
+    node = graph.add_node()
+    edge = graph.add_edge(node, node)
+    graph.delete_edge(edge)
+    assert graph.has_edge(edge) is False
+
+
+def test_opposite_direction_edge_delete():
+    graph = Graph()
+    node_a = graph.add_node()
+    node_b = graph.add_node()
+    edge_a = graph.add_edge(node_a, node_b)
+    edge_b = graph.add_edge(node_b, node_a)
+    graph.delete_edge(edge_a)
+    assert graph.has_edge(edge_a) is False
+    assert graph.has_edge(edge_b) is True


### PR DESCRIPTION
I discovered that Graph.delete_edge((u, v)) was failing on invalid edges (if u == v) and if there was an edge in the opposite direction (v, u), it was also deleted by that call. I have corrected the method so that this should no longer happen.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
