### PR TITLE
add implementation of fillet edges to brep

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -40,3 +40,4 @@
 - Joelle Baehr-Bruyere <<joelle.baehr-bruyere@epfl.ch>> [@baehrjo](https://github.com/baehrjo)
 - Adam Anouar <<aanouar@student.ethz.ch>> [@AdamAnouar](https://github.com/AdamAnouar)
 - Joseph Kenny <<kenny@arch.ethz.ch>> [@jckenny59](https://github.com/jckenny59)
+- Panayiotis Papacharalambous <<papacharalambous@arch.ethz.ch>> [@papachap](https://github.com/papachap)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `native_edge` property of `RhinoBrepEdge`.
+
 ### Removed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added implementation of `RhinoBrep.fillet()` and `RhinoBrep.filleted()` to `compas_rhino`.
+
 ### Changed
 
 ### Removed

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -625,9 +625,10 @@ class RhinoBrep(Brep):
             If the fillet operation fails.
 
         """
-        excluded_indices = [edge.native_edge.EdgeIndex for edge in edges] if edges else []
+        all_edge_indices = set(edge.native_edge.EdgeIndex for edge in self.edges)
+        excluded_indices = set(edge.native_edge.EdgeIndex for edge in edges or [])
 
-        edge_indices = [i for i in range(len(self.edges)) if i not in excluded_indices]
+        edge_indices = all_edge_indices - excluded_indices
         radii = [radius] * len(edge_indices)
         blend = Rhino.Geometry.BlendType.Fillet
         rail = Rhino.Geometry.RailType.DistanceFromEdge

--- a/src/compas_rhino/geometry/brep/edge.py
+++ b/src/compas_rhino/geometry/brep/edge.py
@@ -115,7 +115,7 @@ class RhinoBrepEdge(BrepEdge):
 
     @property
     def native_edge(self):
-        return self._native_edge
+        return self._edge
 
     @native_edge.setter
     def native_edge(self, value):


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?
Adds `fillet` and `filleted` methods to `RhinoBrep` for edge filleting in the Rhino backend.

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
