### PR TITLE
catch AttrbuteError on typing imports from ironpython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `SceneObject.frame` to read-only result of `Frame.from_transformation(SceneObject.worldtransformation)`, representing the local coordinate system of the scene object in world coordinates.
 * Changed `SceneObject.worldtransformation` to the multiplication of all transformations from the scene object to the root of the scene tree, there will no longer be an additional transformation in relation to the object's frame.
 * Fixed call to `astar_shortest_path` in `Graph.shortest_path`.
+* Fixed `AttributeError` on certain imports in IronPython.
 
 ### Removed
 

--- a/src/compas/data/data.py
+++ b/src/compas/data/data.py
@@ -6,7 +6,7 @@ try:
     from typing import TypeVar  # noqa: F401
 
     D = TypeVar("D", bound="Data")
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 import hashlib

--- a/src/compas/data/encoders.py
+++ b/src/compas/data/encoders.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 try:
     from typing import Type  # noqa: F401
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 import json

--- a/src/compas/datastructures/datastructure.py
+++ b/src/compas/datastructures/datastructure.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 try:
     from typing import TypeVar  # noqa: F401
-except ImportError:
+except (ImportError, AttributeError):
     pass
 else:
     G = TypeVar("G", bound="Datastructure")

--- a/src/compas/geometry/geometry.py
+++ b/src/compas/geometry/geometry.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 try:
     from typing import TypeVar  # noqa: F401
-except ImportError:
+except (ImportError, AttributeError):
     pass
 else:
     G = TypeVar("G", bound="Geometry")


### PR DESCRIPTION
Not sure what has changed because these imports aren't new, but started getting `AttributeError` on these typing imports from ironpython.

```
IronPython 2.7.8 (2.7.8.0) on .NET 4.0.30319.42000 (64-bit)
Type "help", "copyright", "credits" or "license" for more information.
>>> from compas.data import Data
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\ckasirer\repos\compas\src\compas\__init__.py", line 16, in <module>
  File "C:\Users\ckasirer\repos\compas\src\compas\data\__init__.py", line 9, in <module>
  File "C:\Users\ckasirer\repos\compas\src\compas\data\encoders.py", line 13, in <module>
  File "C:\Users\ckasirer\repos\compas\src\compas\data\data.py", line 6, in <module>
  File "C:\Program Files\IronPython 2.7\Lib\site-packages\typing.py", line 2061, in <module>
  File "C:\Program Files\IronPython 2.7\Lib\abc.py", line 109, in register
  File "C:\Program Files\IronPython 2.7\Lib\site-packages\typing.py", line 1410, in __subclasscheck__
  File "C:\Program Files\IronPython 2.7\Lib\abc.py", line 154, in __subclasscheck__
  File "C:\Program Files\IronPython 2.7\Lib\site-packages\typing.py", line 1290, in _abc_negative_cache_version
AttributeError: 'GenericMeta' object has no attribute '_abc_generic_negative_cache_version'
```

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
