### PR TITLE
Added code coverage report uploads to codecov.io

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,31 @@
+name: coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    if: "!contains(github.event.pull_request.labels.*.name, 'docs-only')"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: ["3.12"]
+
+    steps:
+      - uses: compas-dev/compas-actions.build@v4
+        with:
+          invoke_lint: false
+          invoke_test: false
+          python: ${{ matrix.python }}
+      - name: Run tests collecting coverage reports
+        run: pytest --cov src/compas --cov-report=html
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build:
+  coverage:
     if: "!contains(github.event.pull_request.labels.*.name, 'docs-only')"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added code coverage report uploads to codecov.io.
+
 ### Changed
 
 * Fixed bug in `compas.geometry.curves.curve.Curve.reversed` by adding missing parenthesis.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The COMPAS framework
 
 ![build](https://github.com/compas-dev/compas/workflows/build/badge.svg)
+[![codecov](https://codecov.io/github/compas-dev/compas/graph/badge.svg?token=wpkfew9szQ)](https://codecov.io/github/compas-dev/compas)
 [![GitHub - License](https://img.shields.io/github/license/compas-dev/compas.svg)](https://github.com/compas-dev/compas)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/compas)](https://anaconda.org/conda-forge/compas)
 [![pip downloads](https://img.shields.io/pypi/dm/compas)](https://pypi.python.org/project/COMPAS)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ black >=22.12.0
 bump-my-version
 compas_invocations2
 invoke >=0.14
+pytest-cov
 ruff
 sphinx_compas2_theme
 twine


### PR DESCRIPTION
This adds code coverage reports of the core part of the library (excludes the cad binding packages) using codecov.io. This is how the report will start looking once we merge this into `main`:
![image](https://github.com/compas-dev/compas/assets/933277/6862c5f5-cf11-452b-a556-8309c35ad0e7)


It does not include coverage generated through doctest stuff, but we could add that as well. An open question is whether we'd want to create a `compas-action` for this, or if this is specific for the core only. I tend to think the latter for the time being, and we can move it to an action if this proves to be useful.

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
