### PR TITLE
Trim vertices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added attribute `start_vertex` to `compas.geometry.BrepTrim`.
+* Added attribute `end_vertex` to `compas.geometry.BrepTrim`.
+* Added attribute `vertices` to `compas.geometry.BrepTrim`.
+* Added attribute `start_vertex` to `compas_rhino.geometry.RhinoBrepTrim`.
+* Added attribute `start_vertex` to `compas_rhino.geometry.RhinoBrepTrim`.
+* Added attribute `vertices` to `compas_rhino.geometry.RhinoBrepTrim`.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Added support for `Polyline` as input for `compas_rhino.Brep.from_extrusion`.
+
 ### Removed
 
 

--- a/src/compas/geometry/brep/brep.py
+++ b/src/compas/geometry/brep/brep.py
@@ -392,7 +392,7 @@ class Brep(Geometry):
 
         Parameters
         ----------
-        curve : :class:`compas.geometry.Curve`
+        curve : :class:`compas.geometry.Curve` or :class:`compas.geometry.Polyline`
             The curve to extrude
         vector : :class:`compas.geometry.Vector`
             The vector to extrude the curve by

--- a/src/compas/geometry/brep/trim.py
+++ b/src/compas/geometry/brep/trim.py
@@ -26,6 +26,11 @@ class BrepTrim(Data):
         True if this trim is reversed from its associated edge curve and False otherwise.
     native_trim : Any
         The underlying trim object. Type is backend-dependent.
+    start_vertex : Any, read-only
+        The start vertex of this trim.
+    end_vertex : Any, read-only
+        The end vertex of this trim.
+    vertices : list[Any], read-only
 
     """
 
@@ -43,4 +48,16 @@ class BrepTrim(Data):
 
     @property
     def native_trim(self):
+        raise NotImplementedError
+
+    @property
+    def start_vertex(self):
+        raise NotImplementedError
+
+    @property
+    def end_vertex(self):
+        raise NotImplementedError
+
+    @property
+    def vertices(self):
         raise NotImplementedError

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -10,6 +10,7 @@ from compas.geometry import BrepTrimmingError
 from compas.geometry import Frame
 from compas.geometry import Plane
 from compas.geometry import Point
+from compas.geometry import Polyline
 from compas.tolerance import TOL
 from compas_rhino.conversions import box_to_rhino
 from compas_rhino.conversions import curve_to_compas
@@ -19,6 +20,7 @@ from compas_rhino.conversions import mesh_to_compas
 from compas_rhino.conversions import mesh_to_rhino
 from compas_rhino.conversions import plane_to_rhino
 from compas_rhino.conversions import point_to_rhino
+from compas_rhino.conversions import polyline_to_rhino_curve
 from compas_rhino.conversions import sphere_to_rhino
 from compas_rhino.conversions import transformation_to_rhino
 from compas_rhino.conversions import vector_to_rhino
@@ -223,7 +225,7 @@ class RhinoBrep(Brep):
 
         Parameters
         ----------
-        curve : :class:`~compas.geometry.Curve`
+        curve : :class:`~compas.geometry.Curve` or :class:`~compas.geometry.Polyline`
             The curve to extrude.
         vector : :class:`~compas.geometry.Vector`
             The vector to extrude the curve along.
@@ -235,7 +237,11 @@ class RhinoBrep(Brep):
         :class:`~compas_rhino.geometry.RhinoBrep`
 
         """
-        extrusion = Rhino.Geometry.Surface.CreateExtrusion(curve_to_rhino(curve), vector_to_rhino(vector))
+        if isinstance(curve, Polyline):
+            rhino_curve = polyline_to_rhino_curve(curve)
+        else:
+            rhino_curve = curve_to_rhino(curve)
+        extrusion = Rhino.Geometry.Surface.CreateExtrusion(rhino_curve, vector_to_rhino(vector))
         if extrusion is None:
             raise BrepError("Failed to create extrusion from curve: {} and vector: {}".format(curve, vector))
         rhino_brep = extrusion.ToBrep()


### PR DESCRIPTION
Two small, seemingly unrelated, changes:
* Added vertex properties to `BrepTrim` so that face vertices can be traversed in order.
* Added support for `Polyline` as input for `Brep.from_extrusion`. 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
