### PR TITLE
fixed Sphere._vertices used before populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `NoneType` error when calling `compas.geometry.Sphere.edges`.
+
 ### Removed
 
 

--- a/src/compas/geometry/shapes/capsule.py
+++ b/src/compas/geometry/shapes/capsule.py
@@ -297,7 +297,7 @@ class Capsule(Shape):
         if v % 2 == 1:
             v += 1
 
-        vertices = self._vertices
+        vertices = self.vertices
 
         faces = []
 

--- a/src/compas/geometry/shapes/cone.py
+++ b/src/compas/geometry/shapes/cone.py
@@ -267,7 +267,7 @@ class Cone(Shape):
         list[list[int]]
 
         """
-        vertices = self._vertices
+        vertices = self.vertices
 
         faces = []
         first = 0

--- a/src/compas/geometry/shapes/cylinder.py
+++ b/src/compas/geometry/shapes/cylinder.py
@@ -267,7 +267,7 @@ class Cylinder(Shape):
         """
         u = self.resolution_u
 
-        vertices = self._vertices
+        vertices = self.vertices
 
         faces = []
         # side faces

--- a/src/compas/geometry/shapes/sphere.py
+++ b/src/compas/geometry/shapes/sphere.py
@@ -218,7 +218,7 @@ class Sphere(Shape):
         u = self.resolution_u
         v = self.resolution_v
 
-        vertices = self._vertices
+        vertices = self.vertices
 
         faces = []
 

--- a/tests/compas/geometry/test_capsule.py
+++ b/tests/compas/geometry/test_capsule.py
@@ -1,0 +1,16 @@
+import pytest
+
+from compas.geometry import Capsule
+
+
+@pytest.fixture
+def capsule():
+    return Capsule(123.0, 13.0)
+
+
+def test_capsule_discretization(capsule):
+    # just checking these don't break. Could not quickly find a formula that worked to test the actual values
+    # as function of the resolution
+    assert capsule.edges
+    assert capsule.faces
+    assert capsule.vertices

--- a/tests/compas/geometry/test_cone.py
+++ b/tests/compas/geometry/test_cone.py
@@ -1,0 +1,16 @@
+import pytest
+
+from compas.geometry import Cone
+
+
+@pytest.fixture
+def cone():
+    return Cone(432.0, 123.0)
+
+
+def test_cone_discretization(cone):
+    # just checking these don't break. Could not quickly find a formula that worked to test the actual values
+    # as function of the resolution
+    assert cone.edges
+    assert cone.faces
+    assert cone.vertices

--- a/tests/compas/geometry/test_cylinder.py
+++ b/tests/compas/geometry/test_cylinder.py
@@ -1,0 +1,15 @@
+import pytest
+from compas.geometry import Cylinder
+
+
+@pytest.fixture
+def cylinder():
+    return Cylinder(radius=0.3, height=1.6)
+
+
+def test_cylinder_discretization(cylinder):
+    # just checking these don't break. Could not quickly find a formula that worked to test the actual values
+    # as function of the resolution
+    assert cylinder.edges
+    assert cylinder.faces
+    assert cylinder.vertices

--- a/tests/compas/geometry/test_shpere.py
+++ b/tests/compas/geometry/test_shpere.py
@@ -1,0 +1,15 @@
+import pytest
+
+from compas.geometry import Frame
+from compas.geometry import Sphere
+
+
+@pytest.fixture
+def sphere():
+    return Sphere(450.0, Frame.worldXY())
+
+
+def test_sphere_discretization(sphere):
+    assert len(sphere.edges) == 496
+    assert len(sphere.faces) == 256
+    assert len(sphere.vertices) == 242

--- a/tests/compas/geometry/test_shpere.py
+++ b/tests/compas/geometry/test_shpere.py
@@ -10,6 +10,10 @@ def sphere():
 
 
 def test_sphere_discretization(sphere):
-    assert len(sphere.edges) == 496
-    assert len(sphere.faces) == 256
-    assert len(sphere.vertices) == 242
+    expected_face_count = sphere.resolution_v * sphere.resolution_u
+    expected_vertex_count = (sphere.resolution_v - 1) * sphere.resolution_u + 2
+    expected_edge_count = expected_face_count * 2 - sphere.resolution_u
+
+    assert len(sphere.edges) == expected_edge_count
+    assert len(sphere.faces) == expected_face_count
+    assert len(sphere.vertices) == expected_vertex_count


### PR DESCRIPTION
Small fix in `Sphere` of issue causing `Sphere.edges` and `Sphere.faces` to fail if calls before first call to `Sphere.vertices`.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
