### PR TITLE
fixed unexpected behavior for opposite parallel planes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Fixed unexpected behavior for method `Plane.is_parallel` for opposite normals.
 
 ### Added
 

--- a/src/compas/geometry/plane.py
+++ b/src/compas/geometry/plane.py
@@ -390,9 +390,7 @@ class Plane(Geometry):
         True
 
         """
-        is_parallel = TOL.is_close(self.normal.dot(other.normal), 1, rtol=0, atol=tol)
-        is_parallel_neg = TOL.is_close(self.normal.dot(other.normal), -1, rtol=0, atol=tol)
-        return is_parallel or is_parallel_neg
+        return TOL.is_close(abs(self.normal.dot(other.normal)), 1, rtol=0, atol=tol)
 
     def is_perpendicular(self, other, tol=None):
         """Verify if this plane is perpendicular to another plane.

--- a/src/compas/geometry/plane.py
+++ b/src/compas/geometry/plane.py
@@ -384,9 +384,15 @@ class Plane(Geometry):
         >>> plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, 1.0])
         >>> plane1.is_parallel(plane2)
         True
+        >>> plane1 = Plane.worldXY()
+        >>> plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, -1.0])
+        >>> plane1.is_parallel(plane2)
+        True
 
         """
-        return TOL.is_close(self.normal.dot(other.normal), 1, rtol=0, atol=tol)
+        is_parallel = TOL.is_close(self.normal.dot(other.normal), 1, rtol=0, atol=tol)
+        is_parallel_neg =  TOL.is_close(self.normal.dot(other.normal), -1, rtol=0, atol=tol)
+        return is_parallel or is_parallel_neg
 
     def is_perpendicular(self, other, tol=None):
         """Verify if this plane is perpendicular to another plane.

--- a/src/compas/geometry/plane.py
+++ b/src/compas/geometry/plane.py
@@ -384,9 +384,15 @@ class Plane(Geometry):
         >>> plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, 1.0])
         >>> plane1.is_parallel(plane2)
         True
+        >>> plane1 = Plane.worldXY()
+        >>> plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, -1.0])
+        >>> plane1.is_parallel(plane2)
+        True
 
         """
-        return TOL.is_close(self.normal.dot(other.normal), 1, rtol=0, atol=tol)
+        is_parallel = TOL.is_close(self.normal.dot(other.normal), 1, rtol=0, atol=tol)
+        is_parallel_neg = TOL.is_close(self.normal.dot(other.normal), -1, rtol=0, atol=tol)
+        return is_parallel or is_parallel_neg
 
     def is_perpendicular(self, other, tol=None):
         """Verify if this plane is perpendicular to another plane.

--- a/src/compas_ghpython/components_cpython/Compas_Info/code.py
+++ b/src/compas_ghpython/components_cpython/Compas_Info/code.py
@@ -3,9 +3,10 @@
 Displays information about the active COMPAS environment.
 """
 
+import os
+
 import Grasshopper
 
-import os
 import compas
 
 

--- a/tests/compas/geometry/test_plane.py
+++ b/tests/compas/geometry/test_plane.py
@@ -76,3 +76,13 @@ def test_plane_from_three_points():
 
     result = Plane.from_three_points(pt1, pt2, pt3)
     assert result == ([0, 0, 0], [0, 0, 1])
+    
+def test_plane_is_parallel():
+    plane1 = Plane.worldXY()
+    plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, 1.0])
+    assert plane1.is_parallel(plane2)
+    
+    plane1 = Plane.worldXY()
+    plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, -1.0])
+    assert plane1.is_parallel(plane2)
+    

--- a/tests/compas/geometry/test_plane.py
+++ b/tests/compas/geometry/test_plane.py
@@ -76,13 +76,13 @@ def test_plane_from_three_points():
 
     result = Plane.from_three_points(pt1, pt2, pt3)
     assert result == ([0, 0, 0], [0, 0, 1])
-    
+
+
 def test_plane_is_parallel():
     plane1 = Plane.worldXY()
     plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, 1.0])
     assert plane1.is_parallel(plane2)
-    
+
     plane1 = Plane.worldXY()
     plane2 = Plane([1.0, 1.0, 1.0], [0.0, 0.0, -1.0])
     assert plane1.is_parallel(plane2)
-    


### PR DESCRIPTION
`Plane.is_parallel()` does not check for opposite normals and thus returns False for this edge case. 

Not the most elegant fix due to the `TOL.is_close()` hope it's fine like this..

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
