### PR TITLE
adding back SceneObject.__new___

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed plugin selection to fall back to a default implementation if possible.
 * Fixed `AttributeError` `_edges` in `compas_rhino.geometry.RhinoBrepLoop.edges`.
 * Fixed `compas_rhino.geometry.RhinoBrep` serialization.
+* The building of correct type of `SceneObject` is moved backed to `__new__` of `SceneObject` itself.
 
 ### Removed
 

--- a/src/compas/scene/__init__.py
+++ b/src/compas/scene/__init__.py
@@ -19,7 +19,7 @@ from .volmeshobject import VolMeshObject
 from .context import clear
 from .context import redraw
 from .context import register_scene_objects
-from .context import build_scene_object
+from .context import get_sceneobject_cls
 from .context import register
 
 from .scene import Scene
@@ -36,6 +36,6 @@ __all__ = [
     "clear",
     "redraw",
     "register_scene_objects",
-    "build_scene_object",
+    "get_sceneobject_cls",
     "register",
 ]

--- a/src/compas/scene/context.py
+++ b/src/compas/scene/context.py
@@ -125,7 +125,7 @@ def _get_sceneobject_cls(data, **kwargs):
     return cls
 
 
-def build_scene_object(item, **kwargs):
+def get_sceneobject_cls(item, **kwargs):
     if not ITEM_SCENEOBJECT:
         register_scene_objects()
 
@@ -136,4 +136,4 @@ def build_scene_object(item, **kwargs):
 
     cls = _get_sceneobject_cls(item, **kwargs)
     PluginValidator.ensure_implementations(cls)
-    return cls(item, **kwargs)
+    return cls

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -1,7 +1,7 @@
 from compas.data import Data
 from compas.datastructures import Tree
 from compas.datastructures import TreeNode
-from .context import build_scene_object
+from .sceneobject import SceneObject
 from .context import redraw
 from .context import clear
 
@@ -23,7 +23,7 @@ class Scene(Data):
         return [node.attributes["sceneobject"] for node in self.tree.nodes if "sceneobject" in node.attributes]
 
     def add(self, item, parent=None, **kwargs):
-        sceneobject = build_scene_object(item, context=self.context, **kwargs)
+        sceneobject = SceneObject(item, context=self.context, **kwargs)
         name = item.name or item.__class__.__name__
         node = TreeNode(name, attributes={"sceneobject": sceneobject})
 

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from abc import abstractmethod
 from .descriptors.protocol import DescriptorProtocol
 from .context import clear
+from .context import get_sceneobject_cls
 
 
 class SceneObject(object):
@@ -25,6 +26,10 @@ class SceneObject(object):
 
     # add this to support the descriptor protocol vor Python versions below 3.6
     __metaclass__ = DescriptorProtocol
+
+    def __new__(cls, item, **kwargs):
+        cls = get_sceneobject_cls(item, **kwargs)
+        return super(SceneObject, cls).__new__(cls)
 
     def __init__(self, item, **kwargs):
         self._item = item

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -28,8 +28,8 @@ class SceneObject(object):
     __metaclass__ = DescriptorProtocol
 
     def __new__(cls, item, **kwargs):
-        cls = get_sceneobject_cls(item, **kwargs)
-        return super(SceneObject, cls).__new__(cls)
+        sceneobject_cls = get_sceneobject_cls(item, **kwargs)
+        return super(SceneObject, cls).__new__(sceneobject_cls)
 
     def __init__(self, item, **kwargs):
         self._item = item

--- a/tests/compas/scene/test_scene.py
+++ b/tests/compas/scene/test_scene.py
@@ -3,7 +3,6 @@ import pytest  # noqa: F401
 import compas
 from compas.scene import context
 from compas.scene import register
-from compas.scene import build_scene_object
 from compas.scene import SceneObject
 from compas.scene import NoSceneObjectContextError
 
@@ -50,11 +49,11 @@ def test_get_sceneobject_cls_with_orderly_registration():
     register(FakeItem, FakeSceneObject, context="fake")
     register(FakeSubItem, FakeSubSceneObject, context="fake")
     item = FakeItem()
-    sceneobject = build_scene_object(item, context="fake")
+    sceneobject = SceneObject(item, context="fake")
     assert isinstance(sceneobject, FakeSceneObject)
 
     item = FakeSubItem()
-    sceneobject = build_scene_object(item, context="fake")
+    sceneobject = SceneObject(item, context="fake")
     assert isinstance(sceneobject, FakeSubSceneObject)
 
 
@@ -62,11 +61,11 @@ def test_get_sceneobject_cls_with_out_of_order_registration():
     register(FakeSubItem, FakeSubSceneObject, context="fake")
     register(FakeItem, FakeSceneObject, context="fake")
     item = FakeItem()
-    sceneobject = build_scene_object(item, context="fake")
+    sceneobject = SceneObject(item, context="fake")
     assert isinstance(sceneobject, FakeSceneObject)
 
     item = FakeSubItem()
-    sceneobject = build_scene_object(item, context="fake")
+    sceneobject = SceneObject(item, context="fake")
     assert isinstance(sceneobject, FakeSubSceneObject)
 
 
@@ -76,7 +75,7 @@ if not compas.IPY:
         register_fake_context()
 
         item = FakeItem()
-        sceneobject = build_scene_object(item)
+        sceneobject = SceneObject(item)
 
         assert isinstance(sceneobject, FakeSceneObject)
 
@@ -85,7 +84,7 @@ if not compas.IPY:
         context.ITEM_SCENEOBJECT["Viewer"] = {FakeItem: FakeSceneObject}
 
         item = FakeSubItem()
-        sceneobject = build_scene_object(item)
+        sceneobject = SceneObject(item)
 
         assert isinstance(sceneobject, FakeSceneObject)
 
@@ -102,7 +101,7 @@ if not compas.IPY:
         context.ITEM_SCENEOBJECT["Plotter"] = {FakeItem: FakePlotterSceneObject}
 
         item = FakeSubItem()
-        sceneobject = build_scene_object(item)
+        sceneobject = SceneObject(item)
 
         assert isinstance(sceneobject, FakeViewerSceneObject)
 
@@ -113,4 +112,4 @@ if not compas.IPY:
 
         with pytest.raises(NoSceneObjectContextError):
             item = FakeSubItem()
-            _ = build_scene_object(item)
+            _ = SceneObject(item)


### PR DESCRIPTION
Alterative option for #1230 , we move back the responsibility of building correct scene object to the `SceneObject.__new__`. 