### PR TITLE
YAK package rename + min version update in GH header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-Updated minimum library version to `2.14.1` in Rhino8 GH components.
+* Updated minimum library version to `2.14.1` in Rhino8 GH components.
+* Changed name of YAK package from `bluejay` to `compas`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+Updated minimum library version to `2.14.1` in Rhino8 GH components.
+
 ### Removed
 
 

--- a/src/compas_ghpython/components_cpython/Compas_FromJson/code.py
+++ b/src/compas_ghpython/components_cpython/Compas_FromJson/code.py
@@ -1,4 +1,4 @@
-# r: compas>=2.8.1
+# r: compas>=2.14.1
 """
 Deserializes JSON into COMPAS objects.
 """

--- a/src/compas_ghpython/components_cpython/Compas_Info/code.py
+++ b/src/compas_ghpython/components_cpython/Compas_Info/code.py
@@ -1,4 +1,4 @@
-# r: compas>=2.8.1
+# r: compas>=2.14.1
 """
 Displays information about the active COMPAS environment.
 """

--- a/src/compas_ghpython/components_cpython/Compas_RpcCall/code.py
+++ b/src/compas_ghpython/components_cpython/Compas_RpcCall/code.py
@@ -1,4 +1,4 @@
-# r: compas>=2.8.1
+# r: compas>=2.14.1
 """
 Remote Procedure Call: to invoke Python functions outside of Rhino, in the context of the CPython interpreter.
 """

--- a/src/compas_ghpython/components_cpython/Compas_ToJson/code.py
+++ b/src/compas_ghpython/components_cpython/Compas_ToJson/code.py
@@ -1,4 +1,4 @@
-# r: compas>=2.8.1
+# r: compas>=2.14.1
 """
 Serializes COMPAS objects to JSON.
 """

--- a/src/compas_ghpython/components_cpython/Compas_ToRhinoGeometry/code.py
+++ b/src/compas_ghpython/components_cpython/Compas_ToRhinoGeometry/code.py
@@ -1,4 +1,4 @@
-# r: compas>=2.8.1
+# r: compas>=2.14.1
 """
 Draws COMPAS geometry in Grasshopper.
 """

--- a/src/compas_ghpython/yak_template/manifest.yml
+++ b/src/compas_ghpython/yak_template/manifest.yml
@@ -1,4 +1,4 @@
-name: bluejay
+name: compas
 version: {{ version }}
 authors:
   - tom van mele et. al.

--- a/tasks.py
+++ b/tasks.py
@@ -26,6 +26,7 @@ ns = Collection(
     build.build_cpython_ghuser_components,
     grasshopper.yakerize,
     grasshopper.publish_yak,
+    grasshopper.update_gh_header,
 )
 ns.configure(
     {


### PR DESCRIPTION
* Renames YAK package `bluejay` -> `compas` (effectively creates a new package called `compas`)
* updates the minimum library dependency to `compas<=2.14.1`

* kinda needs https://github.com/compas-dev/compas_invocations2/pull/7 but not a must

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
