### PR TITLE
backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Changed `Tolerance` class to no longer use singleton pattern. `Tolerance()` now creates independent instances instead of returning the global `TOL`. 
 * Renamed `Tolerance.units` to `Tolerance.unit` to better reflect the documented properties. Left `units` with deprecation warning.
+* Brought back `Tolerance.lineardflection` for backwards compatibility.
+* Brought back `Tolerance.angulardflection` for backwards compatibility.
 
 ### Removed
 

--- a/src/compas/tolerance.py
+++ b/src/compas/tolerance.py
@@ -526,6 +526,26 @@ class Tolerance(Data):
     def angulardeflection(self, value):
         self._angulardeflection = value
 
+    @property
+    def lineardflection(self):
+        warn("The 'lineardflection' property is deprecated. Use 'lineardeflection' instead.", DeprecationWarning)
+        return self.lineardeflection
+
+    @lineardflection.setter
+    def lineardflection(self, value):
+        warn("The 'lineardflection' property is deprecated. Use 'lineardeflection' instead.", DeprecationWarning)
+        self.lineardeflection = value
+
+    @property
+    def angulardflection(self):
+        warn("The 'angulardflection' property is deprecated. Use 'angulardeflection' instead.", DeprecationWarning)
+        return self.angulardeflection
+
+    @angulardflection.setter
+    def angulardflection(self, value):
+        warn("The 'angulardflection' property is deprecated. Use 'angulardeflection' instead.", DeprecationWarning)
+        self.angulardeflection = value
+
     def tolerance(self, truevalue, rtol, atol):
         """Compute the tolerance for a comparison.
 


### PR DESCRIPTION
* Brought back two `Tolerance` attributes for backwards compatibility of changes introduces in https://github.com/compas-dev/compas/pull/1510.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
