### PR TITLE
added frame_at to BrepFace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added method `frame_at` to `compas.geometry.BrepFace`,
+* Added method `frame_at` to `compas_rhino.geometry.RhinoBrepFace`,
+
 ### Changed
 
 ### Removed

--- a/src/compas/geometry/brep/face.py
+++ b/src/compas/geometry/brep/face.py
@@ -292,6 +292,24 @@ class BrepFace(Data):
         """
         raise NotImplementedError
 
+    def frame_at(self, u, v):
+        """Returns the frame at the given uv parameters.
+
+        Parameters
+        ----------
+        u : float
+            The u parameter.
+        v : float
+            The v parameter.
+
+        Returns
+        -------
+        :class:`compas.geometry.Frame`
+            The frame at the given uv parameters.
+
+        """
+        raise NotImplementedError
+
     def try_get_nurbssurface(
         self,
         precision,

--- a/src/compas_rhino/geometry/brep/face.py
+++ b/src/compas_rhino/geometry/brep/face.py
@@ -300,4 +300,7 @@ class RhinoBrepFace(BrepFace):
             The frame at the given uv parameters.
 
         """
-        return plane_to_compas_frame(self._face.FrameAt(u, v))
+        success, rhino_plane = self._face.FrameAt(u, v)
+        if not success:
+            raise ValueError("Failed to get frame at uv parameters: ({},{}).".format(u, v))
+        return plane_to_compas_frame(rhino_plane)

--- a/src/compas_rhino/geometry/brep/face.py
+++ b/src/compas_rhino/geometry/brep/face.py
@@ -283,3 +283,21 @@ class RhinoBrepFace(BrepFace):
 
         """
         return Brep.from_native(self._face.ToBrep())
+
+    def frame_at(self, u, v):
+        """Returns the frame at the given uv parameters.
+
+        Parameters
+        ----------
+        u : float
+            The u parameter.
+        v : float
+            The v parameter.
+
+        Returns
+        -------
+        :class:`compas.geometry.Frame`
+            The frame at the given uv parameters.
+
+        """
+        return plane_to_compas_frame(self._face.FrameAt(u, v))


### PR DESCRIPTION
* Added `BrepFace.frame_at()` to interface + Rhino implementation.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
