### PR TITLE
LTS backports/sync 230929

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed wrong key type when de-serializing `Graph` with integer keys leading to node not found.
 * Fixed bug in `VolMeshArtist.draw_cells` for Rhino, Blender and Grasshopper.
 * Fixed bug in the `is_polygon_in_polygon_xy` that was not correctly generating all the edges of the second polygon before checking for intersections.
+* Fixed `SyntaxError` when importing COMPAS in GHPython.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `SyntaxError` when importing COMPAS in GHPython.
+
 ### Removed
 
 
@@ -31,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed wrong key type when de-serializing `Graph` with integer keys leading to node not found.
 * Fixed bug in `VolMeshArtist.draw_cells` for Rhino, Blender and Grasshopper.
 * Fixed bug in the `is_polygon_in_polygon_xy` that was not correctly generating all the edges of the second polygon before checking for intersections.
-* Fixed `SyntaxError` when importing COMPAS in GHPython.
 
 ### Removed
 

--- a/src/compas/data/encoders.py
+++ b/src/compas/data/encoders.py
@@ -26,7 +26,7 @@ try:
     import numpy as np
 
     numpy_support = True
-except ImportError:
+except (ImportError, SyntaxError):
     numpy_support = False
 
 


### PR DESCRIPTION
Closes #1186

Sync the following merged pull requests into LTS 1.x:
 - https://github.com/compas-dev/compas/pull/1185

### What type of change is this?

- [x] Sync to LTS branch

### Process

The process to create this sync is the following:

- [x] Create a new branch off of the `LTS` branch for syncs up to current date, e.g. `lts-backports/sync-230423`
- [x] For each merged pull request that needs to be merged into LTS:
  - [x] Cherry pick ranges of commits (you can use the github commits page of the PR to copy the oldest and newest commit hash): e.g. `git cherry-pick "fdc342d15a2908f4b72f437aeb05165eba098920^..f3874fea755ba3c6bdb28fcf33d870c4dbad451e"` ([see this stackoverflow answer for details](https://stackoverflow.com/a/3933416/269335))
  - [x] Fix any pending conflicts (using the `Conflict editor` of vscode seems to be the easiest option.
  - [x] Confirm the cherry pick operation with `git cherry-pick --continue`
  - [x] Repeat for the next pull request
  - [x] Ensure the CHANGELOG is correct, after cherry picking, the entries might have been added to previous releases instead of the `Unreleased` section.
- [x] Push the sync branch and create a pull request to the `LTS` branch 

After this PR has been merged:
- [x] Switch to the LTS branch
- [x] Create a new release using `invoke release patch` and push
- [x] Update [`doc_versions.txt`](https://github.com/compas-dev/compas/blob/gh-pages/doc_versions.txt) and [`versions.json`](https://github.com/compas-dev/compas/blob/gh-pages/versions.json)
- [x] Update the cloudflare rules to redirect the previous LTS doc links to the newest
- [x] Create a new issue for the next LTS sync
