### PR TITLE
Unload modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `RuntimeError` when using `compas_rhino.unload_modules` in CPython`. 
+
 ### Removed
 
 

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -75,7 +75,7 @@ def unload_modules(top_level_module_name):
     list
         List of unloaded module names.
     """
-    modules = filter(lambda m: m.startswith(top_level_module_name), sys.modules)
+    modules = [name for name in sys.modules if name.startswith(top_level_module_name)]
 
     for module in modules:
         sys.modules.pop(module)

--- a/src/compas_rhino/__init__.py
+++ b/src/compas_rhino/__init__.py
@@ -75,12 +75,12 @@ def unload_modules(top_level_module_name):
     list
         List of unloaded module names.
     """
-    modules = [name for name in sys.modules if name.startswith(top_level_module_name)]
+    to_remove = [name for name in sys.modules if name.startswith(top_level_module_name)]
 
-    for module in modules:
+    for module in to_remove:
         sys.modules.pop(module)
 
-    return modules
+    return to_remove
 
 
 def clear(guids=None):


### PR DESCRIPTION
Small change in `compas_rhino.unload_modules` as the filter generator causes a `RuntimeError: dictionary changed size during iteration` in CPython.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
