### PR TITLE
added missing property and method in RhinoBrep implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `TOL.update()` method for explicit global state modification. 
 * Added `TOL.temporary()` context manager for scoped changes.
+* Added missing implementation of `Brep.to_polygons()` in `compas_rhino.geometry.RhinoBrep`.
 
 ### Changed
 
 * Changed `Tolerance` class to no longer use singleton pattern. `Tolerance()` now creates independent instances instead of returning the global `TOL`. 
 * Renamed `Tolerance.units` to `Tolerance.unit` to better reflect the documented properties. Left `units` with deprecation warning.
+* Fixed `NotImplementedErorr` when calling `BrepLoop.vertices`.
 
 ### Removed
 

--- a/src/compas_rhino/geometry/brep/brep.py
+++ b/src/compas_rhino/geometry/brep/brep.py
@@ -890,6 +890,16 @@ class RhinoBrep(Brep):
         """
         return _join_meshes(self.to_meshes()), []
 
+    def to_polygons(self):
+        """Convert the faces of this Brep shape to polygons.
+
+        Returns
+        -------
+        list[:class:`~compas.geometry.Polygon`]
+
+        """
+        return [face.to_polygon() for face in self.faces]
+
     def to_step(self, filepath):
         if not (filepath.endswith(".step") or filepath.endswith(".stp")):
             raise ValueError("Attempted to export STEP but file ends with {} extension".format(filepath.split(".")[-1]))

--- a/src/compas_rhino/geometry/brep/loop.py
+++ b/src/compas_rhino/geometry/brep/loop.py
@@ -103,6 +103,15 @@ class RhinoBrepLoop(BrepLoop):
         return [RhinoBrepEdge(trim.Edge) for trim in self._loop.Trims]
 
     @property
+    def vertices(self):
+        assert self.trims
+
+        vertices = [self.trims[0].start_vertex]
+        for trim in self.trims:
+            vertices.append(trim.end_vertex)
+        return vertices
+
+    @property
     def trims(self):
         return self._trims
 


### PR DESCRIPTION
* Added a missing property and method in `RhinoBrep` implementation.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
