### PR TITLE
fixed syntax error when numpy is in path but IronPython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug in `compas.geometry.angle_vectors_signed`.
 * Changed `compas.artists.MeshArtist` default colors.
 * Changed internal _plane storage of the `compas.datastructures.Halfface` from `_plane[u][v][w]` to `_plane[u][v][fkey]`
+* Fixed `SyntaxError` when importing COMPAS in GHPython.
 
 ### Removed
 

--- a/src/compas/data/encoders.py
+++ b/src/compas/data/encoders.py
@@ -25,7 +25,7 @@ try:
     import numpy as np
 
     numpy_support = True
-except ImportError:
+except (ImportError, SyntaxError):
     numpy_support = False
 
 


### PR DESCRIPTION
Fixes https://github.com/compas-dev/compas/issues/1184.

Spotted this issue on some computers where COMPAS has been installed for he first time.
Problem seems to be the presence of `numpy` in `sys.path` of IronPython. The import of `numpy` in `encoders.py` to determine if it's available raises a syntax error, probably due to python3 syntax used.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
