### PR TITLE
Fix box_to_compas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed `planarity` from requirements.
 * Fixed argument order at `compas.geometry.cone.circle`.
 * Pinned `jsonschema` version to >=4.17, <4.18 to avoid Rust toolchain
+* Fixed `box_to_compas` in `compas_rhino.conversions` to correctly take in the center of the box as the center point of the frame.
 
 ### Removed
 

--- a/src/compas_rhino/conversions/shapes.py
+++ b/src/compas_rhino/conversions/shapes.py
@@ -216,9 +216,7 @@ def box_to_compas(box):
     ysize = box.Y.Length
     zsize = box.Z.Length
     frame = plane_to_compas_frame(box.Plane)
-    frame.point += frame.xaxis * 0.5 * xsize
-    frame.point += frame.yaxis * 0.5 * ysize
-    frame.point += frame.zaxis * 0.5 * zsize
+    frame.point = point_to_compas(box.Center)
     return Box(xsize, ysize, zsize, frame=frame)
 
 


### PR DESCRIPTION
Rhino's box has the center in a separate attribute, not as the origin of the attached frame.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
