### PR TITLE
Make Data.__dtype__ delegate to Data.__clstype__

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -44,3 +44,4 @@
 - Oliver Bucklin <<obucklin@arch.ethz.ch>> [@obucklin](https://github.com/obucklin)
 - Dominik Reisach <<reisach@arch.ethz.ch>> [@dominikreisach](https://github.com/dominikreisach)
 - Eric Gozzi <<eric.gozzi@arch.ethz.ch>> [@ericgozzi](https://github.com/ericgozzi)
+- Daniel Nunes Locatelli <<nuneslocatelli@arch.ethz.ch>> [@daniel-locatelli](https://github.com/daniel-locatelli)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed `Data.__dtype__` to delegate to `Data.__clstype__` (removes duplicated dtype format logic).
 * Changed `Tolerance` class to no longer use singleton pattern. `Tolerance()` now creates independent instances instead of returning the global `TOL`. 
 * Renamed `Tolerance.units` to `Tolerance.unit` to better reflect the documented properties. Left `units` with deprecation warning.
 * Fixed `NotImplementedErorr` when calling `BrepLoop.vertices`.

--- a/src/compas/data/data.py
+++ b/src/compas/data/data.py
@@ -73,7 +73,7 @@ class Data(object):
 
     @property
     def __dtype__(self):
-        return "{}/{}".format(".".join(self.__class__.__module__.split(".")[:2]), self.__class__.__name__)
+        return self.__clstype__()
 
     @classmethod
     def __clstype__(cls):


### PR DESCRIPTION
## What

`Data.__dtype__` (property) and `Data.__clstype__` (classmethod) computed the identical dtype string with two duplicated format expressions. This makes `__clstype__` the single source of truth and lets the instance-level property delegate to it:

```python
@property
def __dtype__(self):
    return self.__clstype__()
```

No behavior change — a classmethod accessed through an instance binds `type(self)`, so subclasses resolve exactly as before.

## Why it is safe for the plugin facades

`Brep`, `NurbsCurve`, and `NurbsSurface` override `__dtype__` to pin the facade dtype (so backend instances like `RhinoBrep` / `OCCBrep` never leak `compas_rhino`/`compas_occ` into serialized files). Those overrides shadow the base property through the MRO, so the delegation in `Data` is never consulted for them. Verified on real backend instances in both Rhino 8 (ScriptEditor + Rhino.Inside: `RhinoBrep`, `RhinoNurbsCurve`) and OCC (conda pythonocc-core 7.9.3: `OCCBrep`, `OCCNurbsCurve`) — dtypes stay pinned and round-trips re-materialize the backend classes.

## Verification

- Full test suite (`invoke test`): green on Windows/CPython 3.12 (the two `tests/compas/rpc` tests pass once the venv has a `compas_bootstrapper.py`; see note below).
- IronPython 2.7 suite (the `ironpython.yml` CI job replicated locally): 834 passed, 0 failed.
- Headless Blender 4.2 (wheel installed into Blender's Python): serialization + scene draw OK.
- Downstream sweep with the patched wheel in isolated envs — no regressions in any of: compas_model, compas_fd, compas_timber (842 passed), compas_cadwork, compas_cgal, compas_libigl, compas_gmsh, compas_occ (22 passed), compas_fab (158 passed incl. pybullet backend), compas_robots, compas_rrc, compas_eve, compas_cloud, compas_ifc, compas_viewer, compas_notebook, compas_slicer, compas_fea2.

## Notes

- Added a CHANGELOG entry under `Unreleased` → `Changed`, per step 4 of the dev guide PR procedure.
- Unrelated observation from testing, in case useful: in a plain `pip install -e` dev venv on Windows, `compas._os.select_python()` resolves to the global interpreter (no `compas_bootstrapper.py`), which makes the RPC tests fail out of the box. Can open a separate issue if there is interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
