### PR TITLE
BUG FIX is_coplanar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed and updated the `compas_view2` examples into `compas_viewer`.
 * Changed `compas.scene.Scene` to inherent from `compas.datastructrues.Tree`.
 * Changed `compas.scene.SceneObject` to inherent from `compas.datastructrues.TreeNode`.
+* Changed `compas.geoemetry._core.predicates_3` bug fix in `is_coplanar` while loop when there are 4 points.
 
 ### Removed
 

--- a/src/compas/geometry/_core/predicates_3.py
+++ b/src/compas/geometry/_core/predicates_3.py
@@ -130,7 +130,7 @@ def is_coplanar(points, tol=None):
 
     temp = points[:]
 
-    while True:
+    while len(temp) >= 3:
         a = temp.pop(0)
         b = temp.pop(0)
         c = temp.pop(0)

--- a/tests/compas/geometry/test_core_predicates_3.py
+++ b/tests/compas/geometry/test_core_predicates_3.py
@@ -1,0 +1,13 @@
+from compas.geometry import is_coplanar
+import pytest
+
+
+def test_is_coplanar():
+
+    # 4 points that are colinear:
+    points = [[0, 0, 0], [0, 1, 0], [0, 2, 0], [0, 4, 0]]
+
+    try:
+        is_coplanar(points)
+    except IndexError:
+        pytest.fail("is_coplanar raised an IndexError")


### PR DESCRIPTION
Little culprit, when there are 4 points, the while loop fails while popping points in predicates_3.py -> is_coplanar. The previous if statement in that method is not enough, which I guess was an initial assumption.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
