### PR TITLE
Update devday acknowledgements

### DIFF
--- a/src/compas/__init__.py
+++ b/src/compas/__init__.py
@@ -275,7 +275,7 @@ def get_bunny(localstorage=None):
     return bunny
 
 
-def devday(year, *, open):
+def devday(year, open=True):
     import zlib
     import base64
 

--- a/src/compas/__init__.py
+++ b/src/compas/__init__.py
@@ -275,9 +275,10 @@ def get_bunny(localstorage=None):
     return bunny
 
 
-def devday(year, is_open):
+def devday(year, *, open):
     import zlib
     import base64
 
-    encoded = b"eJxNksFq20AQhu/7FINPLSSxk1BaBDmYOGkoDjW2ac4jaSQNWu2I3VVStxRy6TG00OTQU6AP0Rfom+QJ8ggduTL0siz/zv/tvz/LBXz+AicncDQ5epVA69nFF6PRyJy+v1xMVzCja7LSkocZbrZD5orSwJESqGJsQzIe5wWmB5ZdPc7pOseNMc+PP76qoR+67G1vYvXP+/z48B3W3OjB4XEymcA+HL5Ojie94w7mkmFkcQmcrS/g4s9vV5bkU/LlHizP5z335zeYZrWTG0t5SQ25GIxZV+hq2EgHUUAD+404gptKoMGcIFYcQHNBKyFwagmebu9VJcjERc9pF8WHPRBfouNP1O/R5YDWghRbbs9KtZsShl70IssFHRizailjtMrTEKE/kM5DaAlrJSXGPN3+gtOK9q+IYc4OYKvMpGHHNSyJA2bVoJ5ZcgxTSx95UN5yLjBjstSgC4P4jqy+4pz6RDhoC3QSdG2Vhh4tNql0O8OiYmu5bdVk9cKsUtguyRILJKvOED26HW6FTaeqlk3+v+EPGNhqnVMrXQxaV87B6H95+Rd/oc5T"  # noqa: E501
-    exec(zlib.decompress(base64.b64decode(encoded)).decode().format(year))
+    if open:
+        encoded = b"eJxNksFq20AQhu/7FINPLSSxk1BaBDmYOGkoDjW2ac4jaSQNWu2I3VVStxRy6TG00OTQU6AP0Rfom+QJ8ggduTL0siz/zv/tvz/LBXz+AicncDQ5epVA69nFF6PRyJy+v1xMVzCja7LSkocZbrZD5orSwJESqGJsQzIe5wWmB5ZdPc7pOseNMc+PP76qoR+67G1vYvXP+/z48B3W3OjB4XEymcA+HL5Ojie94w7mkmFkcQmcrS/g4s9vV5bkU/LlHizP5z335zeYZrWTG0t5SQ25GIxZV+hq2EgHUUAD+404gptKoMGcIFYcQHNBKyFwagmebu9VJcjERc9pF8WHPRBfouNP1O/R5YDWghRbbs9KtZsShl70IssFHRizailjtMrTEKE/kM5DaAlrJSXGPN3+gtOK9q+IYc4OYKvMpGHHNSyJA2bVoJ5ZcgxTSx95UN5yLjBjstSgC4P4jqy+4pz6RDhoC3QSdG2Vhh4tNql0O8OiYmu5bdVk9cKsUtguyRILJKvOED26HW6FTaeqlk3+v+EPGNhqnVMrXQxaV87B6H95+Rd/oc5T"  # noqa: E501
+        exec(zlib.decompress(base64.b64decode(encoded)).decode().format(year))


### PR DESCRIPTION
On the T-shirt, it says `compas.devday(2025, open=True)`. The current implementation does not use the boolean, which is anyway called `is_open`, not `open`.

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
