### PR TITLE
Scene.draw etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas.tolerance.Tolerance` into singleton.
 * Changed `compas_rhino.geometry.curves.nursb.RhinoNurbsCurve` to use private data API.
 * Changed `compas_rhino.geometry.surfaces.nursb.RhinoNurbsSurface` to use private data API.
-* Changed `compas.scene.Scene.redraw` to `draw`, `redraw` is kept as alias.
+* Changed `compas.scene.Scene.redraw` to `draw`.
 * Fixed `register_scene_objects` not called when there is a context given in kwargs of `SceneObject`.
 * Changed `compas.scene.SceneObject` to raise `TypeError` when item is instance of `compas.data.Data`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `compas_rhino.objects`.
 * Added `compas_rhino.layers`.
 * Added `compas_rhino.install_with_pip`.
-* Added `predraw` pluggable to `compas.scene.Scene.draw`.
-* Added `postdraw` pluggable to `compas.scene.Scene.draw`.
+* Added `before_draw` pluggable to `compas.scene.Scene.draw`.
+* Added `after_draw` pluggable to `compas.scene.Scene.draw`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas_rhino.geometry.surfaces.nursb.RhinoNurbsSurface` to use private data API.
 * Changed `compas.scene.Scene.redraw` to `draw`.
 * Fixed `register_scene_objects` not called when there is a context given in kwargs of `SceneObject`.
-* Changed `compas.scene.SceneObject` to raise `TypeError` when item is instance of `compas.data.Data`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `compas_rhino.objects`.
 * Added `compas_rhino.layers`.
 * Added `compas_rhino.install_with_pip`.
+* Added `predraw` pluggable to `compas.scene.Scene.draw`.
+* Added `postdraw` pluggable to `compas.scene.Scene.draw`.
 
 ### Changed
 
 * Changed `compas.tolerance.Tolerance` into singleton.
 * Changed `compas_rhino.geometry.curves.nursb.RhinoNurbsCurve` to use private data API.
 * Changed `compas_rhino.geometry.surfaces.nursb.RhinoNurbsSurface` to use private data API.
+* Changed `compas.scene.Scene.redraw` to `draw`, `redraw` is kept as alias.
+* Fixed `register_scene_objects` not called when there is a context given in kwargs of `SceneObject`.
+* Changed `compas.scene.SceneObject` to raise `TypeError` when item is instance of `compas.data.Data`.
 
 ### Removed
 

--- a/docs/api/compas.scene.rst
+++ b/docs/api/compas.scene.rst
@@ -51,5 +51,6 @@ Pluggables are functions that don't have an actual implementation, but receive a
     :nosignatures:
 
     clear
-    redraw
+    before_draw
+    after_draw
     register_scene_objects

--- a/docs/userguide/basics.visualisation.rst
+++ b/docs/userguide/basics.visualisation.rst
@@ -9,7 +9,7 @@ COMPAS (data) objects can be visualised by placing them into a "scene".
 >>> box = Box(1)
 >>> scene = Scene()
 >>> scene.add(box)
->>> scene.redraw()
+>>> scene.draw()
 
 .. When a COMPAS object is added, the scene automatically creates a corresponding scene object for the current/active visualisation context.
 .. Currently, four visualisation contexts are supported: COMPAS Viewer (default), Rhino, Grasshopper, and Blender.

--- a/docs/userguide/cad.blender.rst
+++ b/docs/userguide/cad.blender.rst
@@ -94,7 +94,7 @@ For more information on visualisation scenes, see :doc:`/userguide/basics.visual
     scene = Scene()
     scene.clear()
     scene.add(mesh)
-    scene.redraw()
+    scene.draw()
 
 
 Conversions

--- a/docs/userguide/cad.grasshopper.rst
+++ b/docs/userguide/cad.grasshopper.rst
@@ -26,7 +26,7 @@ component on your Grasshopper canvas, paste the following script and hit `OK`.
 
     scene = Scene()
     scene.add(mesh)
-    a = scene.redraw()
+    a = scene.draw()
 
 
 .. figure:: /_images/userguide/cad.grasshopper.gh_verify.jpg

--- a/docs/userguide/cad.rhino.rst
+++ b/docs/userguide/cad.rhino.rst
@@ -83,7 +83,7 @@ For more information on visualisation scenes, see :doc:`/userguide/basics.visual
     scene = Scene()
     scene.clear()
     scene.add(mesh)
-    scene.redraw()
+    scene.draw()
 
 
 Conversions

--- a/docs/userguide/cad.rhino8.rst
+++ b/docs/userguide/cad.rhino8.rst
@@ -106,7 +106,7 @@ For more information on visualisation scenes, see :doc:`/userguide/basics.visual
     scene = Scene()
     scene.clear()
     scene.add(mesh)
-    scene.redraw()
+    scene.draw()
 
 
 Conversions

--- a/docs/userguide/firststeps.rst
+++ b/docs/userguide/firststeps.rst
@@ -28,7 +28,7 @@ A Simple Box
 
     scene = Scene()
     scene.add(box)
-    scene.redraw()
+    scene.draw()
 
 
 Points-in-box Test
@@ -51,7 +51,7 @@ Points-in-box Test
     for point in pcl:
         color = Color.red() if box.contains(point) else Color.blue()
         scene.add(point, color=color)
-    scene.redraw()
+    scene.draw()
 
 
 Creating a Mesh From an OBJ File
@@ -67,4 +67,4 @@ Creating a Mesh From an OBJ File
 
     scene = Scene()
     scene.add(mesh)
-    scene.redraw()
+    scene.draw()

--- a/docs/userguide/samples/point_in_box.py
+++ b/docs/userguide/samples/point_in_box.py
@@ -22,4 +22,4 @@ for point in pcl:
         size = 30
     scene.add(point, pointcolor=color, pointsize=size)
 
-scene.redraw()
+scene.draw()

--- a/docs/userguide/scene.py
+++ b/docs/userguide/scene.py
@@ -84,4 +84,4 @@ for obj in scene.objects:
 
 
 scene.print_hierarchy()
-scene.redraw()
+scene.draw()

--- a/src/compas/scene/__init__.py
+++ b/src/compas/scene/__init__.py
@@ -16,7 +16,8 @@ from .geometryobject import GeometryObject
 from .volmeshobject import VolMeshObject
 
 from .context import clear
-from .context import redraw
+from .context import before_draw
+from .context import after_draw
 from .context import register_scene_objects
 from .context import get_sceneobject_cls
 from .context import register
@@ -51,7 +52,8 @@ __all__ = [
     "SceneObjectNode",
     "SceneTree",
     "clear",
-    "redraw",
+    "before_draw",
+    "after_draw",
     "register_scene_objects",
     "get_sceneobject_cls",
     "register",

--- a/src/compas/scene/context.py
+++ b/src/compas/scene/context.py
@@ -31,7 +31,7 @@ clear.__pluggable__ = True
 
 @pluggable(category="drawing-utils")
 def before_draw():
-    """Pluggable to perform operations before drawing the scene.
+    """Pluggable to perform operations before drawing the scene. This function is automatically called in the beginning of `compas.scene.Scene.draw()`.
 
     Returns
     -------
@@ -46,8 +46,7 @@ before_draw.__pluggable__ = True
 
 @pluggable(category="drawing-utils")
 def after_draw(drawn_objects):
-    """Pluggable to perform operations after drawing the scene.
-
+    """Pluggable to perform operations after drawing the scene. This function is automatically called at the end of `compas.scene.Scene.draw()`.
     Parameters
     ----------
     drawn_objects : list

--- a/src/compas/scene/context.py
+++ b/src/compas/scene/context.py
@@ -26,6 +26,22 @@ def redraw():
 redraw.__pluggable__ = True
 
 
+@pluggable(category="drawing-utils")
+def predraw():
+    pass
+
+
+predraw.__pluggable__ = True
+
+
+@pluggable(category="drawing-utils")
+def postdraw():
+    pass
+
+
+postdraw.__pluggable__ = True
+
+
 @pluggable(category="factories", selector="collect_all")
 def register_scene_objects():
     """Registers scene objects available in the current context."""
@@ -123,7 +139,6 @@ def _get_sceneobject_cls(data, **kwargs):
 
 
 def get_sceneobject_cls(item, **kwargs):
-
     if not ITEM_SCENEOBJECT:
         register_scene_objects()
 

--- a/src/compas/scene/context.py
+++ b/src/compas/scene/context.py
@@ -82,9 +82,6 @@ def detect_current_context():
 
     """
 
-    if not ITEM_SCENEOBJECT:
-        register_scene_objects()
-
     if is_viewer_open():
         return "Viewer"
     if compas.is_grasshopper():
@@ -126,6 +123,10 @@ def _get_sceneobject_cls(data, **kwargs):
 
 
 def get_sceneobject_cls(item, **kwargs):
+
+    if not ITEM_SCENEOBJECT:
+        register_scene_objects()
+
     if item is None:
         raise ValueError(
             "Cannot create a scene object for None. Please ensure you pass a instance of a supported class."

--- a/src/compas/scene/context.py
+++ b/src/compas/scene/context.py
@@ -12,6 +12,17 @@ ITEM_SCENEOBJECT = defaultdict(dict)
 
 @pluggable(category="drawing-utils")
 def clear(guids=None):
+    """Pluggable to clear the current context of the scene or a list of objects through guids.
+
+    Parameters
+    ----------
+    guids : list, optional
+        A list of guids to clear.
+
+    Returns
+    -------
+    None
+    """
     raise NotImplementedError
 
 
@@ -19,27 +30,38 @@ clear.__pluggable__ = True
 
 
 @pluggable(category="drawing-utils")
-def redraw():
-    raise NotImplementedError
+def before_draw():
+    """Pluggable to perform operations before drawing the scene.
 
+    Returns
+    -------
+    None
 
-redraw.__pluggable__ = True
-
-
-@pluggable(category="drawing-utils")
-def predraw():
+    """
     pass
 
 
-predraw.__pluggable__ = True
+before_draw.__pluggable__ = True
 
 
 @pluggable(category="drawing-utils")
-def postdraw():
+def after_draw(drawn_objects):
+    """Pluggable to perform operations after drawing the scene.
+
+    Parameters
+    ----------
+    drawn_objects : list
+        A list of objects that were drawn.
+
+    Returns
+    -------
+    None
+
+    """
     pass
 
 
-postdraw.__pluggable__ = True
+after_draw.__pluggable__ = True
 
 
 @pluggable(category="factories", selector="collect_all")

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -3,6 +3,8 @@ from compas.datastructures import Tree
 from compas.datastructures import TreeNode
 
 from .context import clear
+from .context import predraw
+from .context import postdraw
 from .context import redraw
 from .context import detect_current_context
 from .sceneobject import SceneObject
@@ -287,8 +289,10 @@ class Scene(Data):
             sceneobject._guids = None
         clear(guids=guids)
 
-    def redraw(self):
-        """Redraw the scene."""
+    def draw(self):
+        """Draw the scene."""
+
+        predraw()
 
         if not self.context:
             raise ValueError("No context detected.")
@@ -302,7 +306,11 @@ class Scene(Data):
         if drawn_objects:
             redraw()
 
+        postdraw()
+
         return drawn_objects
+
+    redraw = draw
 
     def print_hierarchy(self):
         """Print the hierarchy of the scene."""

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -3,9 +3,8 @@ from compas.datastructures import Tree
 from compas.datastructures import TreeNode
 
 from .context import clear
-from .context import predraw
-from .context import postdraw
-from .context import redraw
+from .context import before_draw
+from .context import after_draw
 from .context import detect_current_context
 from .sceneobject import SceneObject
 
@@ -201,7 +200,7 @@ class Scene(Data):
     >>> scene = Scene()
     >>> box = Box.from_width_height_depth(1, 1, 1)
     >>> scene.add(box)
-    >>> scene.redraw()
+    >>> scene.draw()
 
     """
 
@@ -292,7 +291,7 @@ class Scene(Data):
     def draw(self):
         """Draw the scene."""
 
-        predraw()
+        before_draw()
 
         if not self.context:
             raise ValueError("No context detected.")
@@ -303,14 +302,9 @@ class Scene(Data):
         for sceneobject in self.objects:
             drawn_objects += sceneobject.draw()
 
-        if drawn_objects:
-            redraw()
-
-        postdraw()
+        after_draw(drawn_objects)
 
         return drawn_objects
-
-    redraw = draw
 
     def print_hierarchy(self):
         """Print the hierarchy of the scene."""

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -8,7 +8,6 @@ from .descriptors.color import ColorAttribute
 from .context import clear
 from .context import get_sceneobject_cls
 from compas.geometry import Transformation
-from compas.data import Data
 from functools import reduce
 from operator import mul
 
@@ -60,9 +59,6 @@ class SceneObject(object):
     color = ColorAttribute()
 
     def __new__(cls, item, **kwargs):
-        if not isinstance(item, Data):
-            raise TypeError("SceneObject can only be created for compas.data.Data items.")
-
         sceneobject_cls = get_sceneobject_cls(item, **kwargs)
         return super(SceneObject, cls).__new__(sceneobject_cls)
 

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -8,6 +8,7 @@ from .descriptors.color import ColorAttribute
 from .context import clear
 from .context import get_sceneobject_cls
 from compas.geometry import Transformation
+from compas.data import Data
 from functools import reduce
 from operator import mul
 
@@ -59,6 +60,9 @@ class SceneObject(object):
     color = ColorAttribute()
 
     def __new__(cls, item, **kwargs):
+        if not isinstance(item, Data):
+            raise TypeError("SceneObject can only be created for compas.data.Data items.")
+
         sceneobject_cls = get_sceneobject_cls(item, **kwargs)
         return super(SceneObject, cls).__new__(sceneobject_cls)
 

--- a/src/compas_blender/scene/__init__.py
+++ b/src/compas_blender/scene/__init__.py
@@ -59,8 +59,8 @@ def clear_blender(guids=None):
     compas_blender.clear(guids=guids)
 
 
-@plugin(category="drawing-utils", pluggable_name="redraw", requires=["bpy"])
-def redraw_blender():
+@plugin(category="drawing-utils", pluggable_name="after_draw", requires=["bpy"])
+def after_draw_blender(drawn_objects):
     compas_blender.redraw()
 
 

--- a/src/compas_ghpython/scene/__init__.py
+++ b/src/compas_ghpython/scene/__init__.py
@@ -61,11 +61,6 @@ def clear_GH(guids=None):
     pass
 
 
-@plugin(category="drawing-utils", pluggable_name="redraw", requires=["Grasshopper"])
-def redraw_GH():
-    pass
-
-
 @plugin(category="factories", requires=["Rhino"])
 def register_scene_objects():
     register(Box, BoxObject, context="Grasshopper")

--- a/src/compas_rhino/conversions/surfaces.py
+++ b/src/compas_rhino/conversions/surfaces.py
@@ -205,7 +205,7 @@ def surface_to_compas_mesh(surface, cls=None, facefilter=None, cleanup=False):
 
     >>> scene = Scene()
     >>> scene.add(mesh, layer="Blocks")
-    >>> scene.redraw()
+    >>> scene.draw()
 
     """
     if not surface.HasBrepForm:

--- a/src/compas_rhino/scene/__init__.py
+++ b/src/compas_rhino/scene/__init__.py
@@ -68,8 +68,8 @@ def clear_rhino(guids=None):
     compas_rhino.clear(guids=guids)
 
 
-@plugin(category="drawing-utils", pluggable_name="redraw", requires=["Rhino"])
-def redraw_rhino():
+@plugin(category="drawing-utils", pluggable_name="after_draw", requires=["Rhino"])
+def after_draw_rhino(drawn_objects):
     compas_rhino.redraw()
 
 

--- a/src/compas_rhino/scene/graphobject.py
+++ b/src/compas_rhino/scene/graphobject.py
@@ -45,8 +45,8 @@ class GraphObject(RhinoSceneObject, BaseGraphObject):
         None
 
         """
-        guids = compas_rhino.get_objects(name="{}.*".format(self.graph.name))  # type: ignore
-        compas_rhino.delete_objects(guids, purge=True)
+        guids = compas_rhino.objects.get_objects(name="{}.*".format(self.graph.name))  # type: ignore
+        compas_rhino.objects.delete_objects(guids, purge=True)
 
     def clear_nodes(self):
         """Delete all nodes drawn by this scene object.
@@ -56,8 +56,8 @@ class GraphObject(RhinoSceneObject, BaseGraphObject):
         None
 
         """
-        guids = compas_rhino.get_objects(name="{}.node.*".format(self.graph.name))  # type: ignore
-        compas_rhino.delete_objects(guids, purge=True)
+        guids = compas_rhino.objects.get_objects(name="{}.node.*".format(self.graph.name))  # type: ignore
+        compas_rhino.objects.delete_objects(guids, purge=True)
 
     def clear_edges(self):
         """Delete all edges drawn by this scene object.
@@ -67,8 +67,8 @@ class GraphObject(RhinoSceneObject, BaseGraphObject):
         None
 
         """
-        guids = compas_rhino.get_objects(name="{}.edge.*".format(self.graph.name))  # type: ignore
-        compas_rhino.delete_objects(guids, purge=True)
+        guids = compas_rhino.objects.get_objects(name="{}.edge.*".format(self.graph.name))  # type: ignore
+        compas_rhino.objects.delete_objects(guids, purge=True)
 
     # ==========================================================================
     # draw


### PR DESCRIPTION
@tomvanmele Changes you requested:

- Moved registration to `get_scene_object_cls` so it will always be called.
- Renamed `redraw` to `draw`, and kept it as alias.
- Added pluggables `predraw` and `postdraw`.
- Also raise TypeError if item is not an `Data`, as alternative solution to #1274 .