### PR TITLE
Removed `compas_rhino.install` v8 flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Deprecated the `-v8.0` flag in `compas_rhino.install`. Install to Rhino8 by following: https://compas.dev/compas/latest/userguide/cad.rhino8.html.
+
 ### Removed
 
 

--- a/src/compas_rhino/install.py
+++ b/src/compas_rhino/install.py
@@ -17,7 +17,7 @@ def install(version=None, packages=None, clean=False):
 
     Parameters
     ----------
-    version : {'5.0', '6.0', '7.0', '8.0'}, optional
+    version : {'5.0', '6.0', '7.0'}, optional
         The version number of Rhino.
         Default is ``'7.0'``.
     packages : list of str, optional
@@ -47,9 +47,8 @@ def install(version=None, packages=None, clean=False):
     # instead of directly as IPy module.
     # scripts_path = compas_rhino._get_rhino_scripts_path(version)
 
-    # In Rhino 8 there is no scripts folder
     if version == "8.0":
-        installation_path = compas_rhino._get_default_rhino_ironpython_sitepackages_path(version)
+        raise ValueError("Installing to Rhino8 using this script is no longer supported. See https://compas.dev/compas/latest/userguide/cad.rhino8.html")
     else:
         installation_path = compas_rhino._get_rhino_scripts_path(version)
 


### PR DESCRIPTION
Part of https://github.com/compas-dev/compas/issues/1351.

Removing support for the `v8.0` flag from `compas_rhino.install` to alleviate some of the confusion around using COMPAS in Rhino8.

The supported procedure is https://compas.dev/compas/latest/userguide/cad.rhino8.html.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
