### PR TITLE
Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `SceneObject.worldtransformation` to the multiplication of all transformations from the scene object to the root of the scene tree, there will no longer be an additional transformation in relation to the object's frame.
 * Fixed call to `astar_shortest_path` in `Graph.shortest_path`.
 * Fixed a bug when printing an empty `Tree`.
+* Fixed a bug in `Group` for IronPython where the decoding declaration was missing.
+* Fixed a bug where a `Group` without name could not be added to the scene.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `SceneObject.frame` to read-only result of `Frame.from_transformation(SceneObject.worldtransformation)`, representing the local coordinate system of the scene object in world coordinates.
 * Changed `SceneObject.worldtransformation` to the multiplication of all transformations from the scene object to the root of the scene tree, there will no longer be an additional transformation in relation to the object's frame.
 * Fixed call to `astar_shortest_path` in `Graph.shortest_path`.
+* Fixed a bug when printing an empty `Tree`.
 
 ### Removed
 

--- a/src/compas/datastructures/tree/tree.py
+++ b/src/compas/datastructures/tree/tree.py
@@ -465,7 +465,8 @@ class Tree(Datastructure):
             for i, child in enumerate(node.children):
                 traverse(child, hierarchy, prefix, i == len(node.children) - 1, depth + 1)
 
-        traverse(self.root, hierarchy)
+        if self.root:
+            traverse(self.root, hierarchy)
 
         return "\n".join(hierarchy)
 

--- a/src/compas/scene/group.py
+++ b/src/compas/scene/group.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .sceneobject import SceneObject
 
 

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -104,7 +104,7 @@ class SceneObject(TreeNode):
         if item and not isinstance(item, Data):
             raise ValueError("The item assigned to this scene object should be a data object: {}".format(type(item)))
 
-        name = name or item.name
+        name = name or getattr(item, "name", None)
         super(SceneObject, self).__init__(name=name, **kwargs)
         # the scene object needs to store the context
         # because it has no access to the tree and/or the scene before it is added

--- a/tests/compas/datastructures/test_tree.py
+++ b/tests/compas/datastructures/test_tree.py
@@ -51,6 +51,15 @@ def test_tree_initialization():
     assert tree.root is None
 
 
+def test_empty_tree():
+    tree = Tree()
+    assert tree.root is None
+    assert len(list(tree.nodes)) == 0
+    assert len(list(tree.leaves)) == 0
+    assert list(tree.traverse()) == []
+    assert tree.get_hierarchy_string() == ""
+
+
 # =============================================================================
 # TreeNode Properties
 # =============================================================================


### PR DESCRIPTION
* Fixed a bug when printing an empty `Tree`.
* Fixed a bug in `Group` for IronPython where the decoding declaration was missing. #1457 
* Fixed a bug where a `Group` without name could not be added to the scene.