### PR TITLE
Merging SceneObjectNode and SceneObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed `compas.scene.Scene` to inherent from `compas.datastructrues.Tree`.
+* Changed `compas.scene.SceneObject` to inherent from `compas.datastructrues.TreeNode`.
+
 ### Removed
 
 * Removed `compas.scene.SceneObjectNode`, functionalities merged into `compas.scene.SceneObject`.
+* Removed `compas.scene.SceneTree`, functionalities merged into `compas.scene.Scene`.
 
 
 ## [2.1.0] 2024-03-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+* Removed `compas.scene.SceneObjectNode`, functionalities merged into `compas.scene.SceneObject`.
+
 
 ## [2.1.0] 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-* Changed and update the `compas_view2` examples into `compas_viewer`.
 
+* Changed and updated the `compas_view2` examples into `compas_viewer`.
 * Changed `compas.scene.Scene` to inherent from `compas.datastructrues.Tree`.
 * Changed `compas.scene.SceneObject` to inherent from `compas.datastructrues.TreeNode`.
 

--- a/src/compas/datastructures/tree/tree.py
+++ b/src/compas/datastructures/tree/tree.py
@@ -71,7 +71,7 @@ class TreeNode(Data):
         return node
 
     def __init__(self, name=None, **kwargs):
-        super(TreeNode, self).__init__(name=name, **kwargs)
+        super(TreeNode, self).__init__(name=name)
         self.attributes = kwargs
         self._parent = None
         self._children = []

--- a/src/compas/scene/__init__.py
+++ b/src/compas/scene/__init__.py
@@ -23,7 +23,6 @@ from .context import get_sceneobject_cls
 from .context import register
 
 from .scene import Scene
-from .scene import SceneTree
 
 from compas.plugins import plugin
 from compas.geometry import Geometry
@@ -48,7 +47,6 @@ __all__ = [
     "GeometryObject",
     "VolMeshObject",
     "Scene",
-    "SceneTree",
     "clear",
     "before_draw",
     "after_draw",

--- a/src/compas/scene/__init__.py
+++ b/src/compas/scene/__init__.py
@@ -23,7 +23,6 @@ from .context import get_sceneobject_cls
 from .context import register
 
 from .scene import Scene
-from .scene import SceneObjectNode
 from .scene import SceneTree
 
 from compas.plugins import plugin
@@ -49,7 +48,6 @@ __all__ = [
     "GeometryObject",
     "VolMeshObject",
     "Scene",
-    "SceneObjectNode",
     "SceneTree",
     "clear",
     "before_draw",

--- a/src/compas/scene/context.py
+++ b/src/compas/scene/context.py
@@ -92,17 +92,17 @@ def register(item_type, sceneobject_type, context=None):
     ITEM_SCENEOBJECT[context][item_type] = sceneobject_type
 
 
-def is_viewer_open():
-    """Returns True if an instance of the compas_view2 App is available.
+# def is_viewer_open():
+#     """Returns True if an instance of the compas_view2 App is available.
 
-    Returns
-    -------
-    bool
+#     Returns
+#     -------
+#     bool
 
-    """
-    from compas.scene import Scene
+#     """
+#     from compas.scene import Scene
 
-    return Scene.viewerinstance is not None
+#     return Scene.viewerinstance is not None
 
 
 def detect_current_context():
@@ -119,8 +119,8 @@ def detect_current_context():
 
     """
 
-    if is_viewer_open():
-        return "Viewer"
+    # if is_viewer_open():
+    #     return "Viewer"
     if compas.is_grasshopper():
         return "Grasshopper"
     if compas.is_rhino():

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -1,6 +1,5 @@
 import compas.datastructures  # noqa: F401
 import compas.geometry  # noqa: F401
-from compas.data import Data
 from compas.datastructures import Tree
 from compas.datastructures import TreeNode
 
@@ -147,4 +146,3 @@ class Scene(Tree):
         after_draw(drawn_objects)
 
         return drawn_objects
-

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -130,6 +130,14 @@ class Scene(Data):
         if isinstance(item, SceneObject):
             sceneobject = item
         else:
+            if "context" in kwargs:
+                if kwargs["context"] != self.context:
+                    raise Exception(
+                        "Object context should be the same as scene context: {} != {}".format(
+                            kwargs["context"], self.context
+                        )
+                    )
+                del kwargs["context"]  # otherwist the SceneObject receives "context" twice, which results in an error
             sceneobject = SceneObject(item, context=self.context, **kwargs)  # type: ignore
         self.tree.add(sceneobject, parent=parent)
         return sceneobject

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -9,81 +9,6 @@ from .context import detect_current_context
 from .sceneobject import SceneObject
 
 
-class SceneObjectNode(TreeNode):
-    """A node representing a scene object in a scene tree. The SceneObjectNode should only be used internally by the SceneTree.
-
-    Parameters
-    ----------
-    object : :class:`compas.scene.SceneObject`
-        The scene object associated with the node.
-
-    Attributes
-    ----------
-    name : str
-        The name of the node, same as the underlying scene object.
-    object : :class:`compas.scene.SceneObject`
-        The scene object associated with the node.
-    parentobject : :class:`compas.scene.SceneObject`
-        The scene object associated with the parent node.
-    childobjects : list[:class:`compas.scene.SceneObject`]
-        The scene objects associated with the child nodes.
-
-    """
-
-    @property
-    def __data__(self):
-        return {
-            "item": str(self.object.item.guid),
-            "settings": self.object.settings,
-            "children": [child.__data__ for child in self.children],
-        }
-
-    @classmethod
-    def __from_data__(cls, data):
-        raise TypeError("SceneObjectNode cannot be created from data. Use Scene.__from_data__ instead.")
-
-    def __init__(self, sceneobject, name=None):
-        super(SceneObjectNode, self).__init__(name=name)
-        self.object = sceneobject
-
-    @property
-    def name(self):
-        if self.object:
-            return self.object.name
-
-    @property
-    def parentobject(self):
-        if self.parent and isinstance(self.parent, SceneObjectNode):
-            return self.parent.object
-        return None
-
-    @property
-    def childobjects(self):
-        return [child.object for child in self.children]
-
-    def add_item(self, item, **kwargs):
-        """Add an child item to the node.
-
-        Parameters
-        ----------
-        item : :class:`compas.data.Data`
-            The item to add.
-        **kwargs : dict
-            Additional keyword arguments to create the scene object for the item.
-
-        Returns
-        -------
-        :class:`compas.scene.SceneObject`
-            The scene object associated with the item.
-
-        """
-        sceneobject = SceneObject(item, **kwargs)
-        node = SceneObjectNode(sceneobject)
-        self.add(node)
-        sceneobject._node = node  # type: ignore
-        return sceneobject
-
-
 class SceneTree(Tree):
     """A tree structure for storing the hierarchy of scene objects in a scene. The SceneTree should only be used internally by the Scene.
 
@@ -91,11 +16,6 @@ class SceneTree(Tree):
     ----------
     name : str, optional
         The name of the tree.
-
-    Attributes
-    ----------
-    objects : list[:class:`compas.scene.SceneObject`]
-        All scene objects in the scene tree.
 
     """
 
@@ -105,75 +25,8 @@ class SceneTree(Tree):
 
     def __init__(self, name=None):
         super(SceneTree, self).__init__(name=name)
-        root = TreeNode(name="root")
+        root = TreeNode(name="ROOT")
         self.add(root)
-
-    @property
-    def objects(self):
-        return [node.object for node in self.nodes if isinstance(node, SceneObjectNode)]
-
-    def add_object(self, sceneobject, parent=None):
-        """Add a scene object to the tree.
-
-        Parameters
-        ----------
-        sceneobject : :class:`compas.scene.SceneObject`
-            The scene object to add.
-        parent : :class:`compas.scene.SceneObject`, optional
-            The parent scene object.
-
-        Returns
-        -------
-        :class:`compas.scene.SceneObjectNode`
-            The node associated with the scene object.
-
-        """
-        node = SceneObjectNode(sceneobject)
-        if parent is None:
-            self.add(node, parent=self.root)
-        else:
-            parent_node = self.get_node_from_object(parent)
-            self.add(node, parent=parent_node)
-
-        sceneobject._node = node
-        return node
-
-    def remove_object(self, sceneobject):
-        """Remove a scene object from the tree.
-
-        Parameters
-        ----------
-        sceneobject : :class:`compas.scene.SceneObject`
-            The scene object to remove.
-
-        """
-        node = self.get_node_from_object(sceneobject)
-        self.remove(node)
-
-    def get_node_from_object(self, sceneobject):
-        """Get the node associated with a scene object.
-
-        Parameters
-        ----------
-        sceneobject : :class:`compas.scene.SceneObject`
-            The scene object.
-
-        Returns
-        -------
-        :class:`compas.scene.SceneObjectNode`
-            The node associated with the scene object.
-
-        Raises
-        ------
-        ValueError
-            If the scene object is not in the scene tree.
-
-        """
-        for node in self.nodes:
-            if isinstance(node, SceneObjectNode):
-                if node.object is sceneobject:
-                    return node
-        raise ValueError("Scene object not in scene tree")
 
 
 class Scene(Data):
@@ -242,7 +95,7 @@ class Scene(Data):
 
     @property
     def objects(self):
-        return self.tree.objects
+        return [node for node in self.tree.nodes if not node.is_root]
 
     def add(self, item, parent=None, **kwargs):
         """Add an item to the scene.
@@ -261,8 +114,14 @@ class Scene(Data):
         :class:`compas.scene.SceneObject`
             The scene object associated with the item.
         """
-        sceneobject = SceneObject(item, context=self.context, **kwargs)
-        self.tree.add_object(sceneobject, parent=parent)
+
+        parent = parent or self.tree.root
+
+        if isinstance(item, SceneObject):
+            sceneobject = item
+        else:
+            sceneobject = SceneObject(item, context=self.context, **kwargs)
+        self.tree.add(sceneobject, parent=parent)
         return sceneobject
 
     def remove(self, sceneobject):
@@ -274,7 +133,7 @@ class Scene(Data):
             The scene object to remove.
 
         """
-        self.tree.remove_object(sceneobject)
+        self.tree.remove(sceneobject)
 
     def clear(self):
         """Clear the current context of the scene."""

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -1,3 +1,5 @@
+import compas.datastructures  # noqa: F401
+import compas.geometry  # noqa: F401
 from compas.data import Data
 from compas.datastructures import Tree
 from compas.datastructures import TreeNode
@@ -21,9 +23,11 @@ class SceneTree(Tree):
 
     @classmethod
     def __from_data__(cls, data):
+        # type: (dict) -> SceneTree
         raise TypeError("SceneTree cannot be created from data. Use Scene.__from_data__ instead.")
 
     def __init__(self, name=None):
+        # type: (str | None) -> None
         super(SceneTree, self).__init__(name=name)
         root = TreeNode(name="ROOT")
         self.add(root)
@@ -57,10 +61,9 @@ class Scene(Data):
 
     """
 
-    viewerinstance = None
-
     @property
     def __data__(self):
+        # type: () -> dict
         items = {str(object.item.guid): object.item for object in self.objects}
         return {
             "name": self.name,
@@ -70,6 +73,7 @@ class Scene(Data):
 
     @classmethod
     def __from_data__(cls, data):
+        # type: (dict) -> Scene
         scene = cls(data["name"])
         items = {str(item.guid): item for item in data["items"]}
 
@@ -85,19 +89,25 @@ class Scene(Data):
         return scene
 
     def __init__(self, name=None, context=None):
+        # type: (str | None, str | None) -> None
         super(Scene, self).__init__(name)
-        self._tree = SceneTree("Scene")
+        self._tree = SceneTree(name="Scene")
         self.context = context or detect_current_context()
 
     @property
     def tree(self):
+        # type: () -> SceneTree
         return self._tree
 
     @property
     def objects(self):
-        return [node for node in self.tree.nodes if not node.is_root]
+        # type: () -> list[SceneObject]
+        # this is flagged by the type checker
+        # because the tree returns nodes of type TreeNode
+        return [node for node in self.tree.nodes if not node.is_root]  # type: ignore
 
     def add(self, item, parent=None, **kwargs):
+        # type: (compas.geometry.Geometry | compas.datastructures.Datastructure, SceneObject | TreeNode | None, dict) -> SceneObject
         """Add an item to the scene.
 
         Parameters
@@ -120,11 +130,12 @@ class Scene(Data):
         if isinstance(item, SceneObject):
             sceneobject = item
         else:
-            sceneobject = SceneObject(item, context=self.context, **kwargs)
+            sceneobject = SceneObject(item, context=self.context, **kwargs)  # type: ignore
         self.tree.add(sceneobject, parent=parent)
         return sceneobject
 
     def remove(self, sceneobject):
+        # type: (SceneObject) -> None
         """Remove a scene object from the scene.
 
         Parameters
@@ -136,10 +147,12 @@ class Scene(Data):
         self.tree.remove(sceneobject)
 
     def clear(self):
+        # type: () -> None
         """Clear the current context of the scene."""
         clear()
 
     def clear_objects(self):
+        # type: () -> None
         """Clear all objects inside the scene."""
         guids = []
         for sceneobject in self.objects:

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -19,13 +19,6 @@ from functools import reduce
 from operator import mul
 
 
-# if we know the parameters
-# we should document them
-# and not just make everything kwargs
-# not only is this not very helpful for the user
-# it does not allow for proper propagation of parameters across the inheritance chain
-
-
 class SceneObject(TreeNode):
     """Base class for all scene objects.
 
@@ -33,14 +26,22 @@ class SceneObject(TreeNode):
     ----------
     item : Any
         The item which should be visualized using the created SceneObject.
-    name
-    color
-    opacity
-    show
-    frame
-    transformation
-    context
-    **kwargs
+    name : str, optional
+        The name of the scene object. Note that is is not the same as the name of underlying data item, since different scene objects can refer to the same data item.
+    color : :class:`compas.colors.Color`, optional
+        The color of the object.
+    opacity : float, optional
+        The opacity of the object.
+    show : bool, optional
+        Flag for showing or hiding the object. Default is ``True``.
+    frame : :class:`compas.geometry.Frame`, optional
+        The local frame of the scene object, in relation to its parent frame.
+    transformation : :class:`compas.geometry.Transformation`, optional
+        The local transformation of the scene object in relation to its frame.
+    context : str, optional
+        The context in which the scene object is created.
+    **kwargs : dict
+        Additional keyword arguments to create the scene object for the item.
 
     Attributes
     ----------
@@ -68,7 +69,9 @@ class SceneObject(TreeNode):
     show : bool
         Flag for showing or hiding the object. Default is ``True``.
     settings : dict
-        The settings including necessary attributes for reconstructing the scene object.
+        The settings including necessary attributes for reconstructing the scene object besides the Data item.
+    context : str
+        The context in which the scene object is created.
 
     """
 
@@ -195,6 +198,7 @@ class SceneObject(TreeNode):
     @property
     def settings(self):
         # type: () -> dict
+        # The settings are all the nessessary attributes to reconstruct the scene object besides the Data item.
         settings = {
             "name": self.name,
             "color": self.color,

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -19,6 +19,13 @@ from functools import reduce
 from operator import mul
 
 
+# if we know the parameters
+# we should document them
+# and not just make everything kwargs
+# not only is this not very helpful for the user
+# it does not allow for proper propagation of parameters across the inheritance chain
+
+
 class SceneObject(TreeNode):
     """Base class for all scene objects.
 
@@ -26,8 +33,14 @@ class SceneObject(TreeNode):
     ----------
     item : Any
         The item which should be visualized using the created SceneObject.
-    **kwargs : dict
-        Additional keyword arguments for constructing SceneObject.
+    name
+    color
+    opacity
+    show
+    frame
+    transformation
+    context
+    **kwargs
 
     Attributes
     ----------

--- a/tests/compas/scene/test_scene.py
+++ b/tests/compas/scene/test_scene.py
@@ -80,31 +80,31 @@ if not compas.IPY:
 
         assert isinstance(sceneobject, FakeSceneObject)
 
-    def test_sceneobject_auto_context_discovery_viewer(mocker):
-        mocker.patch("compas.scene.context.is_viewer_open", return_value=True)
-        context.ITEM_SCENEOBJECT["Viewer"] = {FakeItem: FakeSceneObject}
+    # def test_sceneobject_auto_context_discovery_viewer(mocker):
+    #     mocker.patch("compas.scene.context.is_viewer_open", return_value=True)
+    #     context.ITEM_SCENEOBJECT["Viewer"] = {FakeItem: FakeSceneObject}
 
-        item = FakeSubItem()
-        sceneobject = SceneObject(item)
+    #     item = FakeSubItem()
+    #     sceneobject = SceneObject(item)
 
-        assert isinstance(sceneobject, FakeSceneObject)
+    #     assert isinstance(sceneobject, FakeSceneObject)
 
-    def test_sceneobject_auto_context_discovery_viewer_priority(mocker):
-        mocker.patch("compas.scene.context.is_viewer_open", return_value=True)
+    # def test_sceneobject_auto_context_discovery_viewer_priority(mocker):
+    #     mocker.patch("compas.scene.context.is_viewer_open", return_value=True)
 
-        class FakeViewerSceneObject(FakeSceneObject):
-            pass
+    #     class FakeViewerSceneObject(FakeSceneObject):
+    #         pass
 
-        class FakePlotterSceneObject(FakeSceneObject):
-            pass
+    #     class FakePlotterSceneObject(FakeSceneObject):
+    #         pass
 
-        context.ITEM_SCENEOBJECT["Viewer"] = {FakeItem: FakeViewerSceneObject}
-        context.ITEM_SCENEOBJECT["Plotter"] = {FakeItem: FakePlotterSceneObject}
+    #     context.ITEM_SCENEOBJECT["Viewer"] = {FakeItem: FakeViewerSceneObject}
+    #     context.ITEM_SCENEOBJECT["Plotter"] = {FakeItem: FakePlotterSceneObject}
 
-        item = FakeSubItem()
-        sceneobject = SceneObject(item)
+    #     item = FakeSubItem()
+    #     sceneobject = SceneObject(item)
 
-        assert isinstance(sceneobject, FakeViewerSceneObject)
+    #     assert isinstance(sceneobject, FakeViewerSceneObject)
 
     def test_sceneobject_auto_context_discovery_no_context(mocker):
         mocker.patch("compas.scene.context.is_viewer_open", return_value=False)

--- a/tests/compas/scene/test_scene.py
+++ b/tests/compas/scene/test_scene.py
@@ -80,34 +80,7 @@ if not compas.IPY:
 
         assert isinstance(sceneobject, FakeSceneObject)
 
-    # def test_sceneobject_auto_context_discovery_viewer(mocker):
-    #     mocker.patch("compas.scene.context.is_viewer_open", return_value=True)
-    #     context.ITEM_SCENEOBJECT["Viewer"] = {FakeItem: FakeSceneObject}
-
-    #     item = FakeSubItem()
-    #     sceneobject = SceneObject(item)
-
-    #     assert isinstance(sceneobject, FakeSceneObject)
-
-    # def test_sceneobject_auto_context_discovery_viewer_priority(mocker):
-    #     mocker.patch("compas.scene.context.is_viewer_open", return_value=True)
-
-    #     class FakeViewerSceneObject(FakeSceneObject):
-    #         pass
-
-    #     class FakePlotterSceneObject(FakeSceneObject):
-    #         pass
-
-    #     context.ITEM_SCENEOBJECT["Viewer"] = {FakeItem: FakeViewerSceneObject}
-    #     context.ITEM_SCENEOBJECT["Plotter"] = {FakeItem: FakePlotterSceneObject}
-
-    #     item = FakeSubItem()
-    #     sceneobject = SceneObject(item)
-
-    #     assert isinstance(sceneobject, FakeViewerSceneObject)
-
     def test_sceneobject_auto_context_discovery_no_context(mocker):
-        # mocker.patch("compas.scene.context.is_viewer_open", return_value=False)
         mocker.patch("compas.scene.context.compas.is_grasshopper", return_value=False)
         mocker.patch("compas.scene.context.compas.is_rhino", return_value=False)
 

--- a/tests/compas/scene/test_scene.py
+++ b/tests/compas/scene/test_scene.py
@@ -107,7 +107,7 @@ if not compas.IPY:
     #     assert isinstance(sceneobject, FakeViewerSceneObject)
 
     def test_sceneobject_auto_context_discovery_no_context(mocker):
-        mocker.patch("compas.scene.context.is_viewer_open", return_value=False)
+        # mocker.patch("compas.scene.context.is_viewer_open", return_value=False)
         mocker.patch("compas.scene.context.compas.is_grasshopper", return_value=False)
         mocker.patch("compas.scene.context.compas.is_rhino", return_value=False)
 


### PR DESCRIPTION
The relation between `SceneObjectNode` and `SceneObject` was too convoluted. This PR merge them into one by having `SceneObject` inherent from `TreeNode`. This simplifies a lot on operations to access parent/ children object or a tree that an object is attachted too. While the most-outer level user APIs stays untouched.  This should also make it easier from creating a `compas_model` object.

```python
from compas.scene import Scene
from compas.geometry import Box
from compas.geometry import Sphere
from compas.geometry import Cylinder
from compas.geometry import Frame
from compas.geometry import Sphere



box = Box.from_width_height_depth(1, 1, 1)
cylinder = Cylinder(1, 1, Frame.worldXY())
sphere = Sphere(1)

scene = Scene()
scene.clear()

obj = scene.add(box).add(cylinder).add(sphere)

scene.print_hierarchy()


print(obj.tree)
```
```
└── <TreeNode: ROOT>
    └── <GeometryObject: Box>
        └── <GeometryObject: Cylinder>
            └── <GeometryObject: Sphere>
<Tree with 4 nodes>
```


### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
