### PR TITLE
serialize and deserilize mro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `mro` field to `__jsondump__` of `compas.datastructures.Datastructure` to allow for deserialization to closest available superclass of custom datastructures.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added `mro` field to `__jsondump__` of `compas.datastructures.Datastructure` to allow for deserialization to closest available superclass of custom datastructures.
+* Added `inheritance` field to `__jsondump__` of `compas.datastructures.Datastructure` to allow for deserialization to closest available superclass of custom datastructures.
 
 ### Changed
 

--- a/src/compas/data/data.py
+++ b/src/compas/data/data.py
@@ -76,7 +76,7 @@ class Data(object):
         return "{}/{}".format(".".join(self.__class__.__module__.split(".")[:2]), self.__class__.__name__)
 
     @classmethod
-    def __cls_dtype__(cls):
+    def __clstype__(cls):
         return "{}/{}".format(".".join(cls.__module__.split(".")[:2]), cls.__name__)
 
     @property

--- a/src/compas/data/data.py
+++ b/src/compas/data/data.py
@@ -75,6 +75,10 @@ class Data(object):
     def __dtype__(self):
         return "{}/{}".format(".".join(self.__class__.__module__.split(".")[:2]), self.__class__.__name__)
 
+    @classmethod
+    def __cls_dtype__(cls):
+        return "{}/{}".format(".".join(cls.__module__.split(".")[:2]), cls.__name__)
+
     @property
     def __data__(self):
         raise NotImplementedError

--- a/src/compas/datastructures/datastructure.py
+++ b/src/compas/datastructures/datastructure.py
@@ -21,6 +21,41 @@ class Datastructure(Data):
         self._aabb = None
         self._obb = None
 
+    def __get_mro__(self):
+        mro = []
+        for cls in self.__class__.__mro__:
+            if cls == self.__class__:
+                continue
+            if cls == Datastructure:
+                break
+            mro.append(cls.__cls_dtype__())
+        return mro
+
+    def __jsondump__(self, minimal=False):
+        """Return the required information for serialization with the COMPAS JSON serializer.
+
+        Parameters
+        ----------
+        minimal : bool, optional
+            If True, exclude the GUID from the dump dict.
+
+        Returns
+        -------
+        dict
+
+        """
+        state = {
+            "dtype": self.__dtype__,
+            "data": self.__data__,
+            "mro": self.__get_mro__(),
+        }
+        if minimal:
+            return state
+        if self._name is not None:
+            state["name"] = self._name
+        state["guid"] = str(self.guid)
+        return state
+
     @property
     def aabb(self):
         if self._aabb is None:

--- a/src/compas/datastructures/datastructure.py
+++ b/src/compas/datastructures/datastructure.py
@@ -21,15 +21,25 @@ class Datastructure(Data):
         self._aabb = None
         self._obb = None
 
-    def __get_mro__(self):
-        mro = []
+    @property
+    def __inheritance__(self):
+        """Get the inheritance chain of the datastructure.
+        Until one level above the Datastructure class (eg. Mesh, Graph, ...).
+
+        Returns
+        -------
+        list[str]
+            The inheritance chain of the datastructure.
+
+        """
+        inheritance = []
         for cls in self.__class__.__mro__:
             if cls == self.__class__:
                 continue
             if cls == Datastructure:
                 break
-            mro.append(cls.__cls_dtype__())
-        return mro
+            inheritance.append(cls.__clstype__())
+        return inheritance
 
     def __jsondump__(self, minimal=False):
         """Return the required information for serialization with the COMPAS JSON serializer.
@@ -47,7 +57,7 @@ class Datastructure(Data):
         state = {
             "dtype": self.__dtype__,
             "data": self.__data__,
-            "mro": self.__get_mro__(),
+            "inheritance": self.__inheritance__,
         }
         if minimal:
             return state

--- a/tests/compas/datastructures/test_datastructure.py
+++ b/tests/compas/datastructures/test_datastructure.py
@@ -1,0 +1,124 @@
+import pytest
+from compas.datastructures import Datastructure
+from compas.data import json_dumps, json_loads
+
+
+class Level1(Datastructure):
+    def __init__(self, attributes=None, name=None):
+        super(Level1, self).__init__(attributes=attributes, name=name)
+        self.level1_attr = "level1"
+
+    @property
+    def __data__(self):
+        return {"attributes": self.attributes, "level1_attr": self.level1_attr}
+
+    @classmethod
+    def __from_data__(cls, data):
+        obj = cls(attributes=data.get("attributes"))
+        obj.level1_attr = data.get("level1_attr", "")
+        return obj
+
+
+@pytest.fixture
+def level2():
+    # Level2 is a custom class that is not available outside of this local scope
+    class Level2(Level1):
+        def __init__(self, attributes=None, name=None):
+            super(Level2, self).__init__(attributes=attributes, name=name)
+            self.level2_attr = "level2"
+
+        @property
+        def __data__(self):
+            data = super(Level2, self).__data__
+            data["level2_attr"] = self.level2_attr
+            return data
+
+        @classmethod
+        def __from_data__(cls, data):
+            obj = super(Level2, cls).__from_data__(data)
+            obj.level2_attr = data.get("level2_attr", "")
+            return obj
+
+    # return an instance of Level2
+    return Level2(name="test")
+
+
+@pytest.fixture
+def level3():
+    # Level2 and Level3 are custom classes that are not available outside of this local scope
+    class Level2(Level1):
+        def __init__(self, attributes=None, name=None):
+            super(Level2, self).__init__(attributes=attributes, name=name)
+            self.level2_attr = "level2"
+
+        @property
+        def __data__(self):
+            data = super(Level2, self).__data__
+            data["level2_attr"] = self.level2_attr
+            return data
+
+        @classmethod
+        def __from_data__(cls, data):
+            obj = super(Level2, cls).__from_data__(data)
+            obj.level2_attr = data.get("level2_attr", "")
+            return obj
+
+    class Level3(Level2):
+        def __init__(self, attributes=None, name=None):
+            super(Level3, self).__init__(attributes=attributes, name=name)
+            self.level3_attr = "level3"
+
+        @property
+        def __data__(self):
+            data = super(Level3, self).__data__
+            data["level3_attr"] = self.level3_attr
+            return data
+
+        @classmethod
+        def __from_data__(cls, data):
+            obj = super(Level3, cls).__from_data__(data)
+            obj.level3_attr = data.get("level3_attr", "")
+            return obj
+
+    # return an instance of Level3
+    return Level3(name="test")
+
+
+def test_mro_fallback(level2):
+    assert level2.__jsondump__()["dtype"] == "test_datastructure/Level2"
+    # Level2 should serialize Level1 into the mro
+    assert level2.__jsondump__()["mro"] == ["test_datastructure/Level1"]
+
+    dumped = json_dumps(level2)
+    loaded = json_loads(dumped)
+
+    # The loaded object should be deserialized as the closes available class: Level1
+    assert loaded.__class__ == Level1
+    assert loaded.__jsondump__()["dtype"] == "test_datastructure/Level1"
+    assert loaded.__jsondump__()["mro"] == []
+
+    # level1 attributes should still be available
+    assert loaded.level1_attr == "level1"
+    # Meanwhile, level2 attributes will be discarded
+    assert not hasattr(loaded, "level2_attr")
+
+
+def test_mro_fallback_multi_level(level3):
+    assert level3.__jsondump__()["dtype"] == "test_datastructure/Level3"
+    # Level3 should serialize Level2 and Level1 into the mro
+    assert level3.__jsondump__()["mro"] == ["test_datastructure/Level2", "test_datastructure/Level1"]
+
+    dumped = json_dumps(level3)
+    loaded = json_loads(dumped)
+
+    # The loaded object should be deserialized as the closes available class: Level1
+    assert loaded.__class__ == Level1
+    assert loaded.__jsondump__()["dtype"] == "test_datastructure/Level1"
+    assert loaded.__jsondump__()["mro"] == []
+
+    # level1 attributes should still be available
+    assert loaded.level1_attr == "level1"
+
+    # level2 and 3 attributes will be discarded
+    assert not hasattr(loaded, "level2_attr")
+    assert not hasattr(loaded, "level3_attr")

--- a/tests/compas/datastructures/test_datastructure.py
+++ b/tests/compas/datastructures/test_datastructure.py
@@ -115,8 +115,8 @@ def test_mro_fallback(level2):
         return
 
     assert level2.__jsondump__()["dtype"] == "test_datastructure/Level2"
-    # Level2 should serialize Level1 into the mro
-    assert level2.__jsondump__()["mro"] == ["test_datastructure/Level1"]
+    # Level2 should serialize Level1 into the inheritance
+    assert level2.__jsondump__()["inheritance"] == ["test_datastructure/Level1"]
 
     dumped = json_dumps(level2)
     loaded = json_loads(dumped)
@@ -124,7 +124,7 @@ def test_mro_fallback(level2):
     # The loaded object should be deserialized as the closes available class: Level1
     assert loaded.__class__ == Level1
     assert loaded.__jsondump__()["dtype"] == "test_datastructure/Level1"
-    assert loaded.__jsondump__()["mro"] == []
+    assert loaded.__jsondump__()["inheritance"] == []
 
     # level1 attributes should still be available
     assert loaded.level1_attr == "level1"
@@ -139,8 +139,8 @@ def test_mro_fallback_multi_level(level3):
         return
 
     assert level3.__jsondump__()["dtype"] == "test_datastructure/Level3"
-    # Level3 should serialize Level2 and Level1 into the mro
-    assert level3.__jsondump__()["mro"] == ["test_datastructure/Level2", "test_datastructure/Level1"]
+    # Level3 should serialize Level2 and Level1 into the inheritance
+    assert level3.__jsondump__()["inheritance"] == ["test_datastructure/Level2", "test_datastructure/Level1"]
 
     dumped = json_dumps(level3)
     loaded = json_loads(dumped)
@@ -148,7 +148,7 @@ def test_mro_fallback_multi_level(level3):
     # The loaded object should be deserialized as the closes available class: Level1
     assert loaded.__class__ == Level1
     assert loaded.__jsondump__()["dtype"] == "test_datastructure/Level1"
-    assert loaded.__jsondump__()["mro"] == []
+    assert loaded.__jsondump__()["inheritance"] == []
 
     # level1 attributes should still be available
     assert loaded.level1_attr == "level1"
@@ -161,7 +161,7 @@ def test_mro_fallback_multi_level(level3):
 def test_custom_mesh(custom_mesh):
     # This test should pass both Python and IronPython
     assert custom_mesh.__jsondump__()["dtype"].endswith("CustomMesh")
-    assert custom_mesh.__jsondump__()["mro"] == ["compas.datastructures/Mesh"]
+    assert custom_mesh.__jsondump__()["inheritance"] == ["compas.datastructures/Mesh"]
     assert custom_mesh.__jsondump__()["data"]["custom_mesh_attr"] == "custom_mesh"
 
     dumped = json_dumps(custom_mesh)
@@ -169,5 +169,5 @@ def test_custom_mesh(custom_mesh):
 
     assert loaded.__class__ == Mesh
     assert loaded.__jsondump__()["dtype"] == "compas.datastructures/Mesh"
-    assert loaded.__jsondump__()["mro"] == []
+    assert loaded.__jsondump__()["inheritance"] == []
     assert not hasattr(loaded, "custom_mesh_attr")

--- a/tests/compas/datastructures/test_datastructure.py
+++ b/tests/compas/datastructures/test_datastructure.py
@@ -108,7 +108,7 @@ def custom_mesh():
     return CustomMesh(name="test")
 
 
-def test_mro_fallback(level2):
+def test_inheritance_fallback(level2):
     if compas.IPY:
         # IronPython is not able to deserialize a class that is defined in a local scope like Level1.
         # We skip this tests for IronPython.
@@ -132,7 +132,7 @@ def test_mro_fallback(level2):
     assert not hasattr(loaded, "level2_attr")
 
 
-def test_mro_fallback_multi_level(level3):
+def test_inheritance_fallback_multi_level(level3):
     if compas.IPY:
         # IronPython is not able to deserialize a class that is defined in a local scope like Level1.
         # We skip this tests for IronPython.


### PR DESCRIPTION
This is to add the ability to deserializing a `datastructure` implementation like `Mesh`, `Graph`, `Cellnetwork` etc. to its closest available parent class. 

For example we want to be able to serialize a `FormDiagram` object using `compas_tna` into a json. And open same json in another environment without `compas_tna` installed, while loading the same object as its closest available class `Mesh`.

An example behaviour:
```python
from compas.datastructures import Mesh
from compas import json_dumps
from compas import json_loads

# Some custom class that inherits from Mesh but is not available when deserializing
class MyCustomMesh(Mesh):
    pass

mesh = MyCustomMesh()
serialized = json_dumps(mesh)

# delete the access to our custom class
del MyCustomMesh

# fallback to Mesh if MyCustomMesh is not available
loaded = json_loads(serialized)
assert loaded.__class__ == Mesh
```


This is done through inserting an `mro` (method resolving order) field into the json dump state, so the decoder can later pickup and use as a backup if `dtype` is not directly found
