### PR TITLE
added is_reversed to BrepFace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added method `frame_at` to `compas.geometry.BrepFace`,
-* Added method `frame_at` to `compas_rhino.geometry.RhinoBrepFace`,
+* Added method `frame_at` to `compas.geometry.BrepFace`.
+* Added method `frame_at` to `compas_rhino.geometry.RhinoBrepFace`.
+* Added property `is_reversed` to `compas.geometry.BrepFace`.
+* Added property `is_reversed` to `compas_rhino.geometry.RhinoBrepFace`.
 
 ### Changed
 

--- a/src/compas/geometry/brep/face.py
+++ b/src/compas/geometry/brep/face.py
@@ -41,6 +41,8 @@ class BrepFace(Data):
         Returns True if this face is a sphere, False otherwise.
     is_torus : bool, read-only
         Returns True if this face is a torus, False otherwise.
+    is_reversed : bool, read-only
+        True if the orientation of this face is reversed, False otherwise.
     is_valid : bool, read-only
         Return True if this face is valid, False otherwise.
     loops : list[:class:`compas.geometry.BrepLoop`], read-only
@@ -117,6 +119,10 @@ class BrepFace(Data):
 
     @property
     def centroid(self):
+        raise NotImplementedError
+
+    @property
+    def is_reversed(self):
         raise NotImplementedError
 
     @property

--- a/src/compas_rhino/geometry/brep/face.py
+++ b/src/compas_rhino/geometry/brep/face.py
@@ -40,6 +40,8 @@ class RhinoBrepFace(BrepFace):
         The list of loops which comprise the holes of this brep, if any.
     is_plane : float, read-only
         True if the geometry of this face is a plane, False otherwise.
+    is_reversed : bool, read-only
+        True if the orientation of this face is reversed, False otherwise.
     native_face : :class:`Rhino.Geometry.BrepFace`
         The underlying BrepFace object.
 
@@ -151,6 +153,10 @@ class RhinoBrepFace(BrepFace):
     @property
     def is_torus(self):
         return self._face.UnderlyingSurface().IsTorus()
+
+    @property
+    def is_reversed(self):
+        return self._face.OrientationIsReversed
 
     @property
     def native_face(self):


### PR DESCRIPTION
* Added `is_reversed` to check if orientation of a face has been reversed.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
