### PR TITLE
Remove cython from requirements

### DIFF
--- a/.github/workflows/ironpython.yml
+++ b/.github/workflows/ironpython.yml
@@ -21,7 +21,6 @@ jobs:
       - name: "[RPC tests] Install CPython dependencies"
         run: |
           python -m pip install --upgrade pip
-          pip install cython --config-settings="--build-option=--no-cython-compile"
       - name: "[RPC tests] Install COMPAS on CPython"
         run: |
           pip install --no-cache-dir .

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,2 @@
 tasks:
-  - init: pip3 install cython --install-option="--no-cython-compile" && pip3 install .
+  - init: pip3 install .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed argument order at `compas.geometry.cone.circle`.
 * Pinned `jsonschema` version to >=4.17, <4.18 to avoid Rust toolchain
 * Fixed `box_to_compas` in `compas_rhino.conversions` to correctly take in the center of the box as the center point of the frame.
+* Removed `cython` from requirements.
 
 ### Removed
 

--- a/docs/devguide/workflow.rst
+++ b/docs/devguide/workflow.rst
@@ -12,7 +12,7 @@ To set up a developer environment
 
    .. code-block:: bash
 
-       conda create -n compas-dev python=3.8 cython --yes
+       conda create -n compas-dev python=3.11 --yes
        conda activate compas-dev
 
 3. Install development dependencies:

--- a/docs/userguide/configuration/blender.rst
+++ b/docs/userguide/configuration/blender.rst
@@ -177,7 +177,7 @@ Alternatively, you can create a new environment and simply install entire COMPAS
 
 .. code-block:: bash
 
-    conda create -n blender python=3.9 cython --yes
+    conda create -n blender python=3.9 --yes
     conda activate blender
     pip install compas
     python -m compas_blender.install

--- a/docs/userguide/installation.rst
+++ b/docs/userguide/installation.rst
@@ -61,7 +61,6 @@ Install COMPAS using ``pip`` from the Python Package Index.
 
 .. code-block:: bash
 
-    pip install cython --install-option="--no-cython-compile"
     pip install compas
 
 Install an editable version from local source.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # flake8: noqa
-cython
 imageio <= 2.6; python_version < '3.5'
 imageio >= 2.7; python_version >= '3.5'
 jsonschema >= 4.17, < 4.18


### PR DESCRIPTION
Following up on https://github.com/compas-dev/compas/pull/1191, I am removing `cython` completely from the requirements.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
