### PR TITLE
Update relation between frame and transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed `SceneObject.worldtransformation` to the multiplication of all transformations from the scene object to the root of the scene tree.
+* Changed `SceneObject.frame` to read-only result of `Frame.from_transformation(SceneObject.worldtransformation)`, representing the local coordinate system of the scene object in world coordinates.
+
 ### Removed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Changed `SceneObject.worldtransformation` to the multiplication of all transformations from the scene object to the root of the scene tree.
 * Changed `SceneObject.frame` to read-only result of `Frame.from_transformation(SceneObject.worldtransformation)`, representing the local coordinate system of the scene object in world coordinates.
-
-### Removed
+* Changed `SceneObject.worldtransformation` to the multiplication of all transformations from the scene object to the root of the scene tree, there will no longer be an additional transformation in relation to the object's frame.
 
 
 ## [2.10.0] 2025-03-03

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -13,6 +13,7 @@ import compas.scene  # noqa: F401
 from compas.colors import Color
 from compas.data import Data
 from compas.datastructures import TreeNode
+from compas.geometry import Frame
 from compas.geometry import Transformation
 
 from .context import clear
@@ -36,10 +37,8 @@ class SceneObject(TreeNode):
         The opacity of the object.
     show : bool, optional
         Flag for showing or hiding the object. Default is ``True``.
-    frame : :class:`compas.geometry.Frame`, optional
-        The local frame of the scene object, in relation to its parent frame.
     transformation : :class:`compas.geometry.Transformation`, optional
-        The local transformation of the scene object in relation to its frame.
+        The local transformation of the scene object in relation to its parent object.
     context : str, optional
         The context in which the scene object is created.
     **kwargs : dict
@@ -56,9 +55,9 @@ class SceneObject(TreeNode):
     guids : list[object]
         The GUIDs of the items drawn in the visualization context.
     frame : :class:`compas.geometry.Frame`
-        The local frame of the scene object, in relation to its parent frame.
+        The frame of the local coordinate system of the scene object.
     transformation : :class:`compas.geometry.Transformation`
-        The local transformation of the scene object in relation to its frame.
+        The local transformation of the scene object in relation to its parent object.
     worldtransformation : :class:`compas.geometry.Transformation`
         The transformation of the scene object in world coordinates.
     color : :class:`compas.colors.Color`
@@ -113,7 +112,6 @@ class SceneObject(TreeNode):
         self._item = item
         self._guids = []
         self._node = None
-        self._frame = frame
         self._transformation = transformation
         self._contrastcolor = None
         self.color = color or self.color
@@ -156,12 +154,7 @@ class SceneObject(TreeNode):
     @property
     def frame(self):
         # type: () -> compas.geometry.Frame | None
-        return self._frame
-
-    @frame.setter
-    def frame(self, frame):
-        # type: (compas.geometry.Frame) -> None
-        self._frame = frame
+        return Frame.from_transformation(self.worldtransformation)
 
     @property
     def transformation(self):
@@ -176,20 +169,16 @@ class SceneObject(TreeNode):
     @property
     def worldtransformation(self):
         # type: () -> compas.geometry.Transformation
-        frame_stack = [self.frame] if self.frame else []
-        parent = self.parent
+        transformations = [self.transformation] if self.transformation else []
+        parent: SceneObject = self.parent
         while parent and not parent.is_root:
-            if parent.frame:
-                frame_stack.append(parent.frame)
+            if parent.transformation:
+                transformations.append(parent.transformation)
             parent = parent.parent
-        matrices = [Transformation.from_frame(f) for f in frame_stack]
-        if matrices:
-            worldtransformation = reduce(mul, matrices[::-1])
+        if transformations:
+            worldtransformation = reduce(mul, transformations[::-1])
         else:
             worldtransformation = Transformation()
-
-        if self.transformation:
-            worldtransformation *= self.transformation
 
         return worldtransformation
 

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -169,8 +169,9 @@ class SceneObject(TreeNode):
     @property
     def worldtransformation(self):
         # type: () -> compas.geometry.Transformation
+        # NOTE: Behaviour change from 2.11.0, there will no longer be the option of additional transformation in relation to the object's frame
         transformations = [self.transformation] if self.transformation else []
-        parent: SceneObject = self.parent
+        parent = self.parent
         while parent and not parent.is_root:
             if parent.transformation:
                 transformations.append(parent.transformation)

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -54,12 +54,13 @@ class SceneObject(TreeNode):
         The node in the scene tree which represents the scene object.
     guids : list[object]
         The GUIDs of the items drawn in the visualization context.
-    frame : :class:`compas.geometry.Frame`
-        The frame of the local coordinate system of the scene object.
     transformation : :class:`compas.geometry.Transformation`
         The local transformation of the scene object in relation to its parent object.
     worldtransformation : :class:`compas.geometry.Transformation`
-        The transformation of the scene object in world coordinates.
+        The global transformation of the scene object in world coordinates, computed by multiplying all transformations from the scene object to the root of the scene tree.
+        (NOTE: Changed from 2.11.0, there will no longer be the option of additional transformation in relation to the object's frame)
+    frame : :class:`compas.geometry.Frame`
+        The frame of the local coordinate system of the scene object, derived from the `worldtransformation`.
     color : :class:`compas.colors.Color`
         The color of the object.
     contrastcolor : :class:`compas.colors.Color`, readon-only
@@ -169,7 +170,6 @@ class SceneObject(TreeNode):
     @property
     def worldtransformation(self):
         # type: () -> compas.geometry.Transformation
-        # NOTE: Behaviour change from 2.11.0, there will no longer be the option of additional transformation in relation to the object's frame
         transformations = [self.transformation] if self.transformation else []
         parent = self.parent
         while parent and not parent.is_root:

--- a/tests/compas/scene/test_scene.py
+++ b/tests/compas/scene/test_scene.py
@@ -87,18 +87,21 @@ if not compas.IPY:
         assert sceneobj1.worldtransformation == sceneobj1.transformation
         assert sceneobj1.worldtransformation == Translation.from_vector([10.0, 0.0, 0.0])
         assert sceneobj1.frame == Frame([10.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
+        assert sceneobj1.frame.to_transformation() == Translation.from_vector([10.0, 0.0, 0.0])
 
         sceneobj2 = scene.add(Box(), parent=sceneobj1)
         sceneobj2.transformation = Translation.from_vector([10.0, 10.0, 0.0])
         assert sceneobj2.worldtransformation == sceneobj1.transformation * sceneobj2.transformation
         assert sceneobj2.worldtransformation == Translation.from_vector([20.0, 10.0, 0.0])
         assert sceneobj2.frame == Frame([20.0, 10.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
+        assert sceneobj2.frame.to_transformation() == Translation.from_vector([20.0, 10.0, 0.0])
 
         sceneobj3 = scene.add(Box(), parent=sceneobj2)
         sceneobj3.transformation = Translation.from_vector([10.0, 10.0, 10.0])
         assert sceneobj3.worldtransformation == sceneobj1.transformation * sceneobj2.transformation * sceneobj3.transformation
         assert sceneobj3.worldtransformation == Translation.from_vector([30.0, 20.0, 10.0])
         assert sceneobj3.frame == Frame([30.0, 20.0, 10.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
+        assert sceneobj3.frame.to_transformation() == Translation.from_vector([30.0, 20.0, 10.0])
 
     def test_scene_clear():
         scene = Scene()

--- a/tests/compas/scene/test_scene.py
+++ b/tests/compas/scene/test_scene.py
@@ -84,17 +84,20 @@ if not compas.IPY:
         scene = Scene()
         sceneobj1 = scene.add(Box())
         sceneobj1.transformation = Translation.from_vector([10.0, 0.0, 0.0])
+        assert sceneobj1.worldtransformation == sceneobj1.transformation
         assert sceneobj1.worldtransformation == Translation.from_vector([10.0, 0.0, 0.0])
         assert sceneobj1.frame == Frame([10.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
 
         sceneobj2 = scene.add(Box(), parent=sceneobj1)
         sceneobj2.transformation = Translation.from_vector([10.0, 10.0, 0.0])
         assert sceneobj2.worldtransformation == sceneobj1.transformation * sceneobj2.transformation
+        assert sceneobj2.worldtransformation == Translation.from_vector([20.0, 10.0, 0.0])
         assert sceneobj2.frame == Frame([20.0, 10.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
 
         sceneobj3 = scene.add(Box(), parent=sceneobj2)
         sceneobj3.transformation = Translation.from_vector([10.0, 10.0, 10.0])
         assert sceneobj3.worldtransformation == sceneobj1.transformation * sceneobj2.transformation * sceneobj3.transformation
+        assert sceneobj3.worldtransformation == Translation.from_vector([30.0, 20.0, 10.0])
         assert sceneobj3.frame == Frame([30.0, 20.0, 10.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
 
     def test_scene_clear():

--- a/tests/compas/scene/test_scene.py
+++ b/tests/compas/scene/test_scene.py
@@ -83,22 +83,19 @@ if not compas.IPY:
     def test_sceneobject_transform():
         scene = Scene()
         sceneobj1 = scene.add(Box())
-        sceneobj1.frame = Frame([1.0, 0.0, 0.0], xaxis=[1.0, 0.0, 0.0], yaxis=[0.0, 1.0, 0.0])
         sceneobj1.transformation = Translation.from_vector([10.0, 0.0, 0.0])
-        assert sceneobj1.worldtransformation == sceneobj1.frame.to_transformation() * sceneobj1.transformation
+        assert sceneobj1.worldtransformation == Translation.from_vector([10.0, 0.0, 0.0])
+        assert sceneobj1.frame == Frame([10.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
 
         sceneobj2 = scene.add(Box(), parent=sceneobj1)
-        sceneobj2.frame = Frame([1.0, 1.0, 0.0], xaxis=[1.0, 0.0, 0.0], yaxis=[0.0, 1.0, 0.0])
         sceneobj2.transformation = Translation.from_vector([10.0, 10.0, 0.0])
-        assert sceneobj2.worldtransformation == sceneobj1.frame.to_transformation() * sceneobj2.frame.to_transformation() * sceneobj2.transformation
+        assert sceneobj2.worldtransformation == sceneobj1.transformation * sceneobj2.transformation
+        assert sceneobj2.frame == Frame([20.0, 10.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
 
         sceneobj3 = scene.add(Box(), parent=sceneobj2)
-        sceneobj3.frame = Frame([1.0, 1.0, 1.0], xaxis=[0.0, 1.0, 0.0], yaxis=[1.0, 0.0, 0.0])
         sceneobj3.transformation = Translation.from_vector([10.0, 10.0, 10.0])
-        assert (
-            sceneobj3.worldtransformation
-            == sceneobj1.frame.to_transformation() * sceneobj2.frame.to_transformation() * sceneobj3.frame.to_transformation() * sceneobj3.transformation
-        )
+        assert sceneobj3.worldtransformation == sceneobj1.transformation * sceneobj2.transformation * sceneobj3.transformation
+        assert sceneobj3.frame == Frame([30.0, 20.0, 10.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
 
     def test_scene_clear():
         scene = Scene()


### PR DESCRIPTION
Hey folks, I'd like propose to update the relation between `frame` and `transformation` in `SceneObject`, to align better with how they are currently defined in `compas_model` (https://github.com/BlockResearchGroup/compas_model/blob/b8d7a992956abcfe96d41eb11fecd5a064a12674/src/compas_model/elements/element.py#L271), which I found makes more sense and easier to understand.

- We update the calculation of `worldtransformation` to the simple multiplication of all transformations along the scene tree.
- We re-define the `frame` property as a read-only computed property which is derived from `Frame.from_transformation(self.worldtransformation)`, and it can be think of as the reference frame of the local coordinate system of this object after all the transformations applied.

This relation also aligns better with other CAD systems and libraries like Threejs. And it will give a lot of advantage for `compas_viewer` where I will be able to push the transformation and scene tree into GPU and calculate the multiplication there.