### PR TITLE
Update `compas_viewer` examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Changed and update the `compas_view2` examples into `compas_viewer`.
 
 ### Removed
 
@@ -24,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `compas.datastructures.Tree.to_graph()`.
 
 ### Changed
-
 * Changed `compas.datastructures.TreeNode` to skip serialising `attributes`, `name` and `children` if being empty.
 * Changed `compas.datastructures.TreeNode.__repr__` to omit `name` if `None`.
 * Fix bug in `compas_rhino.geometry.NurbsCurve.from_parameters` and `compas_rhino.geometry.NurbsCurve.from_points` related to the value of the parameter `degree`.

--- a/docs/userguide/_plotter.py
+++ b/docs/userguide/_plotter.py
@@ -4,32 +4,33 @@
 from compas.datastructures import Mesh
 from compas.colors import Color
 from compas.geometry import Circle, Polygon, Line, Point, Vector
-from compas_view2.objects import Text, Collection
+from compas_viewer.scene import Tag
 
 
-def viewer_add_vertex(viewer, mesh, vertex, facecolor=None, linecolor=None, size=None):
+def viewer_add_vertex(viewer, mesh, vertex, facecolor=None, edgecolor=None, size=None):
     facecolor = facecolor or Color.white()
-    linecolor = linecolor or Color.black()
+    edgecolor = edgecolor or Color.black()
     size = size or 0.1
     point: Point = mesh.vertex_point(vertex) + [0, 0, 0.5]
-    viewer.add(
-        Circle.from_point_and_radius(point, size).to_polygon(100),
+    viewer.scene.add(
+        Circle.from_point_and_radius(point, size),
         facecolor=facecolor,
-        linecolor=linecolor,
+        edgecolor=edgecolor,
         linewidth=2,
+        n =100,
     )
 
 
 def viewer_add_vertex_label(viewer, mesh, vertex, text, height=None):
     height = height or 50
     point: Point = mesh.vertex_point(vertex) + [0.09, -0.075, 0.6]
-    viewer.add(Text(text, point, height=height))
+    viewer.scene.add(Tag(text, point, height=height, absolute_height=True))
 
 
 def viewer_add_edge(viewer, mesh, edge, color=None, width=None):
     color = color or Color.black()
     width = width or 10
-    viewer.add(
+    viewer.scene.add(
         mesh.edge_line(edge).translated([0, 0, 0.1]),
         linecolor=color,
         linewidth=width,
@@ -57,9 +58,9 @@ def viewer_add_halfvector(viewer, mesh: Mesh, halfedge, color=None, basewidth=0.
     arrowbase = Polygon([a, b, c, d])
     arrowhead = Polygon([b, b + direction * basewidth * arrowsize, b + normal * basewidth * arrowsize])
 
-    viewer.add(
-        Collection([arrowbase.translated([0, 0, 0.6]), arrowhead.translated([0, 0, 0.6])]),
-        facecolor=color,
+    viewer.scene.add(
+        [arrowbase.translated([0, 0, 0.6]), arrowhead.translated([0, 0, 0.6])],
+        surfacecolor=color,
         linecolor=color,
         show_lines=False,
     )

--- a/docs/userguide/basics.colors.rst
+++ b/docs/userguide/basics.colors.rst
@@ -132,7 +132,7 @@ However, using the following template we can compare various examples.
 >>> from compas.utilities import linspace, pairwise
 >>> from compas.datastructures import Mesh
 >>> from compas.colors import Color, ColorMap
->>> from compas_view2.app import App
+>>> from compas_viewer import Viewer
 
 >>> n = 1000
 >>> t = 0.3
@@ -151,11 +151,10 @@ However, using the following template we can compare various examples.
 >>> mesh = Mesh.from_polygons(polygons)
 
 >>> cmap = ...  # define color map here
->>> facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
+>>> facecolor = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
->>> viewer = App()
->>> viewer.view.show_grid = False
->>> viewer.add(mesh, facecolor=facecolors, show_lines=False)
+>>> viewer = Viewer(show_grid = False)
+>>> viewer.scene.add(mesh, facecolor=facecolor, show_lines=False)
 >>> viewer.show()
 
 

--- a/docs/userguide/basics.datastructures.meshes.py
+++ b/docs/userguide/basics.datastructures.meshes.py
@@ -1,125 +1,20 @@
 # type: ignore
 
-# import compas
-from compas.datastructures import Mesh
-from compas_view2.app import App
+from compas_viewer import Viewer
+
 from compas.colors import Color
-from compas.geometry import Circle
-from compas_view2.objects import Text
-
-# mesh = Mesh.from_obj(compas.get("tubemesh.obj"))
-
-# viewer = App(width=1600, height=900)
-# viewer.add(mesh)
-# viewer.view.camera.position = [1, -6, 1.5]
-# viewer.view.camera.look_at([1, 0, 1])
-# viewer.run()
-
-# mesh = Mesh.from_meshgrid(dx=9, nx=9)
-
-# viewer = App(viewport="top", width=1600, height=900)
-
-# viewer.add(mesh)
-# for vertex in range(30, 40):
-#     color = (1.0, 0.0, 0.0) if mesh.is_vertex_on_boundary(vertex) else (0.0, 0.0, 0.0)
-#     viewer.add(mesh.vertex_point(vertex), pointsize=20, pointcolor=color)
-
-# viewer.view.camera.zoom_extents()
-# viewer.view.camera.distance = 11
-# viewer.run()
-
-# mesh = Mesh.from_meshgrid(dx=9, nx=9)
-
-# viewer = App(viewport="top", width=1600, height=900)
-
-# red = Color.red()
-
-# viewer.add(mesh, facecolor=(0.95, 0.95, 0.95), linewidth=2)
-# viewer.add(
-#     Circle.from_point_and_radius(mesh.vertex_point(23) + [0, 0, 0.1], 0.1).to_polygon(100),
-#     facecolor=(1.0, 1.0, 1.0),
-#     linecolor=(0.0, 0.0, 0.0),
-#     linewidth=2,
-# )
-
-# for i, nbr in enumerate(mesh.vertex_neighbors(23, True)):
-#     print(nbr)
-#     viewer.add(
-#         Circle.from_point_and_radius(mesh.vertex_point(nbr) + [0, 0, 0.1], 0.2).to_polygon(100),
-#         facecolor=red.lightened(50),
-#         linecolor=red,
-#     )
-#     viewer.add(
-#         Text(
-#             str(i),
-#             mesh.vertex_point(nbr) + [0.09, -0.075, 0.1],
-#             height=50,
-#         )
-#     )
-
-# viewer.view.camera.zoom_extents()
-# viewer.view.camera.distance = 11
-# viewer.run()
-
-# mesh = Mesh.from_meshgrid(dx=9, nx=9)
-
-# viewer = App(viewport="top", width=1600, height=900)
-
-# red = Color.red()
-
-# viewer.add(
-#     Circle.from_point_and_radius(mesh.vertex_point(23) + [0, 0, 0.1], 0.1).to_polygon(100),
-#     facecolor=(1.0, 1.0, 1.0),
-#     linecolor=(0.0, 0.0, 0.0),
-#     linewidth=2,
-# )
-
-# facecolors = {face: (0.95, 0.95, 0.95) for face in mesh.faces()}
-# for i, face in enumerate(mesh.vertex_faces(23)):
-#     print(face)
-#     viewer.add(
-#         Text(
-#             str(i),
-#             mesh.face_centroid(face) + [0.09, -0.075, 0.1],
-#             height=50,
-#         )
-#     )
-#     facecolors[face] = red.lightened(50)
-
-# viewer.add(mesh, facecolor=facecolors, linewidth=2)
-
-# viewer.view.camera.zoom_extents()
-# viewer.view.camera.distance = 11
-# viewer.run()
-
-# mesh = Mesh.from_meshgrid(dx=9, nx=9)
-
-# viewer = App(viewport="top", width=1600, height=900)
-
-# red = Color.red()
-
-# viewer.add(mesh, facecolor=(0.95, 0.95, 0.95), linewidth=2)
-# viewer.add(mesh.edge_line((20, 30)).translated([0, 0, 0.1]), linecolor=red, linewidth=10)
-
-# for edge in mesh.edge_strip((20, 30)):
-#     viewer.add(mesh.edge_line(edge).translated([0, 0, 0.1]), linewidth=10)
-
-# viewer.view.camera.zoom_extents()
-# viewer.view.camera.distance = 11
-# viewer.run()
+from compas.datastructures import Mesh
 
 mesh = Mesh.from_meshgrid(dx=9, nx=9)
 
-viewer = App(viewport="top", width=1600, height=900)
+viewer = Viewer(viewmode="top", width=1600, height=900)
 
 red = Color.red()
 
-viewer.add(mesh, facecolor=(0.95, 0.95, 0.95), linewidth=2)
-viewer.add(mesh.edge_line((30, 31)).translated([0, 0, 0.1]), linecolor=red, linewidth=10)
+viewer.scene.add(mesh, facecolor=(0.95, 0.95, 0.95), lineswidth=2)
+viewer.scene.add(mesh.edge_line((30, 31)).translated([0, 0, 0.1]), linecolor=red, lineswidth=10)
 
 for edge in mesh.edge_loop((30, 31)):
-    viewer.add(mesh.edge_line(edge).translated([0, 0, 0.1]), linewidth=10)
+    viewer.scene.add(mesh.edge_line(edge).translated([0, 0, 0.1]), lineswidth=10)
 
-viewer.view.camera.zoom_extents()
-viewer.view.camera.distance = 11
-viewer.run()
+viewer.show()

--- a/docs/userguide/introduction.rst
+++ b/docs/userguide/introduction.rst
@@ -17,7 +17,7 @@ The Framework
 .. The framework consists of a collection of loosely coupled Python packages that can be used alone or in combination with other packages.
 
 The framework consists of a core library (:mod:`compas`), core extensions (:mod:`compas_cgal`, :mod:`compas_libigl`, :mod:`compas_occ`, :mod:`compas_gmsh`),
-a standalone viewer (:mod:`compas_view2`),
+a standalone viewer (:mod:`compas_viewer`),
 dedicated integrations for Rhino (:mod:`compas_rhino`), Grasshopper (:mod:`compas_ghpython`), and Blender (:mod:`compas_blender`),
 and a growing number of packages for specific tasks in the AEC domain, such as:
 

--- a/docs/userguide/samples/colors.py
+++ b/docs/userguide/samples/colors.py
@@ -1,24 +1,25 @@
 # type: ignore
 
-from compas.geometry import Box, Circle, Frame
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
+from compas_viewer import Viewer
 
-viewer = App()
-viewer.view.show_grid = False
+from compas.colors import Color
+from compas.geometry import Circle
+from compas.geometry import Frame
 
-viewer.add(Circle(0.4, Frame([0, 0, 0])).to_polygon(n=100), facecolor=Color.red())
-viewer.add(Circle(0.4, Frame([1, 0, 0])).to_polygon(n=100), facecolor=Color.orange())
-viewer.add(Circle(0.4, Frame([2, 0, 0])).to_polygon(n=100), facecolor=Color.yellow())
-viewer.add(Circle(0.4, Frame([3, 0, 0])).to_polygon(n=100), facecolor=Color.lime())
-viewer.add(Circle(0.4, Frame([4, 0, 0])).to_polygon(n=100), facecolor=Color.green())
-viewer.add(Circle(0.4, Frame([5, 0, 0])).to_polygon(n=100), facecolor=Color.mint())
-viewer.add(Circle(0.4, Frame([6, 0, 0])).to_polygon(n=100), facecolor=Color.cyan())
-viewer.add(Circle(0.4, Frame([7, 0, 0])).to_polygon(n=100), facecolor=Color.azure())
-viewer.add(Circle(0.4, Frame([8, 0, 0])).to_polygon(n=100), facecolor=Color.blue())
-viewer.add(Circle(0.4, Frame([9, 0, 0])).to_polygon(n=100), facecolor=Color.violet())
-viewer.add(Circle(0.4, Frame([10, 0, 0])).to_polygon(n=100), facecolor=Color.magenta())
-viewer.add(Circle(0.4, Frame([11, 0, 0])).to_polygon(n=100), facecolor=Color.pink())
-viewer.add(Circle(0.4, Frame([12, 0, 0])).to_polygon(n=100), facecolor=Color.red())
+viewer = Viewer(show_grid=False)
 
-viewer.run()
+viewer.scene.add(Circle(0.4, Frame([0, 0, 0])), linecolor=Color.red(), n=100)
+viewer.scene.add(Circle(0.4, Frame([1, 0, 0])), linecolor=Color.orange(), n=100)
+viewer.scene.add(Circle(0.4, Frame([2, 0, 0])), linecolor=Color.yellow(), n=100)
+viewer.scene.add(Circle(0.4, Frame([3, 0, 0])), linecolor=Color.lime(), n=100)
+viewer.scene.add(Circle(0.4, Frame([4, 0, 0])), linecolor=Color.green(), n=100)
+viewer.scene.add(Circle(0.4, Frame([5, 0, 0])), linecolor=Color.mint(), n=100)
+viewer.scene.add(Circle(0.4, Frame([6, 0, 0])), linecolor=Color.cyan(), n=100)
+viewer.scene.add(Circle(0.4, Frame([7, 0, 0])), linecolor=Color.azure(), n=100)
+viewer.scene.add(Circle(0.4, Frame([8, 0, 0])), linecolor=Color.blue(), n=100)
+viewer.scene.add(Circle(0.4, Frame([9, 0, 0])), linecolor=Color.violet(), n=100)
+viewer.scene.add(Circle(0.4, Frame([10, 0, 0])), linecolor=Color.magenta(), n=100)
+viewer.scene.add(Circle(0.4, Frame([11, 0, 0])), linecolor=Color.pink(), n=100)
+viewer.scene.add(Circle(0.4, Frame([12, 0, 0])), linecolor=Color.red(), n=100)
+
+viewer.show()

--- a/docs/userguide/samples/colors_lightness.py
+++ b/docs/userguide/samples/colors_lightness.py
@@ -1,11 +1,12 @@
 # type: ignore
 
-from compas.geometry import Box, Circle, Frame
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
+from compas_viewer import Viewer
 
-viewer = App()
-viewer.view.show_grid = False
+from compas.colors import Color
+from compas.geometry import Circle
+from compas.geometry import Frame
+
+viewer = Viewer(show_grid=False)
 
 colors = [
     Color.red(),
@@ -24,10 +25,10 @@ colors = [
 
 for up in range(5):
     for right, color in enumerate(colors):
-        viewer.add(Circle(0.4, Frame([right, up, 0])).to_polygon(n=100), facecolor=color.darkened(up * 25))
+        viewer.scene.add(Circle(0.4, Frame([right, up, 0])), linecolor=color.darkened(up * 25), n=100)
 
 for down in range(1, 5):
     for right, color in enumerate(colors):
-        viewer.add(Circle(0.4, Frame([right, -down, 0])).to_polygon(n=100), facecolor=color.lightened(down * 25))
+        viewer.scene.add(Circle(0.4, Frame([right, -down, 0])), linecolor=color.lightened(down * 25), n=100)
 
-viewer.run()
+viewer.show()

--- a/docs/userguide/samples/colors_maps.py
+++ b/docs/userguide/samples/colors_maps.py
@@ -1,12 +1,16 @@
 # type: ignore
 
-from compas.geometry import Pointcloud, Circle, Frame, Polygon
-from compas.datastructures import Mesh
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
+from compas_viewer import Viewer
 
-viewer = App()
-viewer.view.show_grid = False
+from compas.colors import Color
+from compas.colors import ColorMap
+from compas.datastructures import Mesh
+from compas.geometry import Circle
+from compas.geometry import Frame
+from compas.geometry import Pointcloud
+from compas.geometry import Polygon
+
+viewer = Viewer(show_grid=False)
 
 cmap = ColorMap.from_mpl("viridis")
 w = 16
@@ -31,6 +35,6 @@ for i, color in enumerate(cmap.colors):
     facecolors[i] = color
     # viewer.add(c.to_polygon(100), facecolor=color)
 
-viewer.add(Mesh.from_polygons(polygons), facecolor=facecolors, show_lines=False)
+viewer.scene.add(Mesh.from_polygons(polygons), facecolor=facecolors, show_lines=False, show_points=False)
 
-viewer.run()
+viewer.show()

--- a/docs/userguide/samples/colors_maps_from-one-color.py
+++ b/docs/userguide/samples/colors_maps_from-one-color.py
@@ -1,10 +1,15 @@
 # type: ignore
 
-from compas.geometry import Point, Polygon, Translation
-from compas.utilities import linspace, pairwise
+from compas_viewer import Viewer
+
+from compas.colors import Color
+from compas.colors import ColorMap
 from compas.datastructures import Mesh
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
+from compas.geometry import Point
+from compas.geometry import Polygon
+from compas.geometry import Translation
+from compas.utilities import linspace
+from compas.utilities import pairwise
 
 n = 1000
 t = 0.3
@@ -22,24 +27,23 @@ for (d, c), (a, b) in zip(pairwise(up), pairwise(down)):
 
 mesh = Mesh.from_polygons(polygons)
 
-viewer = App()
-viewer.view.show_grid = False
+viewer = Viewer(show_grid=False)
 
 cmap = ColorMap.from_color(Color.red())
-facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
+facecolor = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
-viewer.add(mesh, facecolor=facecolors, show_lines=False)
+viewer.scene.add(mesh, facecolor=facecolor, show_lines=False, show_points=False)
 
 cmap = ColorMap.from_color(Color.red(), rangetype="light")
 facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
 translation = Translation.from_vector([0, -3 * t, 0])
-viewer.add(mesh.transformed(translation), facecolor=facecolors, show_lines=False)
+viewer.scene.add(mesh.transformed(translation), facecolor=facecolors, show_lines=False, show_points=False)
 
 cmap = ColorMap.from_color(Color.red(), rangetype="dark")
 facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
 translation = Translation.from_vector([0, -6 * t, 0])
-viewer.add(mesh.transformed(translation), facecolor=facecolors, show_lines=False)
+viewer.scene.add(mesh.transformed(translation), facecolor=facecolors, show_lines=False, show_points=False)
 
 viewer.show()

--- a/docs/userguide/samples/colors_maps_from-one-color.py
+++ b/docs/userguide/samples/colors_maps_from-one-color.py
@@ -8,8 +8,8 @@ from compas.datastructures import Mesh
 from compas.geometry import Point
 from compas.geometry import Polygon
 from compas.geometry import Translation
-from compas.utilities import linspace
-from compas.utilities import pairwise
+from compas.itertools import linspace
+from compas.itertools import pairwise
 
 n = 1000
 t = 0.3

--- a/docs/userguide/samples/colors_maps_from-rgb.py
+++ b/docs/userguide/samples/colors_maps_from-rgb.py
@@ -1,10 +1,15 @@
 # type: ignore
 
-from compas.geometry import Bezier, Point, Polygon, Vector
-from compas.utilities import linspace, pairwise
-from compas.datastructures import Mesh
+from compas_viewer import Viewer
+
 from compas.colors import ColorMap
-from compas_view2.app import App
+from compas.datastructures import Mesh
+from compas.geometry import Bezier
+from compas.geometry import Point
+from compas.geometry import Polygon
+from compas.geometry import Vector
+from compas.utilities import linspace
+from compas.utilities import pairwise
 
 n = 5000
 
@@ -31,7 +36,6 @@ cmap = ColorMap.from_rgb()
 mesh = Mesh.from_polygons(polygons)
 facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
-viewer = App()
-viewer.view.show_grid = False
-viewer.add(mesh, facecolor=facecolors, show_lines=False)
+viewer = Viewer(show_grid=False)
+viewer.scene.add(mesh, facecolor=facecolors, show_lines=False, show_points=False)
 viewer.show()

--- a/docs/userguide/samples/colors_maps_from-rgb.py
+++ b/docs/userguide/samples/colors_maps_from-rgb.py
@@ -8,8 +8,8 @@ from compas.geometry import Bezier
 from compas.geometry import Point
 from compas.geometry import Polygon
 from compas.geometry import Vector
-from compas.utilities import linspace
-from compas.utilities import pairwise
+from compas.itertools import linspace
+from compas.itertools import pairwise
 
 n = 5000
 

--- a/docs/userguide/samples/colors_maps_from-rgb_simple.py
+++ b/docs/userguide/samples/colors_maps_from-rgb_simple.py
@@ -6,8 +6,8 @@ from compas.colors import ColorMap
 from compas.datastructures import Mesh
 from compas.geometry import Point
 from compas.geometry import Polygon
-from compas.utilities import linspace
-from compas.utilities import pairwise
+from compas.itertools import linspace
+from compas.itertools import pairwise
 
 n = 256
 t = 0.3

--- a/docs/userguide/samples/colors_maps_from-rgb_simple.py
+++ b/docs/userguide/samples/colors_maps_from-rgb_simple.py
@@ -1,10 +1,13 @@
 # type: ignore
 
-from compas.geometry import Point, Polygon
-from compas.utilities import linspace, pairwise
-from compas.datastructures import Mesh
+from compas_viewer import Viewer
+
 from compas.colors import ColorMap
-from compas_view2.app import App
+from compas.datastructures import Mesh
+from compas.geometry import Point
+from compas.geometry import Polygon
+from compas.utilities import linspace
+from compas.utilities import pairwise
 
 n = 256
 t = 0.3
@@ -25,7 +28,6 @@ cmap = ColorMap.from_rgb()
 mesh = Mesh.from_polygons(polygons)
 facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
-viewer = App()
-viewer.view.show_grid = False
-viewer.add(mesh, facecolor=facecolors, show_lines=False)
+viewer = Viewer(show_grid=False)
+viewer.scene.add(mesh, facecolor=facecolors, show_lines=False, show_points=False)
 viewer.show()

--- a/docs/userguide/samples/colors_maps_from-three-colors.py
+++ b/docs/userguide/samples/colors_maps_from-three-colors.py
@@ -7,8 +7,8 @@ from compas.colors import ColorMap
 from compas.datastructures import Mesh
 from compas.geometry import Point
 from compas.geometry import Polygon
-from compas.utilities import linspace
-from compas.utilities import pairwise
+from compas.itertools import linspace
+from compas.itertools import pairwise
 
 n = 1000
 t = 0.3

--- a/docs/userguide/samples/colors_maps_from-three-colors.py
+++ b/docs/userguide/samples/colors_maps_from-three-colors.py
@@ -1,10 +1,14 @@
 # type: ignore
 
-from compas.geometry import Point, Polygon, Translation
-from compas.utilities import linspace, pairwise
+from compas_viewer import Viewer
+
+from compas.colors import Color
+from compas.colors import ColorMap
 from compas.datastructures import Mesh
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
+from compas.geometry import Point
+from compas.geometry import Polygon
+from compas.utilities import linspace
+from compas.utilities import pairwise
 
 n = 1000
 t = 0.3
@@ -22,12 +26,11 @@ for (d, c), (a, b) in zip(pairwise(up), pairwise(down)):
 
 mesh = Mesh.from_polygons(polygons)
 
-viewer = App()
-viewer.view.show_grid = False
+viewer = Viewer(show_grid=False)
 
 cmap = ColorMap.from_three_colors(Color.red(), Color.green(), Color.blue())
 facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
-viewer.add(mesh, facecolor=facecolors, show_lines=False)
+viewer.scene.add(mesh, facecolor=facecolors, show_lines=False, show_points=False)
 
 viewer.show()

--- a/docs/userguide/samples/colors_maps_from-two-colors.py
+++ b/docs/userguide/samples/colors_maps_from-two-colors.py
@@ -1,10 +1,15 @@
 # type: ignore
 
-from compas.geometry import Point, Polygon, Translation
-from compas.utilities import linspace, pairwise
+from compas_viewer import Viewer
+
+from compas.colors import Color
+from compas.colors import ColorMap
 from compas.datastructures import Mesh
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
+from compas.geometry import Point
+from compas.geometry import Polygon
+from compas.geometry import Translation
+from compas.utilities import linspace
+from compas.utilities import pairwise
 
 n = 1000
 t = 0.3
@@ -22,18 +27,17 @@ for (d, c), (a, b) in zip(pairwise(up), pairwise(down)):
 
 mesh = Mesh.from_polygons(polygons)
 
-viewer = App()
-viewer.view.show_grid = False
+viewer = Viewer(show_grid=False)
 
 cmap = ColorMap.from_two_colors(Color.from_hex("#0092d2"), Color.pink())
 facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
-viewer.add(mesh, facecolor=facecolors, show_lines=False)
+viewer.scene.add(mesh, facecolor=facecolors, show_lines=False, show_points=False)
 
 cmap = ColorMap.from_two_colors(Color.from_hex("#0092d2"), Color.pink(), diverging=True)
 facecolors = {i: cmap(i, minval=0, maxval=n - 1) for i in range(n)}
 
 translation = Translation.from_vector([0, -3 * t, 0])
-viewer.add(mesh.transformed(translation), facecolor=facecolors, show_lines=False)
+viewer.scene.add(mesh.transformed(translation), facecolor=facecolors, show_lines=False, show_points=False)
 
 viewer.show()

--- a/docs/userguide/samples/colors_maps_from-two-colors.py
+++ b/docs/userguide/samples/colors_maps_from-two-colors.py
@@ -8,8 +8,8 @@ from compas.datastructures import Mesh
 from compas.geometry import Point
 from compas.geometry import Polygon
 from compas.geometry import Translation
-from compas.utilities import linspace
-from compas.utilities import pairwise
+from compas.itertools import linspace
+from compas.itertools import pairwise
 
 n = 1000
 t = 0.3

--- a/docs/userguide/samples/colors_saturation.py
+++ b/docs/userguide/samples/colors_saturation.py
@@ -1,11 +1,10 @@
 # type: ignore
 
-from compas.geometry import Box, Circle, Frame
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
+from compas.geometry import Circle, Frame
+from compas.colors import Color
+from compas_viewer import Viewer
 
-viewer = App()
-viewer.view.show_grid = False
+viewer = Viewer(show_grid = False)
 
 colors = [
     Color.red(),
@@ -24,6 +23,6 @@ colors = [
 
 for up in range(11):
     for right, color in enumerate(colors):
-        viewer.add(Circle(0.4, Frame([right, up, 0])).to_polygon(n=100), facecolor=color.desaturated(up * 10))
+        viewer.scene.add(Circle(0.4, Frame([right, up, 0])), linecolor=color.desaturated(up * 10), n=100)
 
-viewer.run()
+viewer.show()

--- a/docs/userguide/samples/obb.py
+++ b/docs/userguide/samples/obb.py
@@ -1,10 +1,12 @@
 from math import radians
 
-from compas.geometry import Pointcloud, Box
+from compas_viewer import Viewer
+
+from compas.colors import Color
+from compas.geometry import Box
+from compas.geometry import Pointcloud
 from compas.geometry import Rotation
 from compas.geometry import oriented_bounding_box
-
-from compas_view2.app import App
 
 cloud = Pointcloud.from_bounds(10, 5, 3, 100)
 
@@ -17,7 +19,7 @@ cloud.transform(Rz * Ry * Rx)
 bbox = oriented_bounding_box(cloud)
 box = Box.from_bounding_box(bbox)
 
-viewer = App()
-viewer.add(cloud)
-viewer.add(box, show_faces=False, linecolor=(1, 0, 0), linewidth=3)
-viewer.run()
+viewer = Viewer()
+viewer.scene.add(cloud)
+viewer.scene.add(box, show_faces=False, linecolor=Color(1, 0, 0), linewidth=3)
+viewer.show()

--- a/docs/userguide/samples/quadmesh_planarize.py
+++ b/docs/userguide/samples/quadmesh_planarize.py
@@ -1,10 +1,13 @@
 # type: ignore
+from compas_viewer import Viewer
+
 import compas
+from compas.colors import Color
+from compas.colors import ColorMap
 from compas.datastructures import Mesh
+# ! mesh_flatness is not available in compas.geometry
 from compas.datastructures import mesh_flatness
 from compas.geometry import quadmesh_planarize
-from compas.colors import Color, ColorMap
-from compas_view2.app import App
 
 mesh = Mesh.from_obj(compas.get("tubemesh.obj"))
 
@@ -22,7 +25,7 @@ for face in mesh.faces():
     else:
         facecolor[face] = Color.red()
 
-viewer = App()
+viewer = Viewer()
 
-viewer.add(mesh, facecolor=facecolor)
-viewer.run()
+viewer.scene.add(mesh, facecolor=facecolor)
+viewer.show()

--- a/src/compas/colors/colormap.py
+++ b/src/compas/colors/colormap.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import os
 
-from compas.utilities import linspace
+from compas.itertools import linspace
 
 from .color import Color
 from .mpl_colormap import _magma_data

--- a/src/compas/datastructures/cell_network/cell_network.py
+++ b/src/compas/datastructures/cell_network/cell_network.py
@@ -34,7 +34,7 @@ from compas.geometry import scale_vector
 from compas.geometry import subtract_vectors
 from compas.geometry import bounding_box
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 from compas.tolerance import TOL
 

--- a/src/compas/datastructures/graph/duality.py
+++ b/src/compas/datastructures/graph/duality.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from math import pi
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from compas.geometry import angle_vectors
 from compas.geometry import is_ccw_xy
 

--- a/src/compas/datastructures/graph/operations/join.py
+++ b/src/compas/datastructures/graph/operations/join.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 from compas.tolerance import TOL
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 def graph_join_edges(graph, key):

--- a/src/compas/datastructures/mesh/mesh.py
+++ b/src/compas/datastructures/mesh/mesh.py
@@ -51,8 +51,8 @@ from compas.geometry import bounding_box
 from compas.geometry import oriented_bounding_box
 from compas.geometry import transform_points
 
-from compas.utilities import linspace
-from compas.utilities import pairwise
+from compas.itertools import linspace
+from compas.itertools import pairwise
 from compas.utilities import window
 
 from compas.topology import breadth_first_traverse

--- a/src/compas/datastructures/mesh/operations/split.py
+++ b/src/compas/datastructures/mesh/operations/split.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 def mesh_split_edge(mesh, edge, t=0.5, allow_boundary=False):

--- a/src/compas/datastructures/mesh/operations/weld.py
+++ b/src/compas/datastructures/mesh/operations/weld.py
@@ -5,7 +5,7 @@ from __future__ import division
 from compas.topology import vertex_adjacency_from_edges
 from compas.topology import connected_components
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 from .substitute import mesh_substitute_vertex_in_faces
 

--- a/src/compas/datastructures/mesh/subdivision.py
+++ b/src/compas/datastructures/mesh/subdivision.py
@@ -10,7 +10,7 @@ from compas.geometry import centroid_points
 from compas.geometry import offset_polygon
 
 from compas.utilities import iterable_like
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 def subd_factory(cls):

--- a/src/compas/datastructures/volmesh/volmesh.py
+++ b/src/compas/datastructures/volmesh/volmesh.py
@@ -36,8 +36,8 @@ from compas.geometry import bounding_box
 from compas.geometry import transform_points
 from compas.geometry import oriented_bounding_box
 
-from compas.utilities import linspace
-from compas.utilities import pairwise
+from compas.itertools import linspace
+from compas.itertools import pairwise
 
 from compas.tolerance import TOL
 

--- a/src/compas/geometry/_core/centroids.py
+++ b/src/compas/geometry/_core/centroids.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from math import fabs
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 from ._algebra import add_vectors
 from ._algebra import subtract_vectors

--- a/src/compas/geometry/_core/distance.py
+++ b/src/compas/geometry/_core/distance.py
@@ -5,7 +5,7 @@ from __future__ import division
 from math import fabs
 from math import sqrt
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from compas.tolerance import TOL
 
 from ._algebra import add_vectors

--- a/src/compas/geometry/_core/size.py
+++ b/src/compas/geometry/_core/size.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from math import fabs
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 from ._algebra import subtract_vectors
 from ._algebra import subtract_vectors_xy

--- a/src/compas/geometry/curves/arc.py
+++ b/src/compas/geometry/curves/arc.py
@@ -97,19 +97,19 @@ class Arc(Curve):
 
     Visualize the arc using the viewer.
 
-    >>> from compas_view2.app import App   # doctest: +SKIP
-    >>> viewer = App()                     # doctest: +SKIP
-    >>> viewer.add(arc.to_polyline(n=20))  # doctest: +SKIP
-    >>> viewer.add(arc.frame)              # doctest: +SKIP
-    >>> viewer.run()                       # doctest: +SKIP
+    >>> from compas_viewer import Viewer   # doctest: +SKIP
+    >>> viewer = Viewer()                     # doctest: +SKIP
+    >>> viewer.scene.add(arc.to_polyline(n=20))  # doctest: +SKIP
+    >>> viewer.scene.add(arc.frame)              # doctest: +SKIP
+    >>> viewer.show()                       # doctest: +SKIP
 
     Visualize only part of the arc.
 
-    >>> from compas_view2.app import App                        # doctest: +SKIP
-    >>> viewer = App()                                          # doctest: +SKIP
-    >>> viewer.add(arc.to_polyline(n=20, domain=(0.25, 0.75)))  # doctest: +SKIP
-    >>> viewer.add(arc.frame)                                   # doctest: +SKIP
-    >>> viewer.run()                                            # doctest: +SKIP
+    >>> from compas_viewer import Viewer                        # doctest: +SKIP
+    >>> viewer = Viewer()                                          # doctest: +SKIP
+    >>> viewer.scene.add(arc.to_polyline(n=20, domain=(0.25, 0.75)))  # doctest: +SKIP
+    >>> viewer.scene.add(arc.frame)                                   # doctest: +SKIP
+    >>> viewer.show()                                            # doctest: +SKIP
 
     """
 

--- a/src/compas/geometry/curves/circle.py
+++ b/src/compas/geometry/curves/circle.py
@@ -78,12 +78,12 @@ class Circle(Conic):
 
     Visualise the line, circle, and frame of the circle with the COMPAS viewer.
 
-    >>> from compas_view2.app import App  # doctest: +SKIP
-    >>> viewer = App()                    # doctest: +SKIP
-    >>> viewer.add(line)                  # doctest: +SKIP
-    >>> viewer.add(circle)                # doctest: +SKIP
-    >>> viewer.add(circle.frame)          # doctest: +SKIP
-    >>> viewer.run()                      # doctest: +SKIP
+    >>> from compas_viewer import Viewer  # doctest: +SKIP
+    >>> viewer = Viewer()                    # doctest: +SKIP
+    >>> viewer.scene.add(line)                  # doctest: +SKIP
+    >>> viewer.scene.add(circle)                # doctest: +SKIP
+    >>> viewer.scene.add(circle.frame)          # doctest: +SKIP
+    >>> viewer.show()                      # doctest: +SKIP
 
     """
 

--- a/src/compas/geometry/curves/curve.py
+++ b/src/compas/geometry/curves/curve.py
@@ -7,7 +7,7 @@ from compas.geometry import Geometry
 from compas.geometry import Transformation
 from compas.geometry import Plane
 from compas.geometry import Frame
-from compas.utilities import linspace
+from compas.itertools import linspace
 
 
 @pluggable(category="factories")

--- a/src/compas/geometry/curves/ellipse.py
+++ b/src/compas/geometry/curves/ellipse.py
@@ -99,12 +99,12 @@ class Ellipse(Conic):
 
     Visualise the line, ellipse, and frame of the ellipse with the COMPAS viewer.
 
-    >>> from compas_view2.app import App  # doctest: +SKIP
-    >>> viewer = App()                    # doctest: +SKIP
-    >>> viewer.add(line)                  # doctest: +SKIP
-    >>> viewer.add(ellipse)               # doctest: +SKIP
-    >>> viewer.add(ellipse.frame)         # doctest: +SKIP
-    >>> viewer.run()                      # doctest: +SKIP
+    >>> from compas_viewer import Viewer  # doctest: +SKIP
+    >>> viewer = Viewer()                    # doctest: +SKIP
+    >>> viewer.scene.add(line)                  # doctest: +SKIP
+    >>> viewer.scene.add(ellipse)               # doctest: +SKIP
+    >>> viewer.scene.add(ellipse.frame)         # doctest: +SKIP
+    >>> viewer.show()                      # doctest: +SKIP
 
     """
 

--- a/src/compas/geometry/curves/hyperbola.py
+++ b/src/compas/geometry/curves/hyperbola.py
@@ -103,12 +103,12 @@ class Hyperbola(Conic):
 
     Visualise the line, hyperbola, and frame of the hyperbola with the COMPAS viewer.
 
-    >>> from compas_view2.app import App  # doctest: +SKIP
-    >>> viewer = App()                    # doctest: +SKIP
-    >>> viewer.add(line)                  # doctest: +SKIP
-    >>> viewer.add(hyperbola)               # doctest: +SKIP
-    >>> viewer.add(hyperbola.frame)         # doctest: +SKIP
-    >>> viewer.run()                      # doctest: +SKIP
+    >>> from compas_viewer import Viewer  # doctest: +SKIP
+    >>> viewer = Viewer()                    # doctest: +SKIP
+    >>> viewer.scene.add(line)                  # doctest: +SKIP
+    >>> viewer.scene.add(hyperbola)               # doctest: +SKIP
+    >>> viewer.scene.add(hyperbola.frame)         # doctest: +SKIP
+    >>> viewer.show()                      # doctest: +SKIP
 
     """
 

--- a/src/compas/geometry/curves/parabola.py
+++ b/src/compas/geometry/curves/parabola.py
@@ -72,12 +72,12 @@ class Parabola(Conic):
 
     Visualize the parabola with the COMPAS viewer.
 
-    >>> from compas_view2.app import App  # doctest: +SKIP
-    >>> viewer = App()                    # doctest: +SKIP
-    >>> viewer.add(line)                  # doctest: +SKIP
-    >>> viewer.add(parabola)              # doctest: +SKIP
-    >>> viewer.add(parabola.frame)        # doctest: +SKIP
-    >>> viewer.run()                      # doctest: +SKIP
+    >>> from compas_viewer import Viewer  # doctest: +SKIP
+    >>> viewer = Viewer()                    # doctest: +SKIP
+    >>> viewer.scene.add(line)                  # doctest: +SKIP
+    >>> viewer.scene.add(parabola)              # doctest: +SKIP
+    >>> viewer.scene.add(parabola.frame)        # doctest: +SKIP
+    >>> viewer.show()                      # doctest: +SKIP
 
     """
 

--- a/src/compas/geometry/curves/polyline.py
+++ b/src/compas/geometry/curves/polyline.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 from compas.geometry import allclose
 from compas.geometry import transform_points

--- a/src/compas/geometry/intersections.py
+++ b/src/compas/geometry/intersections.py
@@ -7,7 +7,7 @@ from math import sqrt
 
 from compas.tolerance import TOL
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from compas.plugins import pluggable
 from compas.plugins import PluginNotInstalledError
 

--- a/src/compas/geometry/offset.py
+++ b/src/compas/geometry/offset.py
@@ -15,7 +15,7 @@ from compas.geometry import is_colinear
 from compas.data.validators import is_item_iterable
 
 from compas.utilities import iterable_like
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 def intersect_lines(l1, l2, tol):

--- a/src/compas/geometry/polygon.py
+++ b/src/compas/geometry/polygon.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import math
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from compas.geometry import allclose
 from compas.geometry import area_polygon
 from compas.geometry import centroid_polygon

--- a/src/compas/geometry/polyhedron.py
+++ b/src/compas/geometry/polyhedron.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from math import sqrt
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from compas.geometry import transform_points
 from compas.geometry import Polygon
 from compas.geometry import Point

--- a/src/compas/geometry/quadmesh_planarize_none.py
+++ b/src/compas/geometry/quadmesh_planarize_none.py
@@ -10,7 +10,7 @@ from compas.geometry import distance_line_line
 from compas.geometry import bestfit_plane
 
 from compas.utilities import window
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 def mesh_flatness(mesh, maxdev=1.0):

--- a/src/compas/geometry/shapes/cone.py
+++ b/src/compas/geometry/shapes/cone.py
@@ -7,7 +7,7 @@ from math import pi
 from math import sin
 from math import sqrt
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from compas.geometry import transform_points
 from compas.geometry import Circle
 from compas.geometry import Plane

--- a/src/compas/geometry/surfaces/nurbs.py
+++ b/src/compas/geometry/surfaces/nurbs.py
@@ -5,7 +5,7 @@ from __future__ import division
 from compas.plugins import pluggable
 from compas.plugins import PluginNotInstalledError
 from compas.geometry import Point
-from compas.utilities import linspace
+from compas.itertools import linspace
 from compas.utilities import meshgrid
 
 from .surface import Surface

--- a/src/compas/geometry/surfaces/surface.py
+++ b/src/compas/geometry/surfaces/surface.py
@@ -9,7 +9,7 @@ from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas.geometry import Point
 from compas.plugins import pluggable
-from compas.utilities import linspace
+from compas.itertools import linspace
 
 
 @pluggable(category="factories")

--- a/src/compas/scene/context.py
+++ b/src/compas/scene/context.py
@@ -93,7 +93,7 @@ def register(item_type, sceneobject_type, context=None):
 
 
 def is_viewer_open():
-    """Returns True if an instance of the compas_view2 App is available.
+    """Returns True if an instance of the compas_viewer is available.
 
     Returns
     -------

--- a/src/compas/topology/connectivity.py
+++ b/src/compas/topology/connectivity.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 def vertex_adjacency_from_edges(edges):

--- a/src/compas/topology/orientation.py
+++ b/src/compas/topology/orientation.py
@@ -5,7 +5,7 @@ from __future__ import division
 import random
 from compas.topology import breadth_first_traverse
 from compas.geometry import centroid_points
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 def _closest_faces(vertices, faces, nmax=10, radius=10.0):

--- a/src/compas_ghpython/utilities/drawing.py
+++ b/src/compas_ghpython/utilities/drawing.py
@@ -23,7 +23,7 @@ from System.Drawing import Color
 from System.Enum import ToObject
 
 from compas.geometry import centroid_points
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from compas_rhino.utilities.drawing import _face_to_max_quad
 
 try:

--- a/src/compas_rhino/conversions/meshes.py
+++ b/src/compas_rhino/conversions/meshes.py
@@ -13,7 +13,7 @@ import System  # type: ignore
 from compas.colors import Color
 from compas.datastructures import Mesh
 from compas.geometry import centroid_polygon
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 from .geometry import vector_to_compas
 
 

--- a/tests/compas/geometry/test_polygon.py
+++ b/tests/compas/geometry/test_polygon.py
@@ -4,7 +4,7 @@ import compas
 from random import random
 from compas.geometry import Point
 from compas.geometry import Polygon
-from compas.utilities import pairwise
+from compas.itertools import pairwise
 
 
 @pytest.mark.parametrize(

--- a/tests/compas/geometry/test_surfaces_cone.py
+++ b/tests/compas/geometry/test_surfaces_cone.py
@@ -8,7 +8,7 @@ from compas.geometry import Vector  # noqa: F401
 from compas.geometry import Frame
 from compas.geometry import ConicalSurface
 from compas.geometry import close
-from compas.utilities import linspace
+from compas.itertools import linspace
 
 
 @pytest.mark.parametrize(

--- a/tests/compas/geometry/test_surfaces_cylinder.py
+++ b/tests/compas/geometry/test_surfaces_cylinder.py
@@ -8,7 +8,7 @@ from compas.geometry import Vector  # noqa: F401
 from compas.geometry import Frame
 from compas.geometry import CylindricalSurface
 from compas.geometry import close
-from compas.utilities import linspace
+from compas.itertools import linspace
 
 
 @pytest.mark.parametrize(

--- a/tests/compas/geometry/test_surfaces_plane.py
+++ b/tests/compas/geometry/test_surfaces_plane.py
@@ -8,7 +8,7 @@ from compas.geometry import Vector  # noqa: F401
 from compas.geometry import Frame
 from compas.geometry import PlanarSurface
 from compas.geometry import close
-from compas.utilities import linspace
+from compas.itertools import linspace
 
 
 @pytest.mark.parametrize(

--- a/tests/compas/geometry/test_surfaces_sphere.py
+++ b/tests/compas/geometry/test_surfaces_sphere.py
@@ -3,7 +3,7 @@ import json
 import compas
 from random import random
 
-from compas.utilities import linspace
+from compas.itertools import linspace
 from compas.geometry import Point  # noqa: F401
 from compas.geometry import Vector  # noqa: F401
 from compas.geometry import Frame

--- a/tests/compas/geometry/test_surfaces_torus.py
+++ b/tests/compas/geometry/test_surfaces_torus.py
@@ -3,7 +3,7 @@ import json
 import compas
 from random import random
 
-from compas.utilities import linspace
+from compas.itertools import linspace
 from compas.geometry import Point  # noqa: F401
 from compas.geometry import Vector  # noqa: F401
 from compas.geometry import Frame


### PR DESCRIPTION
## Major changes
* Changed and update the `compas_view2` examples into `compas_viewer`. Related to https://github.com/compas-dev/compas_viewer/issues/55.

## Tests
All examples are basically tested. Captures:

| ![2024-03-03-17-18-01-46](https://github.com/compas-dev/compas/assets/57562250/a0c5850b-b7a8-4e8f-9285-035230e5e2eb)  | ![2024-03-03-17-18-01-13](https://github.com/compas-dev/compas/assets/57562250/4d619e01-c3ce-4264-9fcd-97bb622dde9a)  |
|  --- | ---  |
| ![2024-03-03-17-18-00-58](https://github.com/compas-dev/compas/assets/57562250/9e741406-65cf-4ad3-8680-f79d0119dff0)  |  ![2024-03-03-17-18-00-46](https://github.com/compas-dev/compas/assets/57562250/b7bbd71e-e56d-4dd3-a806-c338cae1f0ad) |

## Note

`docs\userguide\samples\quadmesh_planarize.py` is invalid since `mesh_flatness` is not available in compas.geometry. separate issue created in #1312 .