### PR TITLE
Single float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed the `__str__` of `compas.geometry.Point` and `compas.geometry.Vector` to use a limited number of decimals (determined by `Tolerance.PRECISION`). Note: `__repr__` will instead maintain full precision.
 * In pull requests, `docs` Workflow are now only triggered on review approval.
 * The `draw` implementations of `compas.scene.SceneObject` will now always use the `worldtransformation` of the `SceneObject`.
+* Fixed `TypeErrorException` when serializing a `Mesh` which has been converted from Rhino.
+* Fixed color conversions in `compas_rhion.conversions.mesh_to_compas`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed the `__str__` of `compas.geometry.Point` and `compas.geometry.Vector` to use a limited number of decimals (determined by `Tolerance.PRECISION`). Note: `__repr__` will instead maintain full precision.
 * In pull requests, `docs` Workflow are now only triggered on review approval.
 * The `draw` implementations of `compas.scene.SceneObject` will now always use the `worldtransformation` of the `SceneObject`.
+* Fixed typo in name `Rhino.Geometry.MeshingParameters` in `compas_rhino.geometry.RhinoBrep.to_meshes()`.
 * Fixed `TypeErrorException` when serializing a `Mesh` which has been converted from Rhino.
 * Fixed color conversions in `compas_rhion.conversions.mesh_to_compas`.
 
@@ -142,7 +143,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas_blender.install` to use symlinks.
 * Moved `URDF` parsing from `compas.files` to the `compas_robots` extension (`compas_robots.files.URDF`).
 * Changed signature of `compas.geometry.Brep.slice()`
-* Fixed typo in name `Rhino.Geometry.MeshingParameters` in `compas_rhino.geometry.RhinoBrep.to_meshes()`.
 
 ### Removed
 

--- a/src/compas/data/encoders.py
+++ b/src/compas/data/encoders.py
@@ -151,7 +151,7 @@ class DataEncoder(json.JSONEncoder):
                 return None
 
         if dotnet_support:
-            if isinstance(o, System.Decimal):
+            if isinstance(o, (System.Decimal, System.Double, System.Single)):
                 return float(o)
 
         return super(DataEncoder, self).default(o)

--- a/src/compas_rhino/conversions/meshes.py
+++ b/src/compas_rhino/conversions/meshes.py
@@ -261,9 +261,9 @@ def mesh_to_compas(rhinomesh, cls=None):
 
     for vertex, normal, color in zip(rhinomesh.Vertices, rhinomesh.Normals, vertexcolors):
         mesh.add_vertex(
-            x=vertex.X,
-            y=vertex.Y,
-            z=vertex.Z,
+            x=float(vertex.X),
+            y=float(vertex.Y),
+            z=float(vertex.Z),
             normal=vector_to_compas(normal),
             color=Color(color.R, color.G, color.B) if color else None,
         )

--- a/src/compas_rhino/conversions/meshes.py
+++ b/src/compas_rhino/conversions/meshes.py
@@ -265,7 +265,7 @@ def mesh_to_compas(rhinomesh, cls=None):
             y=float(vertex.Y),
             z=float(vertex.Z),
             normal=vector_to_compas(normal),
-            color=Color(color.R, color.G, color.B) if color else None,
+            color=Color.from_rgb255(int(color.R), int(color.G), int(color.B)) if color else None,
         )
 
     facenormals = rhinomesh.FaceNormals


### PR DESCRIPTION
Fixes `Runtime error (TypeErrorException): 1.73519 is not JSON serializable` when attempting to serialize a mesh that has been previously converted from Rhino.

The issue was that C# types (namely `Single`) where directly set in the newly created COMPAS `Mesh` they were stored there peacefully until it was time to serialize.

I also added conversions from `Single` and `Double` in the encoder, similarly to `Decimal` which was already there. Though I'm not sure about this part since I guess we should make sure COMPAS stuff holds only python native types.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
