### PR TITLE
Rhino8 scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Changed supported Blender versions to latest LTS versions (3.3, 3.6, 4.2).
+* `compas_rhino.install` with no version specified installs to all available versions of Rhino.
+* For Rhino8, `compas_rhino.install` installs to both IronPython environments (`scripts` + `py27-rh8/Lib/site-packages`).
 
 ### Removed
 
@@ -101,8 +103,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas_rhino.objects.get_polyline_coordinates` to deprecated (removed in v2.3).
 * Changed `compas_rhino.objects.get_polygon_coordinates` to deprecated (removed in v2.3).
 * Fixed a bug in `worldtransformation` of `compas.scene.SceneObject` to include the object's own frame.
-* `compas_rhino.install` with no version specified installs to all available versions of Rhino.
-* `compas_rhino.install` installs to IronPython, IronPython (Old) and CPython environments.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `compas_rhino.objects.get_polyline_coordinates` to deprecated (removed in v2.3).
 * Changed `compas_rhino.objects.get_polygon_coordinates` to deprecated (removed in v2.3).
 * Fixed a bug in `worldtransformation` of `compas.scene.SceneObject` to include the object's own frame.
+* `compas_rhino.install` with no version specified installs to all available versions of Rhino.
+* `compas_rhino.install` installs to IronPython, IronPython (Old) and CPython environments.
 
 ### Removed
 

--- a/docs/userguide/cad.rhino.rst
+++ b/docs/userguide/cad.rhino.rst
@@ -38,8 +38,8 @@ Once the command terminates, you should see a message like this:
 
     ...
 
-The default Rhino version is 8.
-To install into Rhino 7, use the ``-v`` flag.
+By default, installation will be attempted to all available versions of Rhino.
+To install into Rhino 7 only, use the ``-v`` flag.
 
 .. code-block:: bash
 
@@ -248,7 +248,7 @@ However, you can create a Rhino Object in a Rhino Dcocument explicitly from a CO
 .. code-block:: python
 
     import scriptcontext as sc
-    import compas.geometry 
+    import compas.geometry
     import compas_rhino_conversions
 
     point = compas.geometry.Point(...)

--- a/docs/userguide/cad.rhino8.rst
+++ b/docs/userguide/cad.rhino8.rst
@@ -11,6 +11,10 @@ Working in Rhino 8
     The installation procedures listed here are for using COMPAS with CPython in Rhino 8.
     For using COMPAS with IronPython in Rhino 8, see :doc:`/userguide/cad.rhino`.
 
+.. note::
+
+    This page describes how to install COMPAS in Rhino 8 for use with CPython.
+    To install COMPAS for use with IronPython in Rhino 8, follow the procedure in :doc:`/userguide/cad.rhino` and use the appropriate version flag.
 
 Installation
 ============

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ ruff
 sphinx_compas2_theme
 twine
 wheel
+pythonnet

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -275,7 +275,7 @@ def _get_rhino_scripts_path(version):
     scripts_path = os.path.join(appdata, "{}".format(version), "scripts")
 
     if not os.path.exists(scripts_path):
-        raise Exception("The scripts folder does not exist in this location: {}".format(scripts_path))
+        raise ValueError("The scripts folder does not exist in this location: {}".format(scripts_path))
 
     return scripts_path
 
@@ -467,7 +467,7 @@ def _get_default_rhino_cpython_path(version):
         raise Exception("Unsupported platform")
 
     if not os.path.exists(path):
-        path = None
+        raise ValueError("The cpython installation folder for rhino8 {} doesn't exist.".format(version))
 
     return path
 
@@ -494,7 +494,6 @@ def _get_default_rhino_cpython_path_mac(version):
 
 
 def _get_default_rhino_ironpython_sitepackages_path(version, legacy=False):
-    # this should return the path to both
     version = _check_rhino_version(version)
 
     if version != "8.0":
@@ -510,7 +509,7 @@ def _get_default_rhino_ironpython_sitepackages_path(version, legacy=False):
         raise Exception("Unsupported platform.")
 
     if not os.path.exists(path):
-        raise Exception("The default installation folder for rhino8 {} doesn't exist.".format(version))
+        raise ValueError("The default installation folder for rhino8 {} doesn't exist.".format(version))
 
     return path
 
@@ -559,7 +558,7 @@ def _get_default_rhino_cpython_sitepackages_path(version):
         raise Exception("Unsupported platform.")
 
     if not os.path.exists(path):
-        raise Exception("The default installation folder for rhino8 {} doesn't exist.".format(version))
+        raise ValueError("The scripts folder does not exist in this location: {}".format(path))
 
     return path
 
@@ -572,7 +571,7 @@ def _get_default_rhino_cpython_sitepackages_path_mac(version):
 
 def _get_default_rhino_cpython_sitepackages_path_windows(version):
     if version == "8.0":
-        return "{}/.rhinocode/py39-rh8/lib/python3.9/site-packages".format(os.path.expanduser("~"))
+        return "{}/.rhinocode/py39-rh8/Lib/site-packages".format(os.path.expanduser("~"))
     raise NotImplementedError
 
 

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -159,43 +159,6 @@ def _try_remove_bootstrapper(path):
 # =============================================================================
 # =============================================================================
 # =============================================================================
-# Rhino executable
-# =============================================================================
-# =============================================================================
-# =============================================================================
-
-
-# def _get_default_rhino_executable_path(version):
-#     version = _check_rhino_version(version)
-
-#     if compas.WINDOWS:
-#         path = _get_default_rhino_executable_path_windows(version)
-
-#     elif compas.OSX:
-#         path = _get_default_rhino_executable_path_mac(version)
-
-#     else:
-#         raise Exception("Unsupported platform")
-
-#     if not os.path.exists(path):
-#         path = None
-
-#     return path
-
-
-# def _get_default_rhino_executable_path_mac(version):
-#     if version == "8.0":
-#         return "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
-#     raise NotImplementedError
-
-
-# def _get_default_rhino_executable_path_windows(version):
-#     raise NotImplementedError
-
-
-# =============================================================================
-# =============================================================================
-# =============================================================================
 # Base Application folder (Program Files on Windows and Applications on Mac)
 # =============================================================================
 # =============================================================================
@@ -405,41 +368,6 @@ def _get_rhino_grasshopperplugin_path(version):
         raise Exception("The grasshopper folder does not exist in this location: {}".format(gh_path))
 
     return gh_path
-
-
-# =============================================================================
-# =============================================================================
-# =============================================================================
-# Rhino IronPython
-# =============================================================================
-# =============================================================================
-# =============================================================================
-
-
-# def _get_default_rhino_ironpython_path(version):
-#     version = _check_rhino_version(version)
-
-#     if compas.WINDOWS:
-#         path = _get_default_rhino_ironpython_path_windows(version)
-
-#     elif compas.OSX:
-#         path = _get_default_rhino_ironpython_path_mac(version)
-
-#     else:
-#         raise Exception("Unsupported platform")
-
-#     if not os.path.exists(path):
-#         path = None
-
-#     return path
-
-
-# def _get_default_rhino_ironpython_path_mac(version):
-#     raise NotImplementedError
-
-
-# def _get_default_rhino_ironpython_path_windows(version):
-#     raise NotImplementedError
 
 
 # =============================================================================

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -493,17 +493,18 @@ def _get_default_rhino_cpython_path_mac(version):
 # =============================================================================
 
 
-def _get_default_rhino_ironpython_sitepackages_path(version):
+def _get_default_rhino_ironpython_sitepackages_path(version, legacy=False):
+    # this should return the path to both
     version = _check_rhino_version(version)
 
     if version != "8.0":
         raise NotImplementedError
 
     if compas.OSX:
-        path = _get_default_rhino_ironpython_sitepackages_path_mac(version)
+        path = _get_default_rhino_ironpython_sitepackages_path_mac(version, legacy)
 
     elif compas.WINDOWS:
-        path = _get_default_rhino_ironpython_sitepackages_path_windows(version)
+        path = _get_default_rhino_ironpython_sitepackages_path_windows(version, legacy)
 
     else:
         raise Exception("Unsupported platform.")
@@ -514,16 +515,23 @@ def _get_default_rhino_ironpython_sitepackages_path(version):
     return path
 
 
-def _get_default_rhino_ironpython_sitepackages_path_mac(version):
+def _get_default_rhino_ironpython_sitepackages_path_mac(version, legacy):
+    # TODO: is there a distinction between legacy and new IronPython components on Mac?
     if version == "8.0":
         return "{}/.rhinocode/py27-rh8/Lib/site-packages".format(os.path.expanduser("~"))
     raise NotImplementedError
 
 
-def _get_default_rhino_ironpython_sitepackages_path_windows(version):
-    if version == "8.0":
+def _get_default_rhino_ironpython_sitepackages_path_windows(version, legacy):
+    if version != "8.0":
+        raise NotImplementedError
+
+    if legacy:
+        # EditPythonScript & legacy (OLD) IronPython components both look here
+        return "{}/AppData/Roaming/McNeel/Rhinoceros/8.0/scripts".format(os.path.expanduser("~"))
+    else:
+        # New IronPyhton components look here
         return "{}/.rhinocode/py27-rh8/Lib/site-packages".format(os.path.expanduser("~"))
-    raise NotImplementedError
 
 
 # =============================================================================

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -27,18 +27,24 @@ def _make_specs(packages, clean, versions):
     for version in versions:
         try:
             if version == "8.0":
-                ipy_lib_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version, legacy=False)
-                ipy_lib_path_legacy = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version, legacy=True)
-                cpython_lib_path = compas_rhino._get_default_rhino_cpython_sitepackages_path(version)
-                specs.append((ipy_lib_path, version, packages, clean))
-                specs.append((ipy_lib_path_legacy, version, packages, clean))
-                specs.append((cpython_lib_path, version, packages, clean))
+                specs.extend(_make_rhino8_cpython_specs(packages, clean))
             else:
                 path = compas_rhino._get_rhino_scripts_path(version)
                 specs.append((path, version, packages, clean))
         except ValueError as ex:
             print("Install folder for Rhino version {} not found: {}".format(version, str(ex)))
     return specs
+
+
+def _make_rhino8_cpython_specs(packages, clean):
+    ipy_lib_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path("8.0", legacy=False)
+    ipy_lib_path_legacy = compas_rhino._get_default_rhino_ironpython_sitepackages_path("8.0", legacy=True)
+    cpython_lib_path = compas_rhino._get_default_rhino_cpython_sitepackages_path("8.0")
+    return [
+        (ipy_lib_path, "8.0", packages, clean),
+        (ipy_lib_path_legacy, "8.0", packages, clean),
+        (cpython_lib_path, "8.0", packages, clean),
+    ]
 
 
 def _install(installation_path, version=None, packages=None, clean=False):

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -13,6 +13,35 @@ import compas_rhino
 
 
 def install(version=None, packages=None, clean=False):
+    print("install invoked with version: {}".format(version))
+    if version is None:
+        versions = compas_rhino.SUPPORTED_VERSIONS
+    else:
+        versions = [version]
+    for spec in _make_specs(packages, clean, versions):
+        _install(*spec)
+
+
+def _make_specs(packages, clean, versions):
+    specs = []
+    for version in versions:
+        try:
+            if version == "8.0":
+                ipy_lib_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version, legacy=False)
+                ipy_lib_path_legacy = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version, legacy=True)
+                cpython_lib_path = compas_rhino._get_default_rhino_cpython_sitepackages_path(version)
+                specs.append((ipy_lib_path, version, packages, clean))
+                specs.append((ipy_lib_path_legacy, version, packages, clean))
+                specs.append((cpython_lib_path, version, packages, clean))
+            else:
+                path = compas_rhino._get_rhino_scripts_path(version)
+                specs.append((path, version, packages, clean))
+        except ValueError as ex:
+            print("Install folder for Rhino version {} not found: {}".format(version, str(ex)))
+    return specs
+
+
+def _install(installation_path, version=None, packages=None, clean=False):
     """Install COMPAS for Rhino.
 
     Parameters
@@ -47,11 +76,11 @@ def install(version=None, packages=None, clean=False):
     # instead of directly as IPy module.
     # scripts_path = compas_rhino._get_rhino_scripts_path(version)
 
-    # In Rhino 8 there is no scripts folder
-    if version == "8.0":
-        installation_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version)
-    else:
-        installation_path = compas_rhino._get_rhino_scripts_path(version)
+    # # In Rhino 8 there is no scripts folder
+    # if version == "8.0":
+    #     installation_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version)
+    # else:
+    #     installation_path = compas_rhino._get_rhino_scripts_path(version)
 
     # This is for old installs
     ipylib_path = compas_rhino._get_rhino_ironpython_lib_path(version)
@@ -370,7 +399,7 @@ if __name__ == "__main__":
         "-v",
         "--version",
         choices=compas_rhino.SUPPORTED_VERSIONS,
-        default=compas_rhino.DEFAULT_VERSION,
+        # default=compas_rhino.DEFAULT_VERSION,
         help="The version of Rhino to install the packages in.",
     )
     parser.add_argument("-p", "--packages", nargs="+", help="The packages to install.")

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -68,11 +68,9 @@ def _make_specs(packages, clean, versions):
 def _make_rhino8_cpython_specs(packages, clean):
     ipy_lib_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path("8.0", legacy=False)
     ipy_lib_path_legacy = compas_rhino._get_default_rhino_ironpython_sitepackages_path("8.0", legacy=True)
-    cpython_lib_path = compas_rhino._get_default_rhino_cpython_sitepackages_path("8.0")
     return [
         (ipy_lib_path, "8.0", packages, clean),
         (ipy_lib_path_legacy, "8.0", packages, clean),
-        (cpython_lib_path, "8.0", packages, clean),
     ]
 
 

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -13,12 +13,41 @@ import compas_rhino
 
 
 def install(version=None, packages=None, clean=False):
-    print("install invoked with version: {}".format(version))
+    """Install COMPAS for Rhino.
+
+    Parameters
+    ----------
+    version : {'5.0', '6.0', '7.0', '8.0'}, optional
+        The version number of Rhino.
+        When not specified, installation would be attempted for all supported versions.
+    packages : list of str, optional
+        List of packages to install or None to use default package list.
+        Default is the result of ``installable_rhino_packages``,
+        which collects all installable packages in the current environment.
+    clean : bool, optional
+        If True, this will clean up the entire scripts folder and remove
+        also existing symlinks that are not importable in the current environment.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import compas_rhino.install
+
+        compas_rhino.install.install()
+
+    .. code-block:: bash
+
+        python -m compas_rhino.install
+
+    """
     if version is None:
         versions = compas_rhino.SUPPORTED_VERSIONS
     else:
         versions = [version]
+
     for spec in _make_specs(packages, clean, versions):
+        # specs are tuples of (installation_path, version, packages, clean)
         _install(*spec)
 
 
@@ -48,45 +77,11 @@ def _make_rhino8_cpython_specs(packages, clean):
 
 
 def _install(installation_path, version=None, packages=None, clean=False):
-    """Install COMPAS for Rhino.
-
-    Parameters
-    ----------
-    version : {'5.0', '6.0', '7.0', '8.0'}, optional
-        The version number of Rhino.
-        Default is ``'7.0'``.
-    packages : list of str, optional
-        List of packages to install or None to use default package list.
-        Default is the result of ``installable_rhino_packages``,
-        which collects all installable packages in the current environment.
-    clean : bool, optional
-        If True, this will clean up the entire scripts folder and remove
-        also existing symlinks that are not importable in the current environment.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        import compas_rhino.install
-
-        compas_rhino.install.install()
-
-    .. code-block:: bash
-
-        python -m compas_rhino.install
-
-    """
     version = compas_rhino._check_rhino_version(version)
 
     # We install COMPAS packages in the scripts folder
     # instead of directly as IPy module.
     # scripts_path = compas_rhino._get_rhino_scripts_path(version)
-
-    # # In Rhino 8 there is no scripts folder
-    # if version == "8.0":
-    #     installation_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version)
-    # else:
-    #     installation_path = compas_rhino._get_rhino_scripts_path(version)
 
     # This is for old installs
     ipylib_path = compas_rhino._get_rhino_ironpython_lib_path(version)
@@ -405,8 +400,7 @@ if __name__ == "__main__":
         "-v",
         "--version",
         choices=compas_rhino.SUPPORTED_VERSIONS,
-        # default=compas_rhino.DEFAULT_VERSION,
-        help="The version of Rhino to install the packages in.",
+        help="The version of Rhino to install the packages in. If not specified, all supported versions will be attempted.",
     )
     parser.add_argument("-p", "--packages", nargs="+", help="The packages to install.")
     parser.add_argument("-c", "--clean", default=False, action="store_true", help="Clean up the installation directory")

--- a/tasks.py
+++ b/tasks.py
@@ -22,6 +22,7 @@ ns = Collection(
     build.clean,
     build.release,
     build.build_ghuser_components,
+    build.build_cpython_ghuser_components,
 )
 ns.configure(
     {


### PR DESCRIPTION
> The installer will not install using symlinks for CPython in Rhino8. `pip` shall be used for that.

* For Rhino8, install compas using symlinks in both IronPython locations (IronPython, IronPython legacy).
* In no version is specified, install for all available versions.
* Added the new cpython componentizer to `tasks.py` (and the required `pythonnet` to `requirements-dev.txt`).

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
