### PR TITLE
allow non-Data item in SceneObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas.tolerance.Tolerance` into singleton.
 * Changed `compas_rhino.geometry.curves.nursb.RhinoNurbsCurve` to use private data API.
 * Changed `compas_rhino.geometry.surfaces.nursb.RhinoNurbsSurface` to use private data API.
+* Changed `compas.scene.SceneObject` to allow usage of `Data` items.
 
 ### Removed
 

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -68,7 +68,7 @@ class SceneObject(object):
         self._node = None
         self._frame = kwargs.get("frame", None)
         self._transformation = kwargs.get("transformation", None)
-        self.name = kwargs.get("name", item.name or item.__class__.__name__)
+        self.name = kwargs.get("name", getattr(item, "name", item.__class__.__name__))
         self.color = kwargs.get("color", self.color)
         self.opacity = kwargs.get("opacity", 1.0)
         self.show = kwargs.get("show", True)


### PR DESCRIPTION
Dealing with #1273 . 
`SceneObject` was expected to wrap on items that inherent from `Data`, which will always have a `name`.

This should avoid the error, but not sure yet if it will have other unexpected effects 