### PR TITLE
include object's own frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas_rhino.geometry.curves.new_nurbscurve_from_...` to `nurbscurve_from_...`.
 * Fixed `compas_ghpython` Grasshopper components not included in published pakcage.
 * Chnaged `compas.colors.Color.coerce` to take color as is, if it is already aninstance of `compas.colors.Color`.
+* Fixed a bug in `worldtransformation` of `compas.scene.SceneObject` to include the object's own frame.
 
 ### Removed
 

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -176,7 +176,7 @@ class SceneObject(TreeNode):
     @property
     def worldtransformation(self):
         # type: () -> compas.geometry.Transformation
-        frame_stack = []
+        frame_stack = [self.frame] if self.frame else []
         parent = self.parent
         while parent and not parent.is_root:
             if parent.frame:


### PR DESCRIPTION
@tomvanmele I know we had some discussion on moving responsibility of handling transformation out of Scene. But before we actually do that, there was a mistake here to fix. The `worldtransformation` was not including the object's own frame. This PR is to fix that.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
