### PR TITLE
setters for worldtransformation and frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+
 * Implemented `to_points` method in `compas.datastructures.Mesh`, which before raised a `NotImplementedError`.
 * Implemented `compute_aabb` method in `compas.datastructures.Datastructure`, which before raised a `NotImplementedError`. Made use of the `compas.geometry.bbox.bounding_box` function.
 * Implemented `compute_obb` method in `compas.datastructures.Datastructure`, which before raised a `NotImplementedError`. Made use of the `compas.geometry.bbox_numpy.oriented_bounding_box_numpy` function.
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added test function `test_to_points` in `test_graph.py`.
 * Added test function `test_to_points` in `test_volmesh.py`.
 * Added test functions `test_to_points`, `test_compute_aabb`, and `test_compute_obb` in `test_mesh.py`.
+* Added setters for `SceneObject.worldtransformation` and `SceneObject.frame`, which automatically handles the parent transformations.
 
 ### Changed
 

--- a/src/compas/scene/sceneobject.py
+++ b/src/compas/scene/sceneobject.py
@@ -95,7 +95,6 @@ class SceneObject(TreeNode):
         color=None,  # type: compas.colors.Color | None
         opacity=1.0,  # type: float
         show=True,  # type: bool
-        frame=None,  # type: compas.geometry.Frame | None
         transformation=None,  # type: compas.geometry.Transformation | None
         context=None,  # type: str | None
         **kwargs  # type: dict
@@ -157,6 +156,11 @@ class SceneObject(TreeNode):
         # type: () -> compas.geometry.Frame | None
         return Frame.from_transformation(self.worldtransformation)
 
+    @frame.setter
+    def frame(self, frame):
+        # type: (compas.geometry.Frame) -> None
+        self.worldtransformation = Transformation.from_frame(frame)
+
     @property
     def transformation(self):
         # type: () -> compas.geometry.Transformation | None
@@ -182,6 +186,14 @@ class SceneObject(TreeNode):
             worldtransformation = Transformation()
 
         return worldtransformation
+
+    @worldtransformation.setter
+    def worldtransformation(self, worldtransformation):
+        # type: (compas.geometry.Transformation) -> None
+        if isinstance(self.parent, SceneObject):
+            self.transformation = self.parent.worldtransformation.inverse() * worldtransformation
+        else:
+            self.transformation = worldtransformation
 
     @property
     def contrastcolor(self):


### PR DESCRIPTION
Adding setters for `SceneObject.frame` and `SceneObject.worldtransformation`, which will automatically consider existing parent transformations. 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
