### PR TITLE
LTS backports/sync 230905

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `area_polygon` that was, in some cases, returning a negative area
 * Fixed support for `System.Decimal` data type on json serialization.
 * Fixed `AttributeError` in Plotter's `PolylineArtist` and `SegementArtist`.
+* Fixed wrong key type when de-serializing `Graph` with integer keys leading to node not found.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed uninstall post-process.
 * Fixed `area_polygon` that was, in some cases, returning a negative area
 * Fixed support for `System.Decimal` data type on json serialization.
+* Fixed `AttributeError` in Plotter's `PolylineArtist` and `SegementArtist`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed support for `System.Decimal` data type on json serialization.
 * Fixed `AttributeError` in Plotter's `PolylineArtist` and `SegementArtist`.
 * Fixed wrong key type when de-serializing `Graph` with integer keys leading to node not found.
+* Fixed bug in `VolMeshArtist.draw_cells` for Rhino, Blender and Grasshopper.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `AttributeError` in Plotter's `PolylineArtist` and `SegementArtist`.
 * Fixed wrong key type when de-serializing `Graph` with integer keys leading to node not found.
 * Fixed bug in `VolMeshArtist.draw_cells` for Rhino, Blender and Grasshopper.
+* Fixed bug in the `is_polygon_in_polygon_xy` that was not correctly generating all the edges of the second polygon before checking for intersections.
 
 ### Removed
 

--- a/src/compas/datastructures/assembly/assembly.py
+++ b/src/compas/datastructures/assembly/assembly.py
@@ -58,14 +58,14 @@ class Assembly(Datastructure):
     def data(self):
         data = {
             "attributes": self.attributes,
-            "graph": self.graph.data,
+            "graph": self.graph,
         }
         return data
 
     @data.setter
     def data(self, data):
         self.attributes.update(data["attributes"] or {})
-        self.graph.data = data["graph"]
+        self.graph = data["graph"]
         self._parts = {part.guid: part.key for part in self.parts()}
 
     # ==========================================================================

--- a/src/compas/geometry/predicates/predicates_2.py
+++ b/src/compas/geometry/predicates/predicates_2.py
@@ -383,7 +383,7 @@ def is_polygon_in_polygon_xy(polygon1, polygon2):
         for i in range(len(polygon1)):
             line = [polygon1[-i], polygon1[-i - 1]]
             for j in range(len(polygon2)):
-                line_ = [polygon2[-j], polygon2[j - 1]]
+                line_ = [polygon2[-j], polygon2[-j - 1]]
                 if is_intersection_segment_segment_xy(line, line_):
                     return False
         for pt in polygon2:

--- a/src/compas_blender/artists/volmeshartist.py
+++ b/src/compas_blender/artists/volmeshartist.py
@@ -310,7 +310,7 @@ class VolMeshArtist(BlenderArtist, VolMeshArtist):
             faces = self.volmesh.cell_faces(cell)
             vertex_index = dict((vertex, index) for index, vertex in enumerate(vertices))
             vertices = [vertex_xyz[vertex] for vertex in vertices]
-            faces = [[vertex_index[vertex] for vertex in self.halfface_vertices(face)] for face in faces]
+            faces = [[vertex_index[vertex] for vertex in self.volmesh.halfface_vertices(face)] for face in faces]
             obj = compas_blender.draw_mesh(
                 vertices,
                 faces,

--- a/src/compas_ghpython/artists/volmeshartist.py
+++ b/src/compas_ghpython/artists/volmeshartist.py
@@ -167,7 +167,7 @@ class VolMeshArtist(GHArtist, VolMeshArtist):
             faces = self.volmesh.cell_faces(cell)
             vertex_index = dict((vertex, index) for index, vertex in enumerate(vertices))
             vertices = [vertex_xyz[vertex] for vertex in vertices]
-            faces = [[vertex_index[vertex] for vertex in self.halfface_vertices(face)] for face in faces]
+            faces = [[vertex_index[vertex] for vertex in self.volmesh.halfface_vertices(face)] for face in faces]
             mesh = compas_ghpython.draw_mesh(vertices, faces, color=self.cell_color[cell].rgb255)
             meshes.append(mesh)
         return meshes

--- a/src/compas_plotters/artists/polylineartist.py
+++ b/src/compas_plotters/artists/polylineartist.py
@@ -107,4 +107,4 @@ class PolylineArtist(PlotterArtist, PrimitiveArtist):
         self._mpl_line.set_xdata(x)
         self._mpl_line.set_ydata(y)
         self._mpl_line.set_color(self.color)
-        self._mpl_line.set_linewidth(self.width)
+        self._mpl_line.set_linewidth(self.linewidth)

--- a/src/compas_plotters/artists/segmentartist.py
+++ b/src/compas_plotters/artists/segmentartist.py
@@ -106,7 +106,7 @@ class SegmentArtist(PlotterArtist, PrimitiveArtist):
         self._mpl_line.set_xdata([self.line.start[0], self.line.end[0]])
         self._mpl_line.set_ydata([self.line.start[1], self.line.end[1]])
         self._mpl_line.set_color(self.color)
-        self._mpl_line.set_linewidth(self.width)
+        self._mpl_line.set_linewidth(self.linewidth)
         if self.draw_points:
             self._start_artist.redraw()
             self._end_artist.redraw()

--- a/src/compas_rhino/artists/volmeshartist.py
+++ b/src/compas_rhino/artists/volmeshartist.py
@@ -268,7 +268,7 @@ class VolMeshArtist(RhinoArtist, VolMeshArtist):
             faces = self.volmesh.cell_faces(cell)
             vertex_index = dict((vertex, index) for index, vertex in enumerate(vertices))
             vertices = [vertex_xyz[vertex] for vertex in vertices]
-            faces = [[vertex_index[vertex] for vertex in self.halfface_vertices(face)] for face in faces]
+            faces = [[vertex_index[vertex] for vertex in self.volmesh.halfface_vertices(face)] for face in faces]
             guid = compas_rhino.draw_mesh(
                 vertices,
                 faces,

--- a/tests/compas/datastructures/test_assembly.py
+++ b/tests/compas/datastructures/test_assembly.py
@@ -1,5 +1,7 @@
 import pytest
 
+from compas.data import json_dumps
+from compas.data import json_loads
 from compas.datastructures import Assembly
 from compas.datastructures import AssemblyError
 from compas.datastructures import Part
@@ -69,9 +71,22 @@ def test_find_by_key():
     assert assembly.find_by_key("100") is None
 
 
-def test_find_by_key_after_deserialization():
+def test_find_by_key_after_from_data():
     assembly = Assembly()
     part = Part()
     assembly.add_part(part, key=2)
     assembly = Assembly.from_data(assembly.to_data())
     assert assembly.find_by_key(2) == part
+
+
+def test_find_by_key_after_deserialization():
+    assembly = Assembly()
+    part = Part(name="test_part")
+    assembly.add_part(part, key=2)
+    assembly = json_loads(json_dumps(assembly))
+
+    deserialized_part = assembly.find_by_key(2)
+    assert deserialized_part.name == part.name
+    assert deserialized_part.key == part.key
+    assert deserialized_part.guid == part.guid
+    assert deserialized_part.attributes == part.attributes

--- a/tests/compas/geometry/predicates/test_predicates_2.py
+++ b/tests/compas/geometry/predicates/test_predicates_2.py
@@ -29,7 +29,7 @@ def test_is_point_in_circle_xy_class_input():
 
 def test_is_polygon_in_polygon_xy():
     polygon_contour = Polygon([(0, 0, 0), (4, 2, 0), (10, 0, 0), (11, 10, 0), (8, 12, 0), (0, 10, 0)])
-    polygon_inside = Polygon([(5, 5, 0), (10, 5, 0), (10, 10 , 0), (5, 10, 0)])
+    polygon_inside = Polygon([(5, 5, 0), (10, 5, 0), (10, 10, 0), (5, 10, 0)])
     assert is_polygon_in_polygon_xy(polygon_contour, polygon_inside)
 
     polygon_outside = Polygon([(15, 5, 0), (20, 5, 0), (20, 10, 0), (15, 10, 0)])

--- a/tests/compas/geometry/predicates/test_predicates_2.py
+++ b/tests/compas/geometry/predicates/test_predicates_2.py
@@ -35,6 +35,9 @@ def test_is_polygon_in_polygon_xy():
     polygon_outside = Polygon([(15, 5, 0), (20, 5, 0), (20, 10 ,0), (15, 10, 0)])
     assert is_polygon_in_polygon_xy(polygon_contour, polygon_outside) is False
 
-    polygon_intersecting = Polygon([(10, 5, 0), (15, 5, 0), (15, 10 ,0), (10, 10, 0)])
+    polygon_intersecting = Polygon([(10, 10, 0), (10, 5, 0), (15, 5, 0), (15, 10 ,0)])
     assert is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting) is False
-    
+
+    # shifting the vertices list of the same polygon shouldn't affect the containment check output anymore
+    polygon_intersecting_shifted = Polygon(polygon_intersecting[1:] + polygon_intersecting[:1])
+    assert is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting_shifted) is False

--- a/tests/compas/geometry/predicates/test_predicates_2.py
+++ b/tests/compas/geometry/predicates/test_predicates_2.py
@@ -1,8 +1,9 @@
 from compas.geometry import Circle
 from compas.geometry import Plane
 from compas.geometry import Point
+from compas.geometry import Polygon
 from compas.geometry import Vector
-from compas.geometry import is_point_in_circle_xy
+from compas.geometry import is_point_in_circle_xy, is_polygon_in_polygon_xy
 
 
 def test_is_point_in_circle_xy():
@@ -24,3 +25,16 @@ def test_is_point_in_circle_xy_class_input():
 
     pt_outside = Point(15, 15, 0)
     assert is_point_in_circle_xy(pt_outside, circle) is False
+
+
+def test_is_polygon_in_polygon_xy():
+    polygon_contour = Polygon([(0, 0, 0), (4, 2, 0), (10, 0, 0), (11, 10, 0), (8, 12, 0), (0, 10, 0)])
+    polygon_inside = Polygon([(5, 5, 0), (10, 5, 0), (10, 10 ,0), (5, 10, 0)])
+    assert is_polygon_in_polygon_xy(polygon_contour, polygon_inside) is True
+
+    polygon_outside = Polygon([(15, 5, 0), (20, 5, 0), (20, 10 ,0), (15, 10, 0)])
+    assert is_polygon_in_polygon_xy(polygon_contour, polygon_outside) is False
+
+    polygon_intersecting = Polygon([(10, 5, 0), (15, 5, 0), (15, 10 ,0), (10, 10, 0)])
+    assert is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting) is False
+    

--- a/tests/compas/geometry/predicates/test_predicates_2.py
+++ b/tests/compas/geometry/predicates/test_predicates_2.py
@@ -29,15 +29,15 @@ def test_is_point_in_circle_xy_class_input():
 
 def test_is_polygon_in_polygon_xy():
     polygon_contour = Polygon([(0, 0, 0), (4, 2, 0), (10, 0, 0), (11, 10, 0), (8, 12, 0), (0, 10, 0)])
-    polygon_inside = Polygon([(5, 5, 0), (10, 5, 0), (10, 10 ,0), (5, 10, 0)])
-    assert is_polygon_in_polygon_xy(polygon_contour, polygon_inside) is True
+    polygon_inside = Polygon([(5, 5, 0), (10, 5, 0), (10, 10 , 0), (5, 10, 0)])
+    assert is_polygon_in_polygon_xy(polygon_contour, polygon_inside)
 
     polygon_outside = Polygon([(15, 5, 0), (20, 5, 0), (20, 10, 0), (15, 10, 0)])
-    assert is_polygon_in_polygon_xy(polygon_contour, polygon_outside) is False
+    assert not is_polygon_in_polygon_xy(polygon_contour, polygon_outside)
 
     polygon_intersecting = Polygon([(10, 10, 0), (10, 5, 0), (15, 5, 0), (15, 10, 0)])
-    assert is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting) is False
+    assert not is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting)
 
     # shifting the vertices list of the same polygon shouldn't affect the containment check output anymore
     polygon_intersecting_shifted = Polygon(polygon_intersecting[1:] + polygon_intersecting[:1])
-    assert is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting_shifted) is False
+    assert not is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting_shifted)

--- a/tests/compas/geometry/predicates/test_predicates_2.py
+++ b/tests/compas/geometry/predicates/test_predicates_2.py
@@ -32,10 +32,10 @@ def test_is_polygon_in_polygon_xy():
     polygon_inside = Polygon([(5, 5, 0), (10, 5, 0), (10, 10 ,0), (5, 10, 0)])
     assert is_polygon_in_polygon_xy(polygon_contour, polygon_inside) is True
 
-    polygon_outside = Polygon([(15, 5, 0), (20, 5, 0), (20, 10 ,0), (15, 10, 0)])
+    polygon_outside = Polygon([(15, 5, 0), (20, 5, 0), (20, 10, 0), (15, 10, 0)])
     assert is_polygon_in_polygon_xy(polygon_contour, polygon_outside) is False
 
-    polygon_intersecting = Polygon([(10, 10, 0), (10, 5, 0), (15, 5, 0), (15, 10 ,0)])
+    polygon_intersecting = Polygon([(10, 10, 0), (10, 5, 0), (15, 5, 0), (15, 10, 0)])
     assert is_polygon_in_polygon_xy(polygon_contour, polygon_intersecting) is False
 
     # shifting the vertices list of the same polygon shouldn't affect the containment check output anymore


### PR DESCRIPTION
Closes #1161

Sync the following merged pull requests into LTS 1.x:
 - https://github.com/compas-dev/compas/pull/1130
 - https://github.com/compas-dev/compas/pull/1166
 - https://github.com/compas-dev/compas/pull/1170
 - https://github.com/compas-dev/compas/pull/1158

### What type of change is this?

- [x] Sync to LTS branch

### Process

The process to create this sync is the following:

- [x] Create a new branch off of the `LTS` branch for syncs up to current date, e.g. `lts-backports/sync-230423`
- [x] For each merged pull request that needs to be merged into LTS:
  - [x] Cherry pick ranges of commits (you can use the github commits page of the PR to copy the oldest and newest commit hash): e.g. `git cherry-pick "fdc342d15a2908f4b72f437aeb05165eba098920^..f3874fea755ba3c6bdb28fcf33d870c4dbad451e"` ([see this stackoverflow answer for details](https://stackoverflow.com/a/3933416/269335))
  - [x] Fix any pending conflicts (using the `Conflict editor` of vscode seems to be the easiest option.
  - [x] Confirm the cherry pick operation with `git cherry-pick --continue`
  - [x] Repeat for the next pull request
- [x] Push the sync branch and create a pull request to the `LTS` branch
