### PR TITLE
Fix handling of mesh colors in rhino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Changed `compas.datastructures.TreeNode` to skip serialising `attributes`, `name` and `children` if being empty. 
+* Changed `compas.datastructures.TreeNode` to skip serialising `attributes`, `name` and `children` if being empty.
 * Changed `compas.datastructures.TreeNode.__repr__` to omit `name` if `None`.
+* Changed `compas.scene.descriptors.ColorDictAttribute` to accept a `compas.colors.ColorDict` as value.
+* Changed `compas_rhino.scene.RhinoMeshObject.draw` to preprocess vertex and face color dicts into lists.
+* Changed `compas_rhino.conversions.vertices_and_faces_to_rhino` to handle vertex color information correctly.
 
 ### Removed
 

--- a/src/compas/scene/descriptors/colordict.py
+++ b/src/compas/scene/descriptors/colordict.py
@@ -91,6 +91,11 @@ class ColorDictAttribute(object):
             colordict.clear()
             colordict.update(value)
 
+        elif isinstance(value, ColorDict):
+            colordict.clear()
+            colordict.default = value.default
+            colordict.update(value)
+
         else:
             colordict.clear()
             colordict.default = value

--- a/src/compas_rhino/conversions/meshes.py
+++ b/src/compas_rhino/conversions/meshes.py
@@ -204,19 +204,18 @@ def vertices_and_faces_to_rhino(
 
             face_callback(face)
 
-    # if color:
-    #     mesh.VertexColors.CreateMonotoneMesh(SystemColor.FromArgb(*color.rgb255))
-    # else:
-    if not color:
-        if vertexcolors:
-            if len(mesh.Vertices) != len(vertexcolors):
-                raise ValueError("The number of vertex colors does not match the number of vertices.")
+    if vertexcolors:
+        if len(mesh.Vertices) != len(vertexcolors):
+            raise ValueError("The number of vertex colors does not match the number of vertices.")
 
-            colors = System.Array.CreateInstance(System.Drawing.Color, len(vertexcolors))
-            for index, color in enumerate(vertexcolors):
-                colors[index] = System.Drawing.Color.FromArgb(*color.rgb255)
+        colors = System.Array.CreateInstance(System.Drawing.Color, len(vertexcolors))
+        for index, color in enumerate(vertexcolors):
+            colors[index] = System.Drawing.Color.FromArgb(*color.rgb255)
 
-            mesh.VertexColors.SetColors(colors)
+        mesh.VertexColors.SetColors(colors)
+    else:
+        if color:
+            mesh.VertexColors.CreateMonotoneMesh(System.Drawing.Color.FromArgb(*color.rgb255))
 
     # mesh.UnifyNormals()
     mesh.Normals.ComputeNormals()

--- a/src/compas_rhino/scene/meshobject.py
+++ b/src/compas_rhino/scene/meshobject.py
@@ -181,11 +181,19 @@ class RhinoMeshObject(RhinoSceneObject, MeshObject):
         if self.show_faces is True:
             attr = self.compile_attributes()
 
+            vertexcolors = []
+            if len(self.vertexcolor):
+                vertexcolors = [self.vertexcolor[vertex] for vertex in self.mesh.vertices()]
+
+            facecolors = []
+            if len(self.facecolor):
+                facecolors = [self.facecolor[face] for face in self.mesh.faces()]
+
             geometry = mesh_to_rhino(
                 self.mesh,
                 color=self.color,
-                vertexcolors=self.vertexcolor,
-                facecolors=self.facecolor,
+                vertexcolors=vertexcolors,
+                facecolors=facecolors,
                 disjoint=self.disjoint,
             )
 


### PR DESCRIPTION
This fixes color handling by mesh objects in Rhino scenes.

```python
from compas.datastructures import Mesh
from compas.scene import Scene
from compas.colors import Color
from compas.colors import ColorDict

mesh = Mesh.from_meshgrid(10, 10)

vertexcolor = ColorDict(default=Color.white())
for vertex in mesh.vertex_sample(17):
    vertexcolor[vertex] = Color.red()

facecolor = ColorDict(default=Color.white())
for face in mesh.face_sample(17):
    facecolor[face] = Color.red()

scene = Scene()
scene.clear()
scene.add(mesh, vertexcolor=vertexcolor, facecolor=facecolor, show_faces=True, disjoint=True)
scene.draw()
```

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
