### PR TITLE
Fix int vs enum bug related to python3 not allowing this syntax anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed name of YAK package from `bluejay` to `compas`.
 * Fixed broken `scaled()` method in `Sphere`, `Cylinder`, and `Capsule` classes by overriding to accept uniform scaling factor.
 * Fixed bug in `compas.geometry.PlanarSurface`.
+* Fixed bug in `Curve.offset()` in `compas_rhino`.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/curves/curve.py
+++ b/src/compas_rhino/geometry/curves/curve.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import Rhino.Geometry  # type: ignore
+
 from compas.geometry import Curve
 from compas.geometry import Plane
 from compas_rhino.conversions import box_to_compas
@@ -393,7 +395,8 @@ class RhinoCurve(Curve):
         point = self.point_at(self.domain[0])  # type: ignore
         plane = Plane(point, direction)
         plane = plane_to_rhino(plane)
-        self.native_curve = self.native_curve.Offset(plane, distance, tolerance, 0)[0]  # type: ignore
+        offset_style = Rhino.Geometry.CurveOffsetCornerStyle.NONE
+        self.native_curve = self.native_curve.Offset(plane, distance, tolerance, offset_style)[0]  # type: ignore
 
     def smooth(self):
         raise NotImplementedError


### PR DESCRIPTION
In cpython 3 / pythonnet, it is no longer legal to pass an int value in-place of its corresponding enum value, even if they are ints as well, so this method fails currently in Rhino 8. This PR fixes it by using the enum value. Notice that the `None` in Rhino C#'s enum is replaced with `NONE` 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
