### PR TITLE
removed call to __init__ in __new__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed cannot copy `Line` using `deepcopy`.
+
 ### Removed
 
 

--- a/src/compas/geometry/curves/line.py
+++ b/src/compas/geometry/curves/line.py
@@ -69,9 +69,7 @@ class Line(Curve):
     # overwriting the __new__ method is necessary
     # to avoid triggering the plugin mechanism of the base curve class
     def __new__(cls, *args, **kwargs):
-        curve = object.__new__(cls)
-        curve.__init__(*args, **kwargs)
-        return curve
+        return object.__new__(cls)
 
     DATASCHEMA = {
         "type": "object",

--- a/tests/compas/geometry/test_curves_line.py
+++ b/tests/compas/geometry/test_curves_line.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import pytest
 import json
 import compas
@@ -282,3 +283,17 @@ def test_line_flip(p1, p2):
     flipped_line = Line(p1, p2).flipped()
     assert TOL.is_zero(distance_point_point(flipped_line.start, p2))
     assert TOL.is_zero(distance_point_point(flipped_line.end, p1))
+
+
+def test_line_copy_deepcopy():
+    line = Line([0, 0, 0], [1, 0, 0])
+
+    line_copy = line.copy()
+
+    assert line is not line_copy
+    assert line == line_copy
+
+    line_deepcopy = deepcopy(line)
+
+    assert line is not line_deepcopy
+    assert line == line_deepcopy


### PR DESCRIPTION
Removed call to `__init__` in `Line.__new__` as it was causing deepcopying of `Line` to fail.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
