### PR TITLE
add group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `Group` to `compas.scene`.
+
 ### Changed
 
 ### Removed

--- a/src/compas/scene/__init__.py
+++ b/src/compas/scene/__init__.py
@@ -14,6 +14,7 @@ from .meshobject import MeshObject
 from .graphobject import GraphObject
 from .geometryobject import GeometryObject
 from .volmeshobject import VolMeshObject
+from .group import Group
 
 from .context import clear
 from .context import before_draw
@@ -53,4 +54,5 @@ __all__ = [
     "register_scene_objects",
     "get_sceneobject_cls",
     "register",
+    "Group",
 ]

--- a/src/compas/scene/group.py
+++ b/src/compas/scene/group.py
@@ -4,7 +4,30 @@ from .sceneobject import SceneObject
 
 
 class Group(SceneObject):
-    """A group of scene objects."""
+    """A group of scene objects.
+
+    Parameters
+    ----------
+    name : str, optional
+        The name of the group.
+
+    Examples
+    --------
+    >>> from compas.scene import Scene
+    >>> from compas.scene import Group
+    >>> from compas.geometry import Point
+    >>> scene = Scene()
+    >>> group = Group(name="My Group")
+    >>> scene.add(group)
+    >>> point = Point(0, 0, 0)
+    >>> group.add(point)
+    >>> print(scene)
+    <Tree with 3 nodes>
+    └── <TreeNode: ROOT>
+        └── <Group: My Group>
+            └── <GeometryObject: Point>
+
+    """
 
     def __new__(cls, *args, **kwargs):
         return object.__new__(cls)

--- a/src/compas/scene/group.py
+++ b/src/compas/scene/group.py
@@ -1,4 +1,5 @@
 from compas.data import Data
+
 from .sceneobject import SceneObject
 
 

--- a/src/compas/scene/group.py
+++ b/src/compas/scene/group.py
@@ -1,0 +1,13 @@
+from compas.data import Data
+from .sceneobject import SceneObject
+
+
+class Group(SceneObject):
+    """A group of scene objects."""
+
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
+
+    def __init__(self, **kwargs):
+        name = kwargs.pop("name", "Group")
+        super(Group, self).__init__(item=Data(name=name), **kwargs)

--- a/src/compas/scene/group.py
+++ b/src/compas/scene/group.py
@@ -1,5 +1,3 @@
-from compas.data import Data
-
 from .sceneobject import SceneObject
 
 
@@ -30,8 +28,14 @@ class Group(SceneObject):
     """
 
     def __new__(cls, *args, **kwargs):
+        # overwriting __new__ to revert to the default behavior of normal object, So an instance can be created directly without providing a registered item.
         return object.__new__(cls)
 
-    def __init__(self, **kwargs):
-        name = kwargs.pop("name", "Group")
-        super(Group, self).__init__(item=Data(name=name), **kwargs)
+    @property
+    def __data__(self):
+        # type: () -> dict
+        data = {
+            "settings": self.settings,
+            "children": [child.__data__ for child in self.children],
+        }
+        return data

--- a/src/compas/scene/scene.py
+++ b/src/compas/scene/scene.py
@@ -8,6 +8,7 @@ from .context import after_draw
 from .context import before_draw
 from .context import clear
 from .context import detect_current_context
+from .group import Group
 from .sceneobject import SceneObject
 
 
@@ -42,7 +43,7 @@ class Scene(Tree):
     @property
     def __data__(self):
         # type: () -> dict
-        items = {str(object.item.guid): object.item for object in self.objects}
+        items = {str(object.item.guid): object.item for object in self.objects if object.item is not None}
         return {
             "name": self.name,
             "root": self.root.__data__,  # type: ignore
@@ -57,9 +58,12 @@ class Scene(Tree):
 
         def add(node, parent, items):
             for child_node in node.get("children", []):
-                guid = child_node["item"]
                 settings = child_node["settings"]
-                sceneobject = parent.add(items[guid], **settings)
+                if "item" in child_node:
+                    guid = child_node["item"]
+                    sceneobject = parent.add(items[guid], **settings)
+                else:
+                    sceneobject = parent.add(Group(**settings))
                 add(child_node, sceneobject, items)
 
         add(data["root"], scene, items)

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -101,7 +101,7 @@ class SceneObject(TreeNode):
         **kwargs  # type: dict
     ):  # fmt: skip
         # type: (...) -> None
-        if not isinstance(item, (Data, type(None))):
+        if item and not isinstance(item, Data):
             raise ValueError("The item assigned to this scene object should be a data object: {}".format(type(item)))
 
         name = name or item.name

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -101,7 +101,7 @@ class SceneObject(TreeNode):
         **kwargs  # type: dict
     ):  # fmt: skip
         # type: (...) -> None
-        if not isinstance(item, Data):
+        if not isinstance(item, (Data, type(None))):
             raise ValueError("The item assigned to this scene object should be a data object: {}".format(type(item)))
 
         name = name or item.name

--- a/tests/compas/scene/test_scene_serialisation.py
+++ b/tests/compas/scene/test_scene_serialisation.py
@@ -23,6 +23,7 @@ if not compas.IPY:
     from compas.datastructures import Mesh
     from compas.datastructures import Graph
     from compas.datastructures import VolMesh
+    from compas.scene import Group
 
     @pytest.fixture
     def items():
@@ -45,6 +46,7 @@ if not compas.IPY:
         mesh = Mesh.from_polyhedron(8)
         graph = Graph.from_nodes_and_edges([(0, 0, 0), (0, -1.5, 0), (-1, 1, 0), (1, 1, 0)], [(0, 1), (0, 2), (0, 3)])
         volmesh = VolMesh.from_meshgrid(1, 1, 1, 2, 2, 2)
+        group = Group(name="My Group")
 
         return [
             box,
@@ -66,6 +68,7 @@ if not compas.IPY:
             mesh,
             graph,
             volmesh,
+            group,
         ]
 
     def assert_is_data_equal(obj1, obj2, path=""):


### PR DESCRIPTION
Adding a `Group` object to Scene, which is a custom `SceneObject`.  The usages are similar to Three.js:

```python
from compas.scene import Group
from compas.scene import Scene
from compas.geometry import Point

scene = Scene()

group = Group(name="My Group")
scene.add(group)

point = Point(0, 0, 0)
group.add(point)

print(scene)
```
```
<Tree with 3 nodes>
└── <TreeNode: ROOT>
    └── <Group: My Group>
        └── <GeometryObject: Point>
```