### PR TITLE
Fix bug related to value of degree in Nurbs Curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Changed `compas.datastructures.TreeNode` to skip serialising `attributes`, `name` and `children` if being empty. 
 * Changed `compas.datastructures.TreeNode.__repr__` to omit `name` if `None`.
+* Fix bug in `compas_rhino.geometry.NurbsCurve.from_parameters` and `compas_rhino.geometry.NurbsCurve.from_points` related to the value of the parameter `degree`.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/curves/__init__.py
+++ b/src/compas_rhino/geometry/curves/__init__.py
@@ -1,21 +1,19 @@
-from .curve import RhinoCurve  # noqa: F401
+from .curve import RhinoCurve
 from .nurbs import RhinoNurbsCurve
 
-from compas.geometry import Curve
-from compas.geometry import NurbsCurve
 from compas.plugins import plugin
 
 
 @plugin(category="factories", requires=["Rhino"])
 def new_curve(cls, *args, **kwargs):
-    curve = super(Curve, cls).__new__(cls)
+    curve = object.__new__(RhinoCurve)
     curve.__init__(*args, **kwargs)
     return curve
 
 
 @plugin(category="factories", requires=["Rhino"])
 def new_nurbscurve(cls, *args, **kwargs):
-    curve = super(NurbsCurve, cls).__new__(cls)
+    curve = object.__new__(RhinoNurbsCurve)
     curve.__init__(*args, **kwargs)
     return curve
 

--- a/src/compas_rhino/geometry/curves/__init__.py
+++ b/src/compas_rhino/geometry/curves/__init__.py
@@ -1,19 +1,21 @@
-from .curve import RhinoCurve
+from .curve import RhinoCurve  # noqa: F401
 from .nurbs import RhinoNurbsCurve
 
+from compas.geometry import Curve
+from compas.geometry import NurbsCurve
 from compas.plugins import plugin
 
 
 @plugin(category="factories", requires=["Rhino"])
 def new_curve(cls, *args, **kwargs):
-    curve = object.__new__(RhinoCurve)
+    curve = super(Curve, cls).__new__(cls)
     curve.__init__(*args, **kwargs)
     return curve
 
 
 @plugin(category="factories", requires=["Rhino"])
 def new_nurbscurve(cls, *args, **kwargs):
-    curve = object.__new__(RhinoNurbsCurve)
+    curve = super(NurbsCurve, cls).__new__(cls)
     curve.__init__(*args, **kwargs)
     return curve
 

--- a/src/compas_rhino/geometry/curves/nurbs.py
+++ b/src/compas_rhino/geometry/curves/nurbs.py
@@ -187,6 +187,7 @@ class RhinoNurbsCurve(NurbsCurve, RhinoCurve):
 
         """
         curve = cls()
+        degree = min(degree, len(points) - 1)
         curve.rhino_curve = rhino_curve_from_parameters(points, weights, knots, multiplicities, degree)
         return curve
 
@@ -208,9 +209,10 @@ class RhinoNurbsCurve(NurbsCurve, RhinoCurve):
         :class:`compas_rhino.geometry.RhinoNurbsCurve`
 
         """
-        points[:] = [point_to_rhino(point) for point in points]
         curve = cls()
-        curve.rhino_curve = Rhino.Geometry.NurbsCurve.Create(is_periodic, degree, points)
+        degree = min(degree, len(points) - 1)
+        rhino_curve = Rhino.Geometry.NurbsCurve.Create(is_periodic, degree, [point_to_rhino(point) for point in points])
+        curve.rhino_curve = rhino_curve
         return curve
 
     @classmethod


### PR DESCRIPTION
Maximum degree should be "number_of_control_points - 1".

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
