### PR TITLE
Limit numpy to less than 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated `compas.geometry.vector.__mul__` to allow element-wise multiplication with another vector.
 * Updated `compas.geometry.vector.__truediv__` to allow element-wise division with another vector.
 * Fixed bug in registration `shapely` boolean plugins.
-* Restrict `numpy` to versions lower than `2.x`.
+* Temporarily restrict `numpy` to versions lower than `2.x`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated `compas.geometry.vector.__mul__` to allow element-wise multiplication with another vector.
 * Updated `compas.geometry.vector.__truediv__` to allow element-wise division with another vector.
 * Fixed bug in registration `shapely` boolean plugins.
+* Restrict `numpy` to versions lower than `2.x`.
 
 ### Removed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # flake8: noqa
 jsonschema
 networkx >= 3.0
-numpy >= 1.15.4
+numpy >= 1.15.4, < 2
 scipy >= 1.1
 watchdog; sys_platform != 'emscripten'


### PR DESCRIPTION
Things are starting to break without this limit.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
