### PR TITLE
Release for Alpha.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0-alpha.1
+current_version = 2.0.0-alpha.2
 message = Bump version to {new_version}
 commit = True
 tag = True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+
+## [2.0.0-alpha.2] 2023-11-07
+
+### Added
+
 * Added `Frame.axes`
 * Added `compas.datastructures.TreeNode` and `compas.datastructures.Tree` classes.
 * Added `EllipseArtist` to `compas_rhino` and `compas_ghpython`.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ optional_requirements = {}
 
 setup(
     name="COMPAS",
-    version="2.0.0-alpha.1",
+    version="2.0.0-alpha.2",
     description="The COMPAS framework",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/compas/__init__.py
+++ b/src/compas/__init__.py
@@ -23,7 +23,7 @@ __author__ = "Tom Van Mele and many others (see AUTHORS.md)"
 __copyright__ = "Copyright 2014-2022 - ETH Zurich, Copyright 2023 - COMPAS Association"
 __license__ = "MIT License"
 __email__ = "tom.v.mele@gmail.com"
-__version__ = "2.0.0-alpha.1"
+__version__ = "2.0.0-alpha.2"
 
 version = LooseVersion(compas.__version__)
 versionstring = version.vstring.split("-")[0]

--- a/src/compas_blender/__init__.py
+++ b/src/compas_blender/__init__.py
@@ -35,7 +35,7 @@ def redraw():
     bpy.ops.wm.redraw_timer(type="DRAW_WIN_SWAP", iterations=1)
 
 
-__version__ = "2.0.0-alpha.1"
+__version__ = "2.0.0-alpha.2"
 
 
 def _check_blender_version(version):

--- a/src/compas_ghpython/__init__.py
+++ b/src/compas_ghpython/__init__.py
@@ -20,7 +20,7 @@ import zipfile
 import compas
 import compas_rhino
 
-__version__ = "2.0.0-alpha.1"
+__version__ = "2.0.0-alpha.2"
 
 if compas.is_rhino():
     from .utilities import *  # noqa: F401 F403

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -29,7 +29,7 @@ if compas.is_rhino():
     from .utilities import *  # noqa: F401 F403
 
 
-__version__ = "2.0.0-alpha.1"
+__version__ = "2.0.0-alpha.2"
 
 
 PURGE_ON_DELETE = True


### PR DESCRIPTION
Releasing alpha.2 so that new classes like `compas.brep` is included. We need them to be present for packages like compas_occ to correctly build their latest documentation in github actions. Once this is merged I will create the tag to trigger the release