### PR TITLE
BUG FIX triangulation_earclip for reversed polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas.data.Data.data` to `compas.data.Data.__data__`.
 * Changed `compas.data.Data.dtype` to `compas.data.Data.__dtype__`.
 * Changed `compas.data.Data.from_data` to `compas.data.Data.__from_data__`.
+* Changed `compas.geometry.triangulation_earclip` face vertex index reversion when the polygon is flipped.
 
 ### Removed
 

--- a/src/compas/geometry/triangulation_earclip.py
+++ b/src/compas/geometry/triangulation_earclip.py
@@ -290,4 +290,11 @@ def earclip_polygon(polygon):
 
     # Run the Earcut algorithm.
     ear_cut = Earcut(points)
-    return ear_cut.triangulate()
+    triangles = ear_cut.triangulate()
+
+    # Reverse the triangles to match the original polygon winding.
+    if sum_val > 0.0:
+        n = len(points)-1
+        for i in range(len(triangles)):
+            triangles[i] = [abs(triangles[i][j % 3]-n) for j in range(3)]
+    return triangles

--- a/src/compas/geometry/triangulation_earclip.py
+++ b/src/compas/geometry/triangulation_earclip.py
@@ -294,7 +294,7 @@ def earclip_polygon(polygon):
 
     # Reverse the triangles to match the original polygon winding.
     if sum_val > 0.0:
-        n = len(points)-1
+        n = len(points) - 1
         for i in range(len(triangles)):
-            triangles[i] = [abs(triangles[i][j % 3]-n) for j in range(3)]
+            triangles[i] = [abs(triangles[i][j % 3] - n) for j in range(3)]
     return triangles

--- a/tests/compas/geometry/test_triangulation_earclip.py
+++ b/tests/compas/geometry/test_triangulation_earclip.py
@@ -1,5 +1,6 @@
 import pytest
-import compas.geometry
+from compas.geometry import Polygon
+from compas.geometry.triangulation_earclip import earclip_polygon
 
 
 def test_earclip_polygon_triangle():
@@ -9,8 +10,8 @@ def test_earclip_polygon_triangle():
         [1, 1, 0],
     ]
 
-    polygon = compas.geometry.Polygon(points)
-    faces = compas.geometry.earclip_polygon(polygon)
+    polygon = Polygon(points)
+    faces = earclip_polygon(polygon)
     assert faces == [[0, 1, 2]]
 
 
@@ -22,8 +23,8 @@ def test_earclip_polygon_square():
         [0, 1, 0],
     ]
 
-    polygon = compas.geometry.Polygon(points)
-    faces = compas.geometry.earclip_polygon(polygon)
+    polygon = Polygon(points)
+    faces = earclip_polygon(polygon)
     assert faces == [[3, 0, 1], [1, 2, 3]]
 
 
@@ -60,44 +61,44 @@ def test_earclip_polygon_wrong_winding():
         [377.952174, -3452, 1500.484283],
     ]
 
-    polygon = compas.geometry.Polygon(points)
+    polygon = Polygon(points)
     polygon.points.reverse()
 
-    faces = compas.geometry.earclip_polygon(polygon)
+    faces = earclip_polygon(polygon)
 
     assert faces == [
-        [2, 3, 4],
-        [5, 6, 7],
-        [7, 8, 9],
-        [12, 13, 14],
-        [14, 15, 16],
-        [17, 18, 19],
-        [19, 20, 21],
-        [21, 22, 23],
-        [23, 24, 25],
-        [27, 28, 0],
-        [1, 2, 4],
-        [7, 9, 10],
-        [14, 16, 17],
-        [23, 25, 26],
-        [0, 1, 4],
-        [12, 14, 17],
-        [21, 23, 26],
-        [0, 4, 5],
-        [12, 17, 19],
-        [21, 26, 27],
-        [0, 5, 7],
-        [11, 12, 19],
-        [19, 21, 27],
-        [0, 7, 10],
-        [11, 19, 27],
-        [0, 10, 11],
-        [11, 27, 0],
+        [26, 25, 24],
+        [23, 22, 21],
+        [21, 20, 19],
+        [16, 15, 14],
+        [14, 13, 12],
+        [11, 10, 9],
+        [9, 8, 7],
+        [7, 6, 5],
+        [5, 4, 3],
+        [1, 0, 28],
+        [27, 26, 24],
+        [21, 19, 18],
+        [14, 12, 11],
+        [5, 3, 2],
+        [28, 27, 24],
+        [16, 14, 11],
+        [7, 5, 2],
+        [28, 24, 23],
+        [16, 11, 9],
+        [7, 2, 1],
+        [28, 23, 21],
+        [17, 16, 9],
+        [9, 7, 1],
+        [28, 21, 18],
+        [17, 9, 1],
+        [28, 18, 17],
+        [17, 1, 28],
     ]
 
 
 def test_earclip_polygon_coincident_points():
-    self_intersecting_polygon = compas.geometry.Polygon(
+    self_intersecting_polygon = Polygon(
         [
             [-1, -1, 0],
             [-1, 0, 0],
@@ -108,4 +109,24 @@ def test_earclip_polygon_coincident_points():
     )
 
     with pytest.raises(IndexError):
-        compas.geometry.earclip_polygon(self_intersecting_polygon)
+        earclip_polygon(self_intersecting_polygon)
+
+
+def test_earclip_polygon_when_reversed():
+    polygon = Polygon(
+        points=[
+            [0, 0, 0],
+            [5, 0, 0],
+            [5, 5, 0],
+            [10, 5, 0],
+            [10, 15, 0],
+            [0, 10, 0],
+        ]
+    )
+
+    triangles = earclip_polygon(polygon)
+    assert triangles == [[5, 0, 1], [2, 3, 4], [5, 1, 2], [2, 4, 5]]
+
+    polygon.points.reverse()
+    triangles = earclip_polygon(polygon)
+    assert triangles == [[0, 5, 4], [3, 2, 1], [0, 4, 3], [3, 1, 0]]


### PR DESCRIPTION
I found a small bug for my previous pull request for reversed polygons in the triangulation_earclip.py.
The method creates a good triangulation, but one would never know if a polygon is reversed.
Solution to this problem is a reversion of triangle face indices.

I added a test `test_earclip_polygon_when_reversed` for this case, and updated the rest.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
