### PR TITLE
Fix Graph.from_edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed args for `SceneObject` on Grasshopper `Draw` component.
 * Replaced use of `Rhino.Geometry.VertexColors.SetColors` with a for loop and `SetColor` in `compas_ghpyton` since the former requires a `System.Array`.
 * Fixed `Mesh.face_circle`.
+* Fixed `Graph.from_edges`.
 
 ### Removed
 

--- a/src/compas/datastructures/graph/graph.py
+++ b/src/compas/datastructures/graph/graph.py
@@ -205,6 +205,7 @@ class Graph(Datastructure):
             if v not in graph.node:
                 graph.add_node(v)
             graph.add_edge(u, v)
+        return graph
 
     @classmethod
     def from_networkx(cls, graph):


### PR DESCRIPTION
Constructor from_edges for Graph was not returning the graph

Bug fix in a **backwards-compatible** manner.


- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
