### PR TITLE
Fix `Draw` component for GH 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed args for `SceneObject` on Grasshopper `Draw` component.
+
 ### Removed
 
 

--- a/src/compas_ghpython/components/Compas_ToRhinoGeometry/code.py
+++ b/src/compas_ghpython/components/Compas_ToRhinoGeometry/code.py
@@ -12,4 +12,4 @@ class CompasToRhinoGeometry(component):
         if not cg:
             return None
 
-        return SceneObject(cg).draw()
+        return SceneObject(item=cg).draw()


### PR DESCRIPTION
I think the changes in scene/sceneobject's positional vs kwargs params affected this, the error message was quite odd, but indicated that it was getting a `None` for `item`.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
