### PR TITLE
fixed brep doesn't get capped after trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Merged `compas.datastructures.Halfedge` into `compas.datastructures.Mesh`.
 * Merged `compas.datastructures.Network` into `compas.datastructures.Graph`.
 * Merged `compas.datastructures.Halfface` into `compas.datastructures.VolMesh`.
+* Fixed `RhinoBrep` doesn't get capped after trimming.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -379,7 +379,9 @@ class RhinoBrep(Brep):
 
         breps = []
         for result in results:
-            result.CapPlanarHoles(TOLERANCE)
+            capped = result.CapPlanarHoles(TOLERANCE)
+            if capped:
+                result = capped
             breps.append(RhinoBrep.from_native(result))
         return breps
 


### PR DESCRIPTION
Fixes https://github.com/gramaziokohler/compas_timber/issues/173.

`RhinoBrep` doesn't get capped after trimming. Issue was introduced after the last rework and was `CapPlanarHoles` does not work in-place.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
