### PR TITLE
Fix Mesh.face_circle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed args for `SceneObject` on Grasshopper `Draw` component.
 * Replaced use of `Rhino.Geometry.VertexColors.SetColors` with a for loop and `SetColor` in `compas_ghpyton` since the former requires a `System.Array`.
+* Fixed `Mesh.face_circle`.
 
 ### Removed
 

--- a/src/compas/datastructures/mesh/mesh.py
+++ b/src/compas/datastructures/mesh/mesh.py
@@ -4542,7 +4542,7 @@ class Mesh(Datastructure):
         from compas.geometry import bestfit_circle_numpy
 
         point, normal, radius = bestfit_circle_numpy(self.face_coordinates(face))
-        return Circle((point, normal), radius)
+        return Circle.from_plane_and_radius(Plane(point, normal), radius)
 
     def face_frame(self, face):
         """The frame of a face.


### PR DESCRIPTION
Fixed Mesh.face_circle that was not set with matching function and input.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
