### PR TITLE
Add make_solid method to RhinoBrep to cap planar holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added `Group` to `compas.scene`.
-* Added implementation of `make_solid` to `compas_rhino.geometry.RhinoBrep`.
+* Added `compas.geometry.Brep.cap_planar_holes`.
+* Added `compas_rhino.geometry.RhinoBrep.cap_planar_holes`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added `Group` to `compas.scene`.
+* Added implementation of `make_solid` to `compas_rhino.geometry.RhinoBrep`.
 
 ### Changed
 

--- a/src/compas/geometry/brep/brep.py
+++ b/src/compas/geometry/brep/brep.py
@@ -923,6 +923,11 @@ class Brep(Geometry):
         -------
         None
 
+        Raises
+        ------
+        :class:`~compas.geometry.BrepInvalidError`
+            If the operation fails.
+
         """
         raise NotImplementedError
 

--- a/src/compas/geometry/brep/brep.py
+++ b/src/compas/geometry/brep/brep.py
@@ -923,11 +923,6 @@ class Brep(Geometry):
         -------
         None
 
-        Raises
-        ------
-        :class:`~compas.geometry.BrepInvalidError`
-            If the operation fails.
-
         """
         raise NotImplementedError
 
@@ -1141,6 +1136,26 @@ class Brep(Geometry):
         Returns
         -------
         tuple[list[:class:`compas.geometry.BrepFace`]]
+
+        """
+        raise NotImplementedError
+
+    def cap_planar_holes(self, tolerance=None):
+        """Cap all planar holes in the Brep.
+
+        Parameters
+        ----------
+        tolerance : float, optional
+            The precision to use for the operation. Defaults to `TOL.absolute`.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        BrepError
+            If the operation fails.
 
         """
         raise NotImplementedError

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -684,9 +684,9 @@ class RhinoBrep(Brep):
         None
 
         """
-        if not self._brep.IsSolid:
-            capped_brep = self._brep.CapPlanarHoles(TOL.absolute)
-            if capped_brep:
-                self._brep = capped_brep
+        if not self.is_solid:
+            result = self._brep.CapPlanarHoles(TOL.absolute)
+            if result:
+                self._brep = result
             else:
                 raise BrepInvalidError("Failed to convert Brep to solid")

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -9,7 +9,6 @@ import compas_rhino.objects
 from compas.geometry import Brep
 from compas.geometry import BrepError
 from compas.geometry import BrepFilletError
-from compas.geometry import BrepInvalidError
 from compas.geometry import BrepTrimmingError
 from compas.geometry import Frame
 from compas.geometry import Plane
@@ -676,17 +675,27 @@ class RhinoBrep(Brep):
         """
         self._brep.Flip()
 
-    def make_solid(self):
-        """Convert the current shape to a solid if it is a shell.
+    def cap_planar_holes(self, tolerance=None):
+        """Cap all planar holes in the Brep.
+
+        Parameters
+        ----------
+        tolerance : float, optional
+            The precision to use for the operation. Defaults to `TOL.absolute`.
 
         Returns
         -------
         None
 
+        Raises
+        ------
+        BrepError
+            If the operation fails.
+
         """
-        if not self.is_solid:
-            result = self._brep.CapPlanarHoles(TOL.absolute)
-            if result:
-                self._brep = result
-            else:
-                raise BrepInvalidError("Failed to convert Brep to solid")
+        tolerance = tolerance or TOL.absolute
+        result = self._brep.CapPlanarHoles(tolerance)
+        if result:
+            self._brep = result
+        else:
+            raise BrepError("Failed to cap planar holes")

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -9,6 +9,7 @@ import compas_rhino.objects
 from compas.geometry import Brep
 from compas.geometry import BrepError
 from compas.geometry import BrepFilletError
+from compas.geometry import BrepInvalidError
 from compas.geometry import BrepTrimmingError
 from compas.geometry import Frame
 from compas.geometry import Plane
@@ -674,3 +675,18 @@ class RhinoBrep(Brep):
 
         """
         self._brep.Flip()
+
+    def make_solid(self):
+        """Convert the current shape to a solid if it is a shell.
+
+        Returns
+        -------
+        None
+
+        """
+        if not self._brep.IsSolid:
+            capped_brep = self._brep.CapPlanarHoles(TOL.absolute)
+            if capped_brep:
+                self._brep = capped_brep
+            else:
+                raise BrepInvalidError("Failed to convert Brep to solid")


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?
Adds `make_solid()` method to `RhinoBrep` for converting a brep to a solid if it is a strip in the Rhino backend.

- [ ] Bug fix in a **backwards-compatible** manner.
- [X] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)
