### PR TITLE
handle colors in SceneObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed plugin selection to fall back to a default implementation if possible.
 * Fixed `AttributeError` `_edges` in `compas_rhino.geometry.RhinoBrepLoop.edges`.
 * Fixed `compas_rhino.geometry.RhinoBrep` serialization.
+* UPDATING `color` SETTINGS IN `SceneObject` ... [TO BE FILLED OUT]
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `compas_rhino.geometry.RhinoBrepLoop.native_loop`.
 * Added `compas_rhino.geometry.RhinoBrepTrim.native_trim`.
 * Added `compas_rhino.geometry.RhinoBrepVertex.native_vertex`.
+* Added `color`, `opacity` attributes to `compas.scene.SceneObject`.
+* Added `pointcolor`, `linecolor`, `surfacecolor`, `pointsize`, `linewidth` attributes to `compas.scene.GeometryObject`.
 
 ### Changed
 
@@ -84,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed plugin selection to fall back to a default implementation if possible.
 * Fixed `AttributeError` `_edges` in `compas_rhino.geometry.RhinoBrepLoop.edges`.
 * Fixed `compas_rhino.geometry.RhinoBrep` serialization.
-* UPDATING `color` SETTINGS IN `SceneObject` ... [TO BE FILLED OUT]
+* Naming convention for `ColorDictAttributes` in `compas.scene.MeshObject`, `compas.scene.NetworkObject` and `compas.scene.VolmeshObject` is changed e.g. from `vertex_color` to `vertexcolor`. 
 
 ### Removed
 

--- a/src/compas/scene/descriptors/color.py
+++ b/src/compas/scene/descriptors/color.py
@@ -12,8 +12,9 @@ class ColorAttribute(object):
 
     """
 
-    def __init__(self, default, **kwargs):
+    def __init__(self, default=None, **kwargs):
         super(ColorAttribute, self).__init__(**kwargs)
+        default = default or Color.black()
         self.default = Color.coerce(default)
 
     def __set_name__(self, owner, name):

--- a/src/compas/scene/descriptors/colordict.py
+++ b/src/compas/scene/descriptors/colordict.py
@@ -54,9 +54,6 @@ class ColorDictAttribute(object):
             A defaultdict with the value stored in the default attribute corresponding to the descriptor as a default value.
 
         """
-        if obj is None:
-            # return the descriptor itself if accessed from the class
-            return self
 
         if not hasattr(obj, self.private_name):
             setattr(obj, self.private_name, None)

--- a/src/compas/scene/descriptors/colordict.py
+++ b/src/compas/scene/descriptors/colordict.py
@@ -54,6 +54,10 @@ class ColorDictAttribute(object):
             A defaultdict with the value stored in the default attribute corresponding to the descriptor as a default value.
 
         """
+        if obj is None:
+            # return the descriptor itself if accessed from the class
+            return self
+
         if not hasattr(obj, self.private_name):
             setattr(obj, self.private_name, None)
 

--- a/src/compas/scene/geometryobject.py
+++ b/src/compas/scene/geometryobject.py
@@ -22,8 +22,6 @@ class GeometryObject(SceneObject):
         The color of the points.
     linecolor : :class:`compas.colors.Color`
         The color of the lines or curves.
-    curvecolor : :class:`compas.colors.Color`
-        The color of the lines or curves.
     surfacecolor : :class:`compas.colors.Color`
         The color of the surfaces.
     pointsize : float
@@ -34,7 +32,7 @@ class GeometryObject(SceneObject):
     """
 
     pointcolor = ColorAttribute()
-    curvecolor = linecolor = ColorAttribute()
+    linecolor = ColorAttribute()
     surfacecolor = ColorAttribute()
 
     def __init__(self, geometry, **kwargs):

--- a/src/compas/scene/geometryobject.py
+++ b/src/compas/scene/geometryobject.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from __future__ import division
 
 from .sceneobject import SceneObject
-from .descriptors.color import ColorAttribute
 
 
 class GeometryObject(SceneObject):
@@ -23,10 +22,6 @@ class GeometryObject(SceneObject):
 
     """
 
-    color = ColorAttribute(default=None)
-
     def __init__(self, geometry, **kwargs):
         super(GeometryObject, self).__init__(item=geometry, **kwargs)
         self.geometry = geometry
-        if "color" in kwargs:
-            self.color = kwargs["color"]

--- a/src/compas/scene/geometryobject.py
+++ b/src/compas/scene/geometryobject.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 from .sceneobject import SceneObject
+from .descriptors.color import ColorAttribute
 
 
 class GeometryObject(SceneObject):
@@ -17,11 +18,30 @@ class GeometryObject(SceneObject):
     ----------
     geometry : :class:`compas.geometry.Geometry`
         The geometry object associated with the scene object.
-    color : :class:`compas.colors.Color`
-        The color of the object.
+    pointcolor : :class:`compas.colors.Color`
+        The color of the points.
+    linecolor : :class:`compas.colors.Color`
+        The color of the lines or curves.
+    curvecolor : :class:`compas.colors.Color`
+        The color of the lines or curves.
+    surfacecolor : :class:`compas.colors.Color`
+        The color of the surfaces.
+    pointsize : float
+        The size of the points.
+    linewidth : float
+        The width of the lines or curves.
 
     """
+
+    pointcolor = ColorAttribute()
+    curvecolor = linecolor = ColorAttribute()
+    surfacecolor = ColorAttribute()
 
     def __init__(self, geometry, **kwargs):
         super(GeometryObject, self).__init__(item=geometry, **kwargs)
         self.geometry = geometry
+        self.pointcolor = kwargs.get("pointcolor", self.color)
+        self.linecolor = kwargs.get("linecolor", self.color)
+        self.surfacecolor = kwargs.get("surfacecolor", self.color)
+        self.pointsize = kwargs.get("pointsize", 1.0)
+        self.linewidth = kwargs.get("linewidth", 1.0)

--- a/src/compas/scene/meshobject.py
+++ b/src/compas/scene/meshobject.py
@@ -6,8 +6,6 @@ from abc import abstractmethod
 
 from compas.geometry import transform_points
 from .sceneobject import SceneObject
-from .descriptors.color import ColorAttribute
-from .descriptors.colordict import ColorDictAttribute
 
 
 class MeshObject(SceneObject):
@@ -27,11 +25,11 @@ class MeshObject(SceneObject):
         Defaults to the real coordinates.
     color : :class:`compas.colors.Color`
         The base RGB color of the mesh.
-    vertex_color : :class:`compas.colors.ColorDict`]
+    vertexcolor : :class:`compas.colors.ColorDict`]
         Vertex colors.
-    edge_color : :class:`compas.colors.ColorDict`
+    edgecolor : :class:`compas.colors.ColorDict`
         Edge colors.
-    face_color : :class:`compas.colors.ColorDict`
+    facecolor : :class:`compas.colors.ColorDict`
         Face colors.
 
     See Also
@@ -41,17 +39,16 @@ class MeshObject(SceneObject):
 
     """
 
-    color = ColorAttribute(default=None)
-
-    vertex_color = ColorDictAttribute(default=None)
-    edge_color = ColorDictAttribute(default=None)
-    face_color = ColorDictAttribute(default=None)
+    vertexcolor = SceneObject.pointcolor
+    edgecolor = SceneObject.linecolor
 
     def __init__(self, mesh, **kwargs):
         super(MeshObject, self).__init__(item=mesh, **kwargs)
         self._mesh = None
         self._vertex_xyz = None
         self.mesh = mesh
+        self.vertexcolor = kwargs.get("vertexcolor", self.vertexcolor)
+        self.edgecolor = kwargs.get("edgecolor", self.edgecolor)
 
     @property
     def mesh(self):

--- a/src/compas/scene/meshobject.py
+++ b/src/compas/scene/meshobject.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 
 from compas.geometry import transform_points
 from .sceneobject import SceneObject
+from .descriptors.colordict import ColorDictAttribute
 
 
 class MeshObject(SceneObject):
@@ -25,7 +26,7 @@ class MeshObject(SceneObject):
         Defaults to the real coordinates.
     color : :class:`compas.colors.Color`
         The base RGB color of the mesh.
-    vertexcolor : :class:`compas.colors.ColorDict`]
+    vertexcolor : :class:`compas.colors.ColorDict`
         Vertex colors.
     edgecolor : :class:`compas.colors.ColorDict`
         Edge colors.
@@ -39,16 +40,20 @@ class MeshObject(SceneObject):
 
     """
 
-    vertexcolor = SceneObject.pointcolor
-    edgecolor = SceneObject.linecolor
+    vertexcolor = ColorDictAttribute()
+    edgecolor = ColorDictAttribute()
+    facecolor = ColorDictAttribute()
 
     def __init__(self, mesh, **kwargs):
         super(MeshObject, self).__init__(item=mesh, **kwargs)
         self._mesh = None
         self._vertex_xyz = None
         self.mesh = mesh
-        self.vertexcolor = kwargs.get("vertexcolor", self.vertexcolor)
-        self.edgecolor = kwargs.get("edgecolor", self.edgecolor)
+        self.vertexcolor = kwargs.get("vertexcolor", self.color)
+        self.edgecolor = kwargs.get("edgecolor", self.color)
+        self.facecolor = kwargs.get("facecolor", self.color)
+        self.vertexsize = kwargs.get("vertexsize", 1.0)
+        self.edgewidth = kwargs.get("edgewidth", 1.0)
 
     @property
     def mesh(self):

--- a/src/compas/scene/networkobject.py
+++ b/src/compas/scene/networkobject.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 
 from compas.geometry import transform_points
 from .sceneobject import SceneObject
+from .descriptors.colordict import ColorDictAttribute
 
 
 class NetworkObject(SceneObject):
@@ -27,6 +28,10 @@ class NetworkObject(SceneObject):
         Mapping between nodes and RGB color values.
     edgecolor : :class:`compas.colors.ColorDict`
         Mapping between edges and colors.
+    nodesize : float
+        The size of the nodes.
+    edgewidth : float
+        The width of the edges.
 
     See Also
     --------
@@ -35,16 +40,18 @@ class NetworkObject(SceneObject):
 
     """
 
-    nodecolor = SceneObject.pointcolor
-    edgecolor = SceneObject.linecolor
+    nodecolor = ColorDictAttribute()
+    edgecolor = ColorDictAttribute()
 
     def __init__(self, network, **kwargs):
         super(NetworkObject, self).__init__(item=network, **kwargs)
         self._network = None
         self._node_xyz = None
         self.network = network
-        self.nodecolor = kwargs.get("nodecolor", self.nodecolor)
-        self.edgecolor = kwargs.get("edgecolor", self.edgecolor)
+        self.nodecolor = kwargs.get("nodecolor", self.color)
+        self.edgecolor = kwargs.get("edgecolor", self.color)
+        self.nodesize = kwargs.get("nodesize", 1.0)
+        self.edgewidth = kwargs.get("edgewidth", 1.0)
 
     @property
     def network(self):

--- a/src/compas/scene/networkobject.py
+++ b/src/compas/scene/networkobject.py
@@ -4,10 +4,8 @@ from __future__ import division
 
 from abc import abstractmethod
 
-from compas.colors import Color
 from compas.geometry import transform_points
 from .sceneobject import SceneObject
-from .descriptors.colordict import ColorDictAttribute
 
 
 class NetworkObject(SceneObject):
@@ -25,9 +23,9 @@ class NetworkObject(SceneObject):
     node_xyz : dict[hashable, list[float]]
         Mapping between nodes and their view coordinates.
         The default view coordinates are the actual coordinates of the nodes of the network.
-    node_color : :class:`compas.colors.ColorDict`
+    nodecolor : :class:`compas.colors.ColorDict`
         Mapping between nodes and RGB color values.
-    edge_color : :class:`compas.colors.ColorDict`
+    edgecolor : :class:`compas.colors.ColorDict`
         Mapping between edges and colors.
 
     See Also
@@ -37,14 +35,16 @@ class NetworkObject(SceneObject):
 
     """
 
-    node_color = ColorDictAttribute(default=Color.white())
-    edge_color = ColorDictAttribute(default=Color.black())
+    nodecolor = SceneObject.pointcolor
+    edgecolor = SceneObject.linecolor
 
     def __init__(self, network, **kwargs):
         super(NetworkObject, self).__init__(item=network, **kwargs)
         self._network = None
         self._node_xyz = None
         self.network = network
+        self.nodecolor = kwargs.get("nodecolor", self.nodecolor)
+        self.edgecolor = kwargs.get("edgecolor", self.edgecolor)
 
     @property
     def network(self):

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from abc import abstractmethod
 from .descriptors.protocol import DescriptorProtocol
+from .descriptors.colordict import ColorDictAttribute
 from .context import clear
 
 
@@ -26,10 +27,23 @@ class SceneObject(object):
     # add this to support the descriptor protocol vor Python versions below 3.6
     __metaclass__ = DescriptorProtocol
 
+    color = ColorDictAttribute()
+    pointcolor = ColorDictAttribute()
+    linecolor = ColorDictAttribute()
+    facecolor = ColorDictAttribute()
+
     def __init__(self, item, **kwargs):
         self._item = item
         self._transformation = None
         self._guids = None
+
+        self.color = kwargs.get("opacity", self.color)
+        self.pointcolor = kwargs.get("pointcolor", self.pointcolor)
+        self.linecolor = kwargs.get("linecolor", self.linecolor)
+        self.facecolor = kwargs.get("facecolor", self.facecolor)
+        self.pointsize = kwargs.get("pointsize", 1.0)
+        self.linewidth = kwargs.get("linewidth", 1.0)
+        self.opacity = kwargs.get("opacity", 1.0)
 
     @property
     def guids(self):

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from abc import abstractmethod
 from .descriptors.protocol import DescriptorProtocol
-from .descriptors.colordict import ColorDictAttribute
+from .descriptors.color import ColorAttribute
 from .context import clear
 
 
@@ -21,28 +21,25 @@ class SceneObject(object):
     ----------
     guids : list[object]
         The GUIDs of the items drawn in the visualization context.
+    transformation : :class:`compas.geometry.Transformation`
+        The transformation matrix of the scene object.
+    color : :class:`compas.colors.Color`
+        The color of the object.
+    opacity : float
+        The opacity of the object.
 
     """
 
     # add this to support the descriptor protocol vor Python versions below 3.6
     __metaclass__ = DescriptorProtocol
 
-    color = ColorDictAttribute()
-    pointcolor = ColorDictAttribute()
-    linecolor = ColorDictAttribute()
-    facecolor = ColorDictAttribute()
+    color = ColorAttribute()
 
     def __init__(self, item, **kwargs):
         self._item = item
         self._transformation = None
         self._guids = None
-
-        self.color = kwargs.get("opacity", self.color)
-        self.pointcolor = kwargs.get("pointcolor", self.pointcolor)
-        self.linecolor = kwargs.get("linecolor", self.linecolor)
-        self.facecolor = kwargs.get("facecolor", self.facecolor)
-        self.pointsize = kwargs.get("pointsize", 1.0)
-        self.linewidth = kwargs.get("linewidth", 1.0)
+        self.color = kwargs.get("color", self.color)
         self.opacity = kwargs.get("opacity", 1.0)
 
     @property
@@ -51,14 +48,6 @@ class SceneObject(object):
 
     @property
     def transformation(self):
-        """The transformation matrix of the scene object.
-
-        Returns
-        -------
-        :class:`Transformation` or None
-            The transformation matrix.
-
-        """
         return self._transformation
 
     @transformation.setter

--- a/src/compas/scene/volmeshobject.py
+++ b/src/compas/scene/volmeshobject.py
@@ -7,7 +7,6 @@ from abc import abstractmethod
 from compas.colors import Color
 from compas.geometry import transform_points
 from .sceneobject import SceneObject
-from .descriptors.color import ColorAttribute
 from .descriptors.colordict import ColorDictAttribute
 
 
@@ -26,16 +25,16 @@ class VolMeshObject(SceneObject):
     vertex_xyz : dict[int, list[float]]
         The view coordinates of the vertices.
         By default, the actual vertex coordinates are used.
-    vertex_color : dict[int, :class:`compas.colors.Color`]
+    vertexcolor : dict[int, :class:`compas.colors.Color`]
         Mapping between vertices and colors.
         Missing vertices get the default vertex color: :attr:`default_vertexcolor`.
-    edge_color : dict[tuple[int, int], :class:`compas.colors.Color`]
+    edgecolor : dict[tuple[int, int], :class:`compas.colors.Color`]
         Mapping between edges and colors.
         Missing edges get the default edge color: :attr:`default_edgecolor`.
-    face_color : dict[int, :class:`compas.colors.Color`]
+    facecolor : dict[int, :class:`compas.colors.Color`]
         Mapping between faces and colors.
         Missing faces get the default face color: :attr:`default_facecolor`.
-    cell_color : dict[int, :class:`compas.colors.Color`]
+    cellcolor : dict[int, :class:`compas.colors.Color`]
         Mapping between cells and colors.
         Missing cells get the default cell color: :attr:`default_facecolor`.
 
@@ -46,18 +45,18 @@ class VolMeshObject(SceneObject):
 
     """
 
-    color = ColorAttribute(default=Color.grey().lightened(50))
-
-    vertex_color = ColorDictAttribute(default=Color.white())
-    edge_color = ColorDictAttribute(default=Color.black())
-    face_color = ColorDictAttribute(default=Color.grey().lightened(50))
-    cell_color = ColorDictAttribute(default=Color.grey())
+    vertexcolor = SceneObject.pointcolor
+    edgecolor = SceneObject.linecolor
+    cellcolor = ColorDictAttribute(default=Color.grey())
 
     def __init__(self, volmesh, **kwargs):
         super(VolMeshObject, self).__init__(item=volmesh, **kwargs)
         self._volmesh = None
         self._vertex_xyz = None
         self.volmesh = volmesh
+        self.vertexcolor = kwargs.get("vertexcolor", self.vertexcolor)
+        self.edgecolor = kwargs.get("edgecolor", self.edgecolor)
+        self.facecolor = kwargs.get("facecolor", self.facecolor)
 
     @property
     def volmesh(self):

--- a/src/compas/scene/volmeshobject.py
+++ b/src/compas/scene/volmeshobject.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 from abc import abstractmethod
 
-from compas.colors import Color
 from compas.geometry import transform_points
 from .sceneobject import SceneObject
 from .descriptors.colordict import ColorDictAttribute
@@ -25,18 +24,22 @@ class VolMeshObject(SceneObject):
     vertex_xyz : dict[int, list[float]]
         The view coordinates of the vertices.
         By default, the actual vertex coordinates are used.
-    vertexcolor : dict[int, :class:`compas.colors.Color`]
+    vertexcolor : :class:`compas.colors.ColorDict`
         Mapping between vertices and colors.
         Missing vertices get the default vertex color: :attr:`default_vertexcolor`.
-    edgecolor : dict[tuple[int, int], :class:`compas.colors.Color`]
+    edgecolor : :class:`compas.colors.ColorDict`
         Mapping between edges and colors.
         Missing edges get the default edge color: :attr:`default_edgecolor`.
-    facecolor : dict[int, :class:`compas.colors.Color`]
+    facecolor : :class:`compas.colors.ColorDict`
         Mapping between faces and colors.
         Missing faces get the default face color: :attr:`default_facecolor`.
-    cellcolor : dict[int, :class:`compas.colors.Color`]
+    cellcolor : :class:`compas.colors.ColorDict`
         Mapping between cells and colors.
         Missing cells get the default cell color: :attr:`default_facecolor`.
+    vertexsize : float
+        The size of the vertices.
+    edgewidth : float
+        The width of the edges.
 
     See Also
     --------
@@ -45,18 +48,22 @@ class VolMeshObject(SceneObject):
 
     """
 
-    vertexcolor = SceneObject.pointcolor
-    edgecolor = SceneObject.linecolor
-    cellcolor = ColorDictAttribute(default=Color.grey())
+    vertexcolor = ColorDictAttribute()
+    edgecolor = ColorDictAttribute()
+    facecolor = ColorDictAttribute()
+    cellcolor = ColorDictAttribute()
 
     def __init__(self, volmesh, **kwargs):
         super(VolMeshObject, self).__init__(item=volmesh, **kwargs)
         self._volmesh = None
         self._vertex_xyz = None
         self.volmesh = volmesh
-        self.vertexcolor = kwargs.get("vertexcolor", self.vertexcolor)
-        self.edgecolor = kwargs.get("edgecolor", self.edgecolor)
-        self.facecolor = kwargs.get("facecolor", self.facecolor)
+        self.vertexcolor = kwargs.get("vertexcolor", self.color)
+        self.edgecolor = kwargs.get("edgecolor", self.color)
+        self.facecolor = kwargs.get("facecolor", self.color)
+        self.cellcolor = kwargs.get("cellcolor", self.color)
+        self.vertexsize = kwargs.get("vertexsize", 1.0)
+        self.edgewidth = kwargs.get("edgewidth", 1.0)
 
     @property
     def volmesh(self):

--- a/src/compas_blender/scene/meshobject.py
+++ b/src/compas_blender/scene/meshobject.py
@@ -147,11 +147,11 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
         """
         objects = []
 
-        self.vertex_color = color
+        self.vertexcolor = color
 
         for vertex in vertices or self.mesh.vertices():  # type: ignore
             name = f"{self.mesh.name}.vertex.{vertex}"  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
             point = self.vertex_xyz[vertex]
 
             # there is no such thing as a sphere data block
@@ -188,11 +188,11 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
         """
         objects = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for u, v in edges or self.mesh.edges():  # type: ignore
             name = f"{self.mesh.name}.edge.{u}-{v}"  # type: ignore
-            color = self.edge_color[u, v]  # type: ignore
+            color = self.edgecolor[u, v]  # type: ignore
             curve = conversions.line_to_blender_curve(Line(self.vertex_xyz[u], self.vertex_xyz[v]))
 
             obj = self.create_object(curve, name=name)
@@ -229,11 +229,11 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
         """
         objects = []
 
-        self.face_color = color
+        self.facecolor = color
 
         for face in faces or self.mesh.faces():  # type: ignore
             name = f"{self.mesh.name}.face.{face}"  # type: ignore
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             points = [self.vertex_xyz[vertex] for vertex in self.mesh.face_vertices(face)]  # type: ignore
             mesh = conversions.polygon_to_blender_mesh(points, name=name)  # type: ignore
 
@@ -365,7 +365,7 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
     #                 "pos": self.vertex_xyz[vertex],
     #                 "name": f"{self.mesh.name}.vertexlabel.{vertex}",
     #                 "text": self.vertex_text[vertex],
-    #                 "color": self.vertex_color[vertex],
+    #                 "color": self.vertexcolor[vertex],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.vertexlabelcollection)
@@ -393,7 +393,7 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
     #                 "pos": centroid_points([self.vertex_xyz[u], self.vertex_xyz[v]]),
     #                 "name": f"{self.mesh.name}.edgelabel.{u}-{v}",
     #                 "text": self.edge_text[edge],
-    #                 "color": self.edge_color[edge],
+    #                 "color": self.edgecolor[edge],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.edgelabelcollection)
@@ -420,7 +420,7 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
     #                 "pos": centroid_points([self.vertex_xyz[vertex] for vertex in self.mesh.face_vertices(face)]),
     #                 "name": "{}.facelabel.{}".format(self.mesh.name, face),
     #                 "text": self.face_text[face],
-    #                 "color": self.face_color[face],
+    #                 "color": self.facecolor[face],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.collection)
@@ -453,11 +453,11 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
         """
         objects = []
 
-        self.vertex_color = color
+        self.vertexcolor = color
 
         for vertex in radius:
             name = "{}.vertex.{}.sphere".format(self.mesh.name, vertex)  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
 
             sphere = Sphere.from_point_and_radius(self.vertex_xyz[vertex], radius[vertex])
             geometry = conversions.sphere_to_blender_mesh(sphere, name=name)
@@ -493,11 +493,11 @@ class MeshObject(BlenderSceneObject, BaseMeshObject):
         """
         objects = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for u, v in radius:
             name = "{}.edge.{}-{}.pipe".format(self.mesh.name, u, v)  # type: ignore
-            color = self.edge_color[u, v]  # type: ignore
+            color = self.edgecolor[u, v]  # type: ignore
 
             line = Line(self.vertex_xyz[u], self.vertex_xyz[v])
             cylinder = Cylinder.from_line_and_radius(line, radius[u, v])  # type: ignore

--- a/src/compas_blender/scene/networkobject.py
+++ b/src/compas_blender/scene/networkobject.py
@@ -140,11 +140,11 @@ class NetworkObject(BlenderSceneObject, BaseSceneObject):
         """
         objects = []
 
-        self.node_color = color
+        self.nodecolor = color
 
         for node in nodes or self.network.nodes():  # type: ignore
             name = f"{self.network.name}.node.{node}"  # type: ignore
-            color = self.node_color[node]  # type: ignore
+            color = self.nodecolor[node]  # type: ignore
             point = self.network.nodes_attributes("xyz")[node]  # type: ignore
 
             # there is no such thing as a sphere data block
@@ -181,11 +181,11 @@ class NetworkObject(BlenderSceneObject, BaseSceneObject):
         """
         objects = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for u, v in edges or self.network.edges():  # type: ignore
             name = f"{self.network.name}.edge.{u}-{v}"  # type: ignore
-            color = self.edge_color[u, v]  # type: ignore
+            color = self.edgecolor[u, v]  # type: ignore
             curve = conversions.line_to_blender_curve(
                 Line(self.network.nodes_attributes("xyz")[u], self.network.nodes_attributes("xyz")[v])
             )
@@ -222,7 +222,7 @@ class NetworkObject(BlenderSceneObject, BaseSceneObject):
     #                 "pos": self.network.nodes_attributes("xyz")[node],
     #                 "name": f"{self.network.name}.nodelabel.{node}",
     #                 "text": self.node_text[node],
-    #                 "color": self.node_color[node],
+    #                 "color": self.nodecolor[node],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.nodelabelcollection)
@@ -250,7 +250,7 @@ class NetworkObject(BlenderSceneObject, BaseSceneObject):
     #                 "pos": centroid_points([self.network.nodes_attributes("xyz")[u], self.network.nodes_attributes("xyz")[v]]),
     #                 "name": f"{self.network.name}.edgelabel.{u}-{v}",
     #                 "text": self.edge_text[edge],
-    #                 "color": self.edge_color[edge],
+    #                 "color": self.edgecolor[edge],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.edgelabelcollection)

--- a/src/compas_blender/scene/volmeshobject.py
+++ b/src/compas_blender/scene/volmeshobject.py
@@ -150,11 +150,11 @@ class VolMeshObject(BlenderSceneObject, BaseVolMeshObject):
         """
         objects = []
 
-        self.vertex_color = color
+        self.vertexcolor = color
 
         for vertex in vertices or self.volmesh.vertices():  # type: ignore
             name = f"{self.volmesh.name}.vertex.{vertex}"  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
             point = self.volmesh.vertices_attributes("xyz")[vertex]
 
             # there is no such thing as a sphere data block
@@ -191,11 +191,11 @@ class VolMeshObject(BlenderSceneObject, BaseVolMeshObject):
         """
         objects = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for u, v in edges or self.volmesh.edges():  # type: ignore
             name = f"{self.volmesh.name}.edge.{u}-{v}"  # type: ignore
-            color = self.edge_color[u, v]  # type: ignore
+            color = self.edgecolor[u, v]  # type: ignore
             curve = conversions.line_to_blender_curve(
                 Line(self.volmesh.vertices_attributes("xyz")[u], self.volmesh.vertices_attributes("xyz")[v])
             )
@@ -234,11 +234,11 @@ class VolMeshObject(BlenderSceneObject, BaseVolMeshObject):
         """
         objects = []
 
-        self.face_color = color
+        self.facecolor = color
 
         for face in faces or self.volmesh.faces():  # type: ignore
             name = f"{self.volmesh.name}.face.{face}"  # type: ignore
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             points = [self.volmesh.vertices_attributes("xyz")[vertex] for vertex in self.volmesh.face_vertices(face)]  # type: ignore
             mesh = conversions.polygon_to_blender_mesh(points, name=name)  # type: ignore
 
@@ -276,11 +276,11 @@ class VolMeshObject(BlenderSceneObject, BaseVolMeshObject):
         """
         objects = []
 
-        self.cell_color = color
+        self.cellcolor = color
 
         for cell in cells or self.volmesh.cells():  # type: ignore
             name = f"{self.volmesh.name}.cell.{cell}"  # type: ignore
-            color = self.cell_color[cell]  # type: ignore
+            color = self.cellcolor[cell]  # type: ignore
 
             vertices = self.volmesh.cell_vertices(cell)  # type: ignore
             faces = self.volmesh.cell_faces(cell)  # type: ignore
@@ -420,7 +420,7 @@ class VolMeshObject(BlenderSceneObject, BaseVolMeshObject):
     #                 "pos": self.volmesh.vertices_attributes("xyz")[vertex],
     #                 "name": f"{self.volmesh.name}.vertexlabel.{vertex}",
     #                 "text": self.vertex_text[vertex],
-    #                 "color": self.vertex_color[vertex],
+    #                 "color": self.vertexcolor[vertex],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.vertexlabelcollection)
@@ -448,7 +448,7 @@ class VolMeshObject(BlenderSceneObject, BaseVolMeshObject):
     #                 "pos": centroid_points([self.volmesh.vertices_attributes("xyz")[u], self.volmesh.vertices_attributes("xyz")[v]]),
     #                 "name": f"{self.volmesh.name}.edgelabel.{u}-{v}",
     #                 "text": self.edge_text[edge],
-    #                 "color": self.edge_color[edge],
+    #                 "color": self.edgecolor[edge],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.edgelabelcollection)
@@ -475,7 +475,7 @@ class VolMeshObject(BlenderSceneObject, BaseVolMeshObject):
     #                 "pos": centroid_points([self.volmesh.vertices_attributes("xyz")[vertex] for vertex in self.volmesh.face_vertices(face)]),
     #                 "name": "{}.facelabel.{}".format(self.volmesh.name, face),
     #                 "text": self.face_text[face],
-    #                 "color": self.face_color[face],
+    #                 "color": self.facecolor[face],
     #             }
     #         )
     #     return compas_blender.draw_texts(labels, collection=self.collection)

--- a/src/compas_ghpython/scene/meshobject.py
+++ b/src/compas_ghpython/scene/meshobject.py
@@ -125,12 +125,12 @@ class MeshObject(GHSceneObject, BaseMeshObject):
         """
         faces = faces or self.mesh.faces()  # type: ignore
 
-        self.face_color = color
+        self.facecolor = color
 
         meshes = []
 
         for face in faces:
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             vertices = [self.vertex_xyz[vertex] for vertex in self.mesh.face_vertices(face)]  # type: ignore
             facet = ngon(len(vertices))
             if facet:

--- a/src/compas_ghpython/scene/volmeshobject.py
+++ b/src/compas_ghpython/scene/volmeshobject.py
@@ -106,12 +106,12 @@ class VolMeshObject(GHSceneObject, BaseVolMeshObject):
         """
         faces = faces or self.volmesh.faces()  # type: ignore
 
-        self.face_color = color
+        self.facecolor = color
 
         meshes = []
 
         for face in faces:
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             vertices = [self.vertex_xyz[vertex] for vertex in self.volmesh.face_vertices(face)]  # type: ignore
             facet = ngon(len(vertices))
             if facet:
@@ -135,12 +135,12 @@ class VolMeshObject(GHSceneObject, BaseVolMeshObject):
         list[:rhino:`Rhino.Geometry.Mesh`]
 
         """
-        self.cell_color = color
+        self.cellcolor = color
 
         meshes = []
 
         for cell in cells or self.volmesh.cells():  # type: ignore
-            color = self.cell_color[cell]  # type: ignore
+            color = self.cellcolor[cell]  # type: ignore
 
             vertices = self.volmesh.cell_vertices(cell)  # type: ignore
             faces = self.volmesh.cell_faces(cell)  # type: ignore

--- a/src/compas_rhino/scene/meshobject.py
+++ b/src/compas_rhino/scene/meshobject.py
@@ -213,11 +213,11 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
         """
         guids = []
 
-        self.vertex_color = color
+        self.vertexcolor = color
 
         for vertex in vertices or self.mesh.vertices():  # type: ignore
             name = "{}.vertex.{}".format(self.mesh.name, vertex)  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             point = point_to_rhino(self.vertex_xyz[vertex])
@@ -255,11 +255,11 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
         """
         guids = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for edge in edges or self.mesh.edges():  # type: ignore
             name = "{}.edge.{}-{}".format(self.mesh.name, *edge)  # type: ignore
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             line = Line(self.vertex_xyz[edge[0]], self.vertex_xyz[edge[1]])
@@ -297,11 +297,11 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
         """
         guids = []
 
-        self.face_color = color
+        self.facecolor = color
 
         for face in faces or self.mesh.faces():  # type: ignore
             name = "{}.face.{}".format(self.mesh.name, face)  # type: ignore
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             vertices = [self.vertex_xyz[vertex] for vertex in self.mesh.face_vertices(face)]  # type: ignore
@@ -344,11 +344,11 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
         """
         guids = []
 
-        self.vertex_color = color
+        self.vertexcolor = color
 
         for vertex in text:
             name = "{}.vertex.{}.label".format(self.mesh.name, vertex)  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             point = point_to_rhino(self.vertex_xyz[vertex])
@@ -389,11 +389,11 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
         """
         guids = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for edge in text:
             name = "{}.edge.{}-{}".format(self.mesh.name, *edge)  # type: ignore
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             attr = attributes(name="{}.label".format(name), color=color, layer=self.layer)
 
             line = Line(self.vertex_xyz[edge[0]], self.vertex_xyz[edge[1]])
@@ -437,7 +437,7 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
 
         for face in text:
             name = "{}.face.{}.label".format(self.mesh.name, face)  # type: ignore
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             points = [self.vertex_xyz[vertex] for vertex in self.mesh.face_vertices(face)]  # type: ignore
@@ -563,11 +563,11 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
         """
         guids = []
 
-        self.vertex_color = color
+        self.vertexcolor = color
 
         for vertex in radius:
             name = "{}.vertex.{}.sphere".format(self.mesh.name, vertex)  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             sphere = Sphere.from_point_and_radius(self.vertex_xyz[vertex], radius[vertex])
@@ -601,11 +601,11 @@ class MeshObject(RhinoSceneObject, BaseMeshObject):
         """
         guids = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for edge in radius:
             name = "{}.edge.{}-{}.pipe".format(self.mesh.name, *edge)  # type: ignore
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             line = Line(self.vertex_xyz[edge[0]], self.vertex_xyz[edge[1]])

--- a/src/compas_rhino/scene/networkobject.py
+++ b/src/compas_rhino/scene/networkobject.py
@@ -127,11 +127,11 @@ class NetworkObject(RhinoSceneObject, BaseNetworkObject):
         """
         guids = []
 
-        self.node_color = color
+        self.nodecolor = color
 
         for node in nodes or self.network.nodes():  # type: ignore
             name = "{}.node.{}".format(self.network.name, node)  # type: ignore
-            attr = attributes(name=name, color=self.node_color[node], layer=self.layer)  # type: ignore
+            attr = attributes(name=name, color=self.nodecolor[node], layer=self.layer)  # type: ignore
 
             point = point_to_rhino(self.node_xyz[node])
 
@@ -167,12 +167,12 @@ class NetworkObject(RhinoSceneObject, BaseNetworkObject):
         guids = []
 
         arrow = "end" if show_direction else None
-        self.edge_color = color
+        self.edgecolor = color
 
         for edge in edges or self.network.edges():  # type: ignore
             u, v = edge
 
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             name = "{}.edge.{}-{}".format(self.network.name, u, v)  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer, arrow=arrow)  # type: ignore
 
@@ -214,11 +214,11 @@ class NetworkObject(RhinoSceneObject, BaseNetworkObject):
         """
         guids = []
 
-        self.node_color = color
+        self.nodecolor = color
 
         for node in text:
             name = "{}.node.{}.label".format(self.network.name, node)  # type: ignore
-            attr = attributes(name=name, color=self.node_color[node], layer=self.layer)  # type: ignore
+            attr = attributes(name=name, color=self.nodecolor[node], layer=self.layer)  # type: ignore
 
             point = point_to_rhino(self.node_xyz[node])
 
@@ -258,12 +258,12 @@ class NetworkObject(RhinoSceneObject, BaseNetworkObject):
         """
         guids = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for edge in text:
             u, v = edge
 
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             name = "{}.edge.{}-{}.label".format(self.network.name, u, v)  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
@@ -306,11 +306,11 @@ class NetworkObject(RhinoSceneObject, BaseNetworkObject):
         """
         guids = []
 
-        self.node_color = color
+        self.nodecolor = color
 
         for node in radius:
             name = "{}.node.{}.sphere".format(self.network.name, node)  # type: ignore
-            color = self.node_color[node]  # type: ignore
+            color = self.nodecolor[node]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             sphere = Sphere.from_point_and_radius(self.node_xyz[node], radius[node])
@@ -344,11 +344,11 @@ class NetworkObject(RhinoSceneObject, BaseNetworkObject):
         """
         guids = []
 
-        self.edge_color = color
+        self.edgecolor = color
 
         for edge in radius:
             name = "{}.edge.{}-{}.pipe".format(self.network.name, *edge)  # type: ignore
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             line = Line(self.node_xyz[edge[0]], self.node_xyz[edge[1]])

--- a/src/compas_rhino/scene/volmeshobject.py
+++ b/src/compas_rhino/scene/volmeshobject.py
@@ -169,13 +169,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             The GUIDs of the created Rhino point objects.
 
         """
-        self.vertex_color = color
+        self.vertexcolor = color
 
         guids = []
 
         for vertex in vertices or self.volmesh.vertices():  # type: ignore
             name = "{}.vertex.{}".format(self.volmesh.name, vertex)  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             point = self.vertex_xyz[vertex]
@@ -204,13 +204,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             The GUIDs of the created Rhino line objects.
 
         """
-        self.edge_color = color
+        self.edgecolor = color
 
         guids = []
 
         for edge in edges or self.volmesh.edges():  # type: ignore
             name = "{}.edge.{}-{}".format(self.volmesh.name, *edge)  # type: ignore
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             line = Line(self.vertex_xyz[edge[0]], self.vertex_xyz[edge[1]])
@@ -242,13 +242,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             The GUIDs of the created Rhino objects.
 
         """
-        self.face_color = color
+        self.facecolor = color
 
         guids = []
 
         for face in faces or self.volmesh.faces():  # type: ignore
             name = "{}.face.{}".format(self.volmesh.name, face)  # type: ignore
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             vertices = [self.vertex_xyz[vertex] for vertex in self.volmesh.face_vertices(face)]  # type: ignore
@@ -283,13 +283,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             Every cell is drawn as an individual mesh.
 
         """
-        self.cell_color = color
+        self.cellcolor = color
 
         guids = []
 
         for cell in cells or self.volmesh.cells():  # type: ignore
             name = "{}.cell.{}".format(self.volmesh.name, cell)  # type: ignore
-            color = self.cell_color[cell]  # type: ignore
+            color = self.cellcolor[cell]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             vertices = self.volmesh.cell_vertices(cell)  # type: ignore
@@ -329,13 +329,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             The GUIDs of the created Rhino objects.
 
         """
-        self.vertex_color = color
+        self.vertexcolor = color
 
         guids = []
 
         for vertex in text:
             name = "{}.vertex.{}.label".format(self.volmesh.name, vertex)  # type: ignore
-            color = self.vertex_color[vertex]  # type: ignore
+            color = self.vertexcolor[vertex]  # type: ignore
             attr = attributes(name=name, color=color, layer=self.layer)
 
             point = self.vertex_xyz[vertex]
@@ -374,13 +374,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             The GUIDs of the created Rhino objects.
 
         """
-        self.edge_color = color
+        self.edgecolor = color
 
         guids = []
 
         for edge in text:
             name = "{}.edge.{}-{}.label".format(self.volmesh.name, *edge)  # type: ignore
-            color = self.edge_color[edge]  # type: ignore
+            color = self.edgecolor[edge]  # type: ignore
             attr = attributes(name="{}.label".format(name), color=color, layer=self.layer)
 
             line = Line(self.vertex_xyz[edge[0]], self.vertex_xyz[edge[1]])
@@ -420,13 +420,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             The GUIDs of the created Rhino objects.
 
         """
-        self.face_color = color
+        self.facecolor = color
 
         guids = []
 
         for face in text:
             name = "{}.face.{}.label".format(self.volmesh.name, face)  # type: ignore
-            color = self.face_color[face]  # type: ignore
+            color = self.facecolor[face]  # type: ignore
             attr = attributes(name="{}.label".format(name), color=color, layer=self.layer)
 
             vertices = [self.vertex_xyz[vertex] for vertex in self.volmesh.face_vertices(face)]  # type: ignore
@@ -466,13 +466,13 @@ class VolMeshObject(RhinoSceneObject, BaseVolMeshObject):
             The GUIDs of the created Rhino objects.
 
         """
-        self.cell_color = color
+        self.cellcolor = color
 
         guids = []
 
         for cell in text:
             name = "{}.cell.{}.label".format(self.volmesh.name, cell)  # type: ignore
-            color = self.cell_color[cell]  # type: ignore
+            color = self.cellcolor[cell]  # type: ignore
             attr = attributes(name="{}.label".format(name), color=color, layer=self.layer)
 
             vertices = [self.vertex_xyz[vertex] for vertex in self.volmesh.cell_vertices(cell)]  # type: ignore


### PR DESCRIPTION
@tomvanmele 

1. Adding generic vis attributes to scene object:
- `color`, `pointcolor`, `linecolor`, `facecolor` as descriptors.
- `linewidth`, `pointsize`, `opacity` as simple attribute.

2. For `MeshObject` and `Networkobject`:
- Use `vertexcolor=SceneObject.pointcolor` and `nodecolor=SceneObject.pointcolor` to read from and write to shared descriptors.

3. Naming convention, should it be `pointcolor` or `point_color`??