### PR TITLE
compas_rhino meshes average color output type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas.scene.descriptors.ColorDictAttribute` to accept a `compas.colors.ColorDict` as value.
 * Changed `compas_rhino.scene.RhinoMeshObject.draw` to preprocess vertex and face color dicts into lists.
 * Changed `compas_rhino.conversions.vertices_and_faces_to_rhino` to handle vertex color information correctly.
+* Changed `compas_rhino.conversions.average_color` return type `compas.colors.Color` instead of tuple.
 
 ### Removed
 

--- a/src/compas_rhino/conversions/meshes.py
+++ b/src/compas_rhino/conversions/meshes.py
@@ -23,7 +23,7 @@ def average_color(colors):
     r = sum(r) / c
     g = sum(g) / c
     b = sum(b) / c
-    return int(r), int(g), int(b)
+    return Color(int(r), int(g), int(b))
 
 
 def connected_ngon(face, vertices, rmesh):


### PR DESCRIPTION
The compas_rhino->conversions->meshes->average_color has to output a `Color` not a `tuple`.

Where it is used:
Line 200 `vertexcolors.append(average_color([vertexcolors[index] for index in face]))`
Line 217 it is called like this: `colors[index] = System.Drawing.Color.FromArgb(*color.rgb255)`

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
