### PR TITLE
Brep fromextrusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added optional argument `cap_ends` to `Brep.from_extrusion()`.
+* Added implementation in `RhinoBrep.from_extrusion()`.
+
 ### Changed
 
 ### Removed

--- a/src/compas/geometry/brep/brep.py
+++ b/src/compas/geometry/brep/brep.py
@@ -389,7 +389,7 @@ class Brep(Geometry):
         return from_cylinder(cylinder)
 
     @classmethod
-    def from_extrusion(cls, curve, vector):
+    def from_extrusion(cls, curve, vector, cap_ends=True):
         """Construct a Brep by extruding a closed curve along a direction vector.
 
         Parameters
@@ -398,13 +398,15 @@ class Brep(Geometry):
             The curve to extrude
         vector : :class:`compas.geometry.Vector`
             The vector to extrude the curve by
+        cap_ends : bool, optional
+            If True, the plannar ends of the extrusion will be capped, if possible.
 
         Returns
         -------
         :class:`compas.geometry.Brep`
 
         """
-        return from_extrusion(curve, vector)
+        return from_extrusion(curve, vector, cap_ends)
 
     @classmethod
     def from_iges(cls, filename):

--- a/src/compas_rhino/geometry/brep/__init__.py
+++ b/src/compas_rhino/geometry/brep/__init__.py
@@ -11,6 +11,10 @@ def new_brep(*args, **kwargs):
 
 
 @plugin(category="factories", requires=["Rhino"])
+def from_extrusion(*args, **kwargs):
+    return RhinoBrep.from_extrusion(*args, **kwargs)
+
+@plugin(category="factories", requires=["Rhino"])
 def from_native(*args, **kwargs):
     return RhinoBrep.from_native(*args, **kwargs)
 

--- a/src/compas_rhino/geometry/brep/__init__.py
+++ b/src/compas_rhino/geometry/brep/__init__.py
@@ -14,6 +14,7 @@ def new_brep(*args, **kwargs):
 def from_extrusion(*args, **kwargs):
     return RhinoBrep.from_extrusion(*args, **kwargs)
 
+
 @plugin(category="factories", requires=["Rhino"])
 def from_native(*args, **kwargs):
     return RhinoBrep.from_native(*args, **kwargs)


### PR DESCRIPTION
* Implemented plugin `RhinoBrep.from_extrusion`.
* By popular demand, added flag `cap_ends` to `Brep.from_extrusion`.

![image](https://github.com/compas-dev/compas/assets/3398309/b5f75fb6-9536-4c77-a1d6-72b2f0f7a4fe)


### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
