### PR TITLE
Testing Tolerance.format_number

### DIFF
--- a/tests/compas/files/test_gltf.py
+++ b/tests/compas/files/test_gltf.py
@@ -179,4 +179,4 @@ def test_gltf_content():
 
 
 # Reset the precision to its default value
-TOL.precision = 3
+TOL.precision = TOL.PRECISION

--- a/tests/compas/files/test_gltf.py
+++ b/tests/compas/files/test_gltf.py
@@ -5,6 +5,7 @@ from compas.files import GLTF
 from compas.files import GLTFContent
 from compas.tolerance import TOL
 
+# Temporary change the global precision in the TOL class to 12
 TOL.precision = 12
 
 BASE_FOLDER = os.path.dirname(__file__)
@@ -175,3 +176,7 @@ def test_gltf_content():
     assert len(node_0.children) == 0
     assert len(content.nodes) == 1
     assert len(scene.nodes) == 1
+
+
+# Reset the precision to its default value
+TOL.precision = 3

--- a/tests/compas/files/test_stl.py
+++ b/tests/compas/files/test_stl.py
@@ -5,6 +5,7 @@ from compas.datastructures import Mesh
 from compas.files import STL
 from compas.tolerance import TOL
 
+# Temporary change the global precision in the TOL class to 12
 TOL.precision = 12
 
 BASE_FOLDER = os.path.dirname(__file__)
@@ -43,3 +44,7 @@ def test_binary_read_write_fidelity():
     mesh_2 = Mesh.from_stl(fp)
     assert mesh.adjacency == mesh_2.adjacency
     assert mesh.vertex == mesh_2.vertex
+
+
+# Reset the precision to its default value
+TOL.precision = 3

--- a/tests/compas/files/test_stl.py
+++ b/tests/compas/files/test_stl.py
@@ -47,4 +47,4 @@ def test_binary_read_write_fidelity():
 
 
 # Reset the precision to its default value
-TOL.precision = 3
+TOL.precision = TOL.PRECISION

--- a/tests/compas/test_tolerance.py
+++ b/tests/compas/test_tolerance.py
@@ -1,6 +1,18 @@
 from compas.tolerance import TOL
+from compas.geometry import Point
 
 
 def test_tolerance_format_number():
     assert TOL.format_number(0, precision=3) == "0.000"
     assert TOL.format_number(0.5, precision=3) == "0.500"
+    assert TOL.format_number(float(0), precision=3) == "0.000"
+
+    # Using default precision
+    assert TOL.format_number(0) == "0.000"
+    assert TOL.format_number(0.5) == "0.500"
+    assert TOL.format_number(float(0)) == "0.000"
+
+
+def test_tolerance_format_point():
+    point = Point(0, 0, 0)
+    assert str(point) == "Point(x=0.000, y=0.000, z=0.000)"

--- a/tests/compas/test_tolerance.py
+++ b/tests/compas/test_tolerance.py
@@ -4,8 +4,8 @@ from compas.geometry import Point
 
 
 def test_tolerance_default_tolerance():
-    TOL.precision == Tolerance.PRECISION
-    TOL.precision == 3
+    assert TOL.precision == Tolerance.PRECISION
+    assert TOL.precision == 3
 
 
 def test_tolerance_format_number():

--- a/tests/compas/test_tolerance.py
+++ b/tests/compas/test_tolerance.py
@@ -1,5 +1,10 @@
 from compas.tolerance import TOL
+from compas.tolerance import Tolerance
 from compas.geometry import Point
+
+
+def test_tolerance_default_tolerance():
+    TOL.precision == Tolerance.PRECISION
 
 
 def test_tolerance_format_number():
@@ -7,7 +12,8 @@ def test_tolerance_format_number():
     assert TOL.format_number(0.5, precision=3) == "0.500"
     assert TOL.format_number(float(0), precision=3) == "0.000"
 
-    # Using default precision
+
+def test_tolerance_format_number_with_default_precision():
     assert TOL.format_number(0) == "0.000"
     assert TOL.format_number(0.5) == "0.500"
     assert TOL.format_number(float(0)) == "0.000"

--- a/tests/compas/test_tolerance.py
+++ b/tests/compas/test_tolerance.py
@@ -1,0 +1,6 @@
+from compas.tolerance import TOL
+
+
+def test_tolerance_format_number():
+    assert TOL.format_number(0, precision=3) == "0.000"
+    assert TOL.format_number(0.5, precision=3) == "0.500"

--- a/tests/compas/test_tolerance.py
+++ b/tests/compas/test_tolerance.py
@@ -5,6 +5,7 @@ from compas.geometry import Point
 
 def test_tolerance_default_tolerance():
     TOL.precision == Tolerance.PRECISION
+    TOL.precision == 3
 
 
 def test_tolerance_format_number():


### PR DESCRIPTION
This is an investigation about TOL.format_number behavior on GitHub CI.

The behavior of the function seems to be unstable across environments.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
